### PR TITLE
Set up project config (zenflow)

### DIFF
--- a/.zenflow/settings.json
+++ b/.zenflow/settings.json
@@ -1,0 +1,5 @@
+{
+  "setup_script": "dotnet restore && cd frontend && npm install",
+  "dev_script": "cd frontend && npm run dev",
+  "verification_script": "dotnet build && cd frontend && npm run test"
+}

--- a/.zenflow/tasks/set-up-project-config-2d62/plan.md
+++ b/.zenflow/tasks/set-up-project-config-2d62/plan.md
@@ -1,0 +1,36 @@
+# Quick change
+
+## Configuration
+- **Artifacts Path**: {@artifacts_path} → `.zenflow/tasks/{task_id}`
+
+---
+
+## Agent Instructions
+
+This is a quick change workflow for small or straightforward tasks where all requirements are clear from the task description.
+
+### Your Approach
+
+1. Proceed directly with implementation
+2. Make reasonable assumptions when details are unclear
+3. Do not ask clarifying questions unless absolutely blocked
+4. Focus on getting the task done efficiently
+
+This workflow also works for experiments when the feature is bigger but you don't care about implementation details.
+
+If blocked or uncertain on a critical decision, ask the user for direction.
+
+---
+
+## Workflow Steps
+
+### [ ] Step: Implementation
+
+Implement the task directly based on the task description.
+
+1. Make reasonable assumptions for any unclear details
+2. Implement the required changes in the codebase
+3. Add and run relevant tests and linters if applicable
+4. Perform basic manual verification if applicable
+
+Save a brief summary of what was done to `{@artifacts_path}/report.md` if significant changes were made.

--- a/.zenflow/tasks/set-up-project-config-2d62/plan.md
+++ b/.zenflow/tasks/set-up-project-config-2d62/plan.md
@@ -24,7 +24,8 @@ If blocked or uncertain on a critical decision, ask the user for direction.
 
 ## Workflow Steps
 
-### [ ] Step: Implementation
+### [x] Step: Implementation
+<!-- chat-id: 15f6f303-ee4f-42e3-8d92-a3e147d12b93 -->
 
 Implement the task directly based on the task description.
 


### PR DESCRIPTION
You're gathering configuration for Zenflow, a task orchestration system that creates a new git worktree for each task. Each worktree starts fresh with no installed dependencies and no files outside of version control. Your goal is to configure automation that will prepare these worktrees for development.

Analyze the repository and identify:

1. **Setup Script**: Commands required to install project dependencies and prepare the environment.
   - Examples: `npm install`, `yarn install`, `pip install -r requirements.txt`, `bundle install`, `cargo build`, `go mod download`
   - May include multiple commands if needed (e.g., install + build step)
   - Applies to: Almost all projects with external dependencies

2. **Dev Server Script**: Command to start the development server for live preview.
   - Examples: `npm run dev`, `yarn dev`, `python manage.py runserver`, `rails server`, `cargo run`
   - Only applicable for: Web applications, APIs, or projects with a development server
   - Skip if: The project is a library, CLI tool, or has no server component

3. **Verification Script**: Commands for linting, testing, and type checking configured in the project.
   - Examples: `npm run lint && npm test`, `pytest`, `cargo test`, `go test ./...`, `bundle exec rspec`
   - Only include if: The project has linting/testing configured (check for test files, lint configs)
   - Skip if: No test infrastructure exists
   - **Important**: Git hooks (pre-commit, husky, etc.) run automatically during commits in worktrees - they don't need to be duplicated here
   - First, check if pre-commit hooks are configured (look for `.pre-commit-config.yaml`, `.husky/`, or `core.hooksPath` in `.gitconfig`):
     - If pre-commit hooks exist: Only include checks NOT already covered by hooks (e.g., if hooks run lint, add type-check or tests that hooks don't run)
     - If no pre-commit hooks: Include the standard checks from CI or build configs
   - Check these sources to find what checks exist:
      - CI actions/checks (only checks that run on every commit)
      - Build and config files (Makefile, package.json scripts, etc.)
      - Agent documentation (only if exists and doesn't contradict the sources above)
   - **Speed constraint**: Commands run after every agent turn, so they must complete in under 60 seconds. Exclude slow checks (e.g., full E2E test suites, integration tests with external services)

4. **Copy Files**: Local configuration files that are gitignored but required to run the project.
   - Include: Environment files (`.env`, `.env.local`), local config overrides, API keys, license files
   - NEVER include installed dependencies (`node_modules/`, `.venv/`, `vendor/`), build artifacts (`dist/`, `build/`, `target/`), cache directories, or large generated files - these are automatically excluded even if matched by glob patterns
   - Only files that are small, gitignored, and strictly necessary for the project to function
   - Skip if: The project runs without any local configuration files
   - Use glob patterns to match multiple files when appropriate (e.g., `config/*.local.json`)
   - Patterns starting with `..` or `/` are rejected for security
   - **Critical rule for template files**: If a template file exists (e.g., `.env.example`, `.env.template`, `.env.sample`), you MUST include the corresponding target file (e.g., `.env`) in copy_files. Do not skip it just because:
     - Other environment files like `.env.development` exist in the repo
     - The file seems "optional" for some configurations
     - The README says it can be generated or is not always needed
   - The presence of a template file is a strong signal that the user has local secrets/config that need to be copied to worktrees
   - Also detect needed files by checking:
     - README/documentation for setup instructions mentioning environment files or local config
     - `.gitignore` for patterns like `.env*` or `*.local` that suggest local config files are expected


Save the results to .zenflow/settings.json. Only include fields that apply to this project - omit fields that don't make sense (e.g., no dev_script for a library without a server):
{
  "setup_script": "command string",
  "dev_script": "command string",
  "verification_script": "command string",
  "copy_files": ["path/to/file1", "path/to/file2"]
}
