### PR TITLE
Add back button

### DIFF
--- a/Backend.Tests/UnitTests/TallyServiceTests.cs
+++ b/Backend.Tests/UnitTests/TallyServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Backend.Domain.Entities;
 using Backend.Domain.Enumerations;
@@ -11,12 +12,20 @@ public class TallyServiceTests : ServiceTestBase
     private readonly TallyService _service;
     private readonly Mock<ILogger<TallyService>> _loggerMock;
     private readonly Mock<ISignalRNotificationService> _signalRMock;
+    private readonly Mock<IStringLocalizer<TallyService>> _localizerMock;
 
     public TallyServiceTests()
     {
         _loggerMock = new Mock<ILogger<TallyService>>();
         _signalRMock = new Mock<ISignalRNotificationService>();
-        _service = new TallyService(Context, _loggerMock.Object, _signalRMock.Object);
+        _localizerMock = new Mock<IStringLocalizer<TallyService>>();
+        
+        // Setup localizer to return section codes
+        _localizerMock.Setup(l => l["tally.section.elected"]).Returns(new LocalizedString("tally.section.elected", "E"));
+        _localizerMock.Setup(l => l["tally.section.extra"]).Returns(new LocalizedString("tally.section.extra", "X"));
+        _localizerMock.Setup(l => l["tally.section.other"]).Returns(new LocalizedString("tally.section.other", "O"));
+        
+        _service = new TallyService(Context, _loggerMock.Object, _signalRMock.Object, _localizerMock.Object);
     }
 
     [Fact]

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -10,6 +10,7 @@ declare global {
 declare const FB: any;
 declare const Kakao: any;
 
+import { ArrowLeft } from "@element-plus/icons-vue";
 import { useNotifications } from "@/composables/useNotifications";
 import { getAppConfig } from "@/config/appConfig";
 import type { FormInstance, FormRules } from "element-plus";
@@ -599,6 +600,11 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="login-page">
+    <div class="login-wrapper">
+    <el-button link class="back-nav" @click="router.push('/')">
+      <el-icon><ArrowLeft /></el-icon>
+      {{ t("common.back") }}
+    </el-button>
     <el-card class="login-card">
       <template #header>
         <div class="login-header">
@@ -805,12 +811,10 @@ onBeforeUnmount(() => {
           >
             {{ t("auth.noAccount") }}
           </router-link>
-          <router-link to="/">
-            {{ t("common.cancel") }}
-          </router-link>
         </div>
       </el-form>
     </el-card>
+    </div>
   </div>
 </template>
 
@@ -818,12 +822,24 @@ onBeforeUnmount(() => {
 .login-page {
   display: flex;
   justify-content: center;
-  align-items: center;
-  padding-top: 40px;
+  padding-top: 20px;
+
+  .login-wrapper {
+    width: 100%;
+    max-width: 400px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .back-nav {
+    align-self: flex-start;
+    margin-bottom: 12px;
+    font-size: 1rem;
+    padding: 0;
+  }
 
   .login-card {
     width: 100%;
-    max-width: 400px;
     border-radius: 12px;
   }
 

--- a/frontend/src/pages/TellerJoinPage.vue
+++ b/frontend/src/pages/TellerJoinPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ArrowLeft } from "@element-plus/icons-vue";
 import { useNotifications } from "@/composables/useNotifications";
 import type { FormInstance, FormRules } from "element-plus";
 import { onBeforeUnmount, onMounted, reactive, ref } from "vue";
@@ -144,6 +145,11 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="login-page">
+    <div class="login-wrapper">
+    <el-button link class="back-nav" @click="router.push('/')">
+      <el-icon><ArrowLeft /></el-icon>
+      {{ t("common.back") }}
+    </el-button>
     <el-card class="login-card">
       <template #header>
         <div class="login-header">
@@ -217,13 +223,9 @@ onBeforeUnmount(() => {
           </el-button>
         </div>
 
-        <div class="auth-links">
-          <router-link to="/">
-            {{ t("common.cancel") }}
-          </router-link>
-        </div>
       </el-form>
     </el-card>
+    </div>
   </div>
 </template>
 
@@ -231,12 +233,24 @@ onBeforeUnmount(() => {
 .login-page {
   display: flex;
   justify-content: center;
-  align-items: center;
-  padding-top: 40px;
+  padding-top: 20px;
+
+  .login-wrapper {
+    width: 100%;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .back-nav {
+    align-self: flex-start;
+    margin-bottom: 12px;
+    font-size: 1rem;
+    padding: 0;
+  }
 
   .login-card {
     width: 100%;
-    max-width: 500px;
     border-radius: 12px;
   }
 
@@ -283,22 +297,5 @@ onBeforeUnmount(() => {
     width: 100%;
   }
 
-  .auth-links {
-    margin-top: 20px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 10px;
-  }
-
-  .auth-links a {
-    color: var(--color-primary-500);
-    text-decoration: none;
-    font-size: 0.85rem;
-  }
-
-  .auth-links a:hover {
-    text-decoration: underline;
-  }
 }
 </style>

--- a/frontend/src/pages/voting/VoterAuthPage.vue
+++ b/frontend/src/pages/voting/VoterAuthPage.vue
@@ -8,6 +8,7 @@ declare global {
 }
 
 import {
+  ArrowLeft,
   ChromeFilled,
   Key,
   Lock,
@@ -601,6 +602,10 @@ onBeforeUnmount(() => {
 <template>
   <div class="voter-auth-page">
     <div class="auth-container">
+      <ElButton link class="back-nav" @click="router.push('/')">
+        <ElIcon><ArrowLeft /></ElIcon>
+        {{ $t("common.back") }}
+      </ElButton>
       <div class="welcome-section">
         <div class="welcome-icon">
           <ElIcon :size="56" color="var(--color-public-text)">
@@ -1037,6 +1042,12 @@ onBeforeUnmount(() => {
   .auth-container {
     width: 100%;
     max-width: 780px;
+  }
+
+  .back-nav {
+    margin-bottom: 8px;
+    font-size: 1rem;
+    padding: 0;
   }
 
   .phone-form {


### PR DESCRIPTION
This pull request introduces a consistent "Back" navigation button across several authentication-related pages in the frontend, improving user experience and navigation clarity. Additionally, it updates the styling and layout of these pages for better alignment and usability. On the backend, the test setup for `TallyService` is improved to support localization, preparing for future internationalization needs.

**Frontend: Navigation and UI Improvements**

* Added a "Back" button with an arrow icon to the top of `LoginPage.vue`, `TellerJoinPage.vue`, and `VoterAuthPage.vue`, replacing or removing previous "Cancel" links for a more unified and visually clear navigation option. [[1]](diffhunk://#diff-c1ebabf2e3ed4a8b6add3e4814966ddd3c019a1f3debdd1559d760fca66f2fe1R603-R607) [[2]](diffhunk://#diff-b49b897f090fa60e4dbbb28777b46148b8fe0220a4ac36758a87afdddede4f01R148-R152) [[3]](diffhunk://#diff-1f39c24e66d578ae6a0a4c253e1dc962c144285b639a0b28730c6ba22c9e1149R605-R608)
* Updated page layouts and CSS: introduced a `.login-wrapper` container, adjusted padding, and refined the appearance and positioning of the new back button for consistency across pages. [[1]](diffhunk://#diff-c1ebabf2e3ed4a8b6add3e4814966ddd3c019a1f3debdd1559d760fca66f2fe1L808-R842) [[2]](diffhunk://#diff-b49b897f090fa60e4dbbb28777b46148b8fe0220a4ac36758a87afdddede4f01L220-R253) [[3]](diffhunk://#diff-b49b897f090fa60e4dbbb28777b46148b8fe0220a4ac36758a87afdddede4f01L286-L302) [[4]](diffhunk://#diff-1f39c24e66d578ae6a0a4c253e1dc962c144285b639a0b28730c6ba22c9e1149R1047-R1052)

**Backend: Test Setup Enhancement**

* Modified `TallyServiceTests` to mock and inject `IStringLocalizer<TallyService>`, setting up localized section codes. This prepares the service for future localization and ensures tests remain robust as localization is introduced. [[1]](diffhunk://#diff-141a2118e99d97fb19fc5ee7a5f95996df78380399b77dc26e24291a7556c8fdL1-R2) [[2]](diffhunk://#diff-141a2118e99d97fb19fc5ee7a5f95996df78380399b77dc26e24291a7556c8fdR15-R28)