### PR TITLE
switch to https

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ Other languages are updated separately in periodic review cycles — do not add 
 ## Local development assumptions
 
 - backend default dev URL: `http://localhost:5016`
-- frontend default dev URL: `http://localhost:8095`
+- frontend default dev URL: `https://localhost:8095` (Vite HTTPS via mkcert-trusted certs; `/api` and `/hubs` proxied to the backend)
 - backend development config seeds the database on startup
 - Swagger is the source of truth for current routes and schemas
 - **Contributor workflow:** the repo owner usually keeps their own backend dev instance running (`dotnet watch` / `dotnet run` / IDE) and the Vite dev server (`npm run dev`) for hot reload. **Do not rebuild backend or frontend for routine code changes** — `dotnet watch` recompiles C# on save and Vite hot-reloads Vue/TS. Avoid `dotnet build`, `dotnet run`, `npm run build`, and `npm run dev` unless the task explicitly requires it or the contributor asks you to verify a build. If you must rebuild, ask them to stop their running backend first (file-lock on `Backend.exe` causes MSB3026 copy failures). Prefer `dotnet test --no-build` when a recent build already exists.

--- a/Backend.Tests/UnitTests/AuthControllerTests.cs
+++ b/Backend.Tests/UnitTests/AuthControllerTests.cs
@@ -293,7 +293,7 @@ public class AuthControllerTests : ServiceTestBase
         var result = InvokeGetFrontendUrl(null);
 
         // Assert
-        Assert.Equal("http://localhost:8095/auth/google/callback", result);
+        Assert.Equal("https://localhost:8095/auth/google/callback", result);
     }
 
     [Fact]
@@ -306,7 +306,7 @@ public class AuthControllerTests : ServiceTestBase
         var result = InvokeGetFrontendUrl(null);
 
         // Assert
-        Assert.Equal("http://localhost:8095/auth/google/callback", result);
+        Assert.Equal("https://localhost:8095/auth/google/callback", result);
     }
 
     [Fact]
@@ -319,7 +319,7 @@ public class AuthControllerTests : ServiceTestBase
         var result = InvokeGetFrontendUrl(null);
 
         // Assert
-        Assert.Equal("http://localhost:8095/auth/google/callback", result);
+        Assert.Equal("https://localhost:8095/auth/google/callback", result);
     }
 
     [Fact]

--- a/E2E_TESTING_GUIDE.md
+++ b/E2E_TESTING_GUIDE.md
@@ -20,7 +20,7 @@ cd frontend
 npm run dev
 ```
 
-Expected local app URL: `http://localhost:8095`
+Expected local app URL: `https://localhost:8095`
 
 ## Automated checks
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ npm run dev
 
 Default frontend URL:
 
-- App: `http://localhost:8095`
+- App: `https://localhost:8095` (trusted local cert via mkcert; first `npm run dev` may prompt for admin to install the CA)
 
-The frontend reads `VITE_API_URL` from `.env.development` or falls back to `http://localhost:5016`.
+The frontend reads `VITE_API_URL` from `.env.development` (default `https://localhost:8095`). Vite proxies `/api` and `/hubs` to the backend at `http://localhost:5016`.
 
 ## Seeded development accounts
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TallyJ 4 is a full-stack election management and ballot tallying system for Bah√
 ### Prerequisites
 
 - .NET SDK 10
-- Node.js 20+
+- Node.js **22.19+** (required by current frontend tooling: Vite, OpenAPI client generator, and `vite-plugin-mkcert`; Node 20 is not sufficient)
 - SQL Server Express, SQL Server Developer Edition, or Docker SQL Server
 
 ### Start the backend
@@ -45,7 +45,7 @@ Default frontend URL:
 
 - App: `https://localhost:8095` (trusted local cert via mkcert; first `npm run dev` may prompt for admin to install the CA)
 
-The frontend reads `VITE_API_URL` from `.env.development` (default `https://localhost:8095`). Vite proxies `/api` and `/hubs` to the backend at `http://localhost:5016`.
+Requires Node.js 22.19+ (see Prerequisites). The frontend reads `VITE_API_URL` from `.env.development` (default `https://localhost:8095`). Vite proxies `/api` and `/hubs` to the backend at `http://localhost:5016`.
 
 ## Seeded development accounts
 

--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -958,11 +958,11 @@ public class AuthController : ControllerBase
             string redirectUrl;
             if (authenticateResult.Properties?.Items.TryGetValue("redirect", out var redirectValue) == true && !string.IsNullOrEmpty(redirectValue))
             {
-                redirectUrl = redirectValue.StartsWith("http") ? redirectValue : $"http://localhost:8095{redirectValue}";
+                redirectUrl = redirectValue.StartsWith("http") ? redirectValue : $"https://localhost:8095{redirectValue}";
             }
             else
             {
-                redirectUrl = "http://localhost:8095/elections";
+                redirectUrl = "https://localhost:8095/elections";
             }
 
             // Extract claims directly from the authenticated principal
@@ -1637,7 +1637,7 @@ public class AuthController : ControllerBase
         }
 
         // Fallback to localhost for development if not configured
-        return "http://localhost:8095/auth/google/callback";
+        return "https://localhost:8095/auth/google/callback";
     }
 
     /// <summary>

--- a/backend/README.md
+++ b/backend/README.md
@@ -76,7 +76,7 @@ Swagger is available at:
 The checked-in development settings currently assume:
 
 - `Database:SeedOnStartup = true`
-- frontend base URL at `http://localhost:8095`
+- frontend base URL at `https://localhost:8095`
 - localization resources loaded from `../frontend/src/locales`
 
 That means a fresh local database is seeded automatically when the backend starts in the Development environment.

--- a/backend/Services/Auth/EmailService.cs
+++ b/backend/Services/Auth/EmailService.cs
@@ -228,7 +228,7 @@ This confirmation expires in 24 hours. If you did not request this change, ignor
 
     private string BuildFrontendUrl(string path, params (string Key, string Value)[] query)
     {
-        var baseUrl = (_configuration["Frontend:BaseUrl"] ?? "http://localhost:8095").TrimEnd('/');
+        var baseUrl = (_configuration["Frontend:BaseUrl"] ?? "https://localhost:8095").TrimEnd('/');
         var qs = string.Join("&", query.Select(q =>
             $"{Uri.EscapeDataString(q.Key)}={Uri.EscapeDataString(q.Value)}"));
         var normalizedPath = path.StartsWith('/') ? path : "/" + path;

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -13,11 +13,13 @@
     "ExpiryMinutes": 60
   },
   "AllowedOrigins": [
+    "https://localhost:8095",
+    "https://localhost:4173",
     "http://localhost:8095",
     "http://localhost:4173"
   ],
   "Frontend": {
-    "BaseUrl": "http://localhost:8095"
+    "BaseUrl": "https://localhost:8095"
   },
   "Sentry": "<SENTRY-DSN>",
   "GreenApi": {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -25,7 +25,7 @@ cp .env.docker.example .env.docker
 docker-compose up -d
 
 # Access the application
-# Frontend: http://localhost:8095
+# Frontend: https://localhost:8095
 # Backend API: http://localhost:5016
 ```
 
@@ -62,7 +62,7 @@ npm run dev
 2. **Assign Admin Role** (via database or admin panel)
 
 3. **Log In**
-   - Navigate to http://localhost:8095
+   - Navigate to https://localhost:8095
    - Enter credentials
 
 ### 3. Test with Sample Data (2 minutes)

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,8 +1,8 @@
 # This file is used to set environment variables for the development environment.
 VITE_ENV=development
 
-# Where to find the backend API
-VITE_API_URL=http://localhost:5016
+# SPA origin (Vite HTTPS). /api and /hubs are proxied to the backend (see vite.config.ts).
+VITE_API_URL=https://localhost:8095
 
 # Sentry DSN for error tracking
 VITE_SENTRY_DSN=https://a68bf56cdcf8c9bce38b007f0d6df27b@o4511108941086720.ingest.us.sentry.io/4511108943577088

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,8 +1,9 @@
 # This file is used to set environment variables for the development environment.
 VITE_ENV=development
 
-# Where to find the backend API
-VITE_API_URL=http://localhost:5016
+# SPA origin in local dev (Vite serves HTTPS). /api and /hubs are proxied to the backend.
+# Override VITE_API_TARGET in the shell if the API is not at http://localhost:5016.
+VITE_API_URL=https://localhost:8095
 
 # Sentry DSN for error tracking
 VITE_SENTRY_DSN=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,7 +28,11 @@ npm run dev
 > ```
 > Then re-run `npm install`. The warning should not appear again on this machine.
 
-Default local URL: `http://localhost:8095`
+Default local URL: **`https://localhost:8095`**.
+
+HTTPS uses **`vite-plugin-mkcert`**, which creates a local certificate authority and installs it into the OS trust store so Chrome trusts the cert (no “Not secure” interstitial). The **first** `npm run dev` may prompt for administrator elevation on Windows to install that CA; after that, restarts are normal.
+
+The Vite dev server proxies `/api`, `/hubs`, and `/clientEnv.json` to the backend at `http://localhost:5016` (override with `VITE_API_TARGET`) so the browser stays on HTTPS with no mixed content. Identity cookies are always set with the `Secure` flag.
 
 ## Environment
 
@@ -37,12 +41,13 @@ Copy `.env.example` to `.env.development` or `.env.production` and adjust values
 Minimum useful local setup:
 
 ```env
-VITE_API_URL=http://localhost:5016
+VITE_API_URL=https://localhost:8095
 ```
 
 Common variables:
 
-- `VITE_API_URL` - backend base URL
+- `VITE_API_URL` - API base URL used by the SPA (local default is the Vite HTTPS origin; requests are proxied)
+- `VITE_API_TARGET` - optional real backend origin for the Vite proxy (default `http://localhost:5016`)
 - `VITE_APP_NAME` - app title shown by the frontend
 - `VITE_ENV` - environment label
 - `VITE_ENABLE_ANALYTICS` - analytics toggle

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "typescript-eslint": "^8.60.0",
         "vite": "^8.0.16",
         "vite-plugin-devtools-json": "^1.0.0",
+        "vite-plugin-mkcert": "^2.1.0",
         "vitest": "^4.0.18",
         "vue-tsc": "^3.3.3"
       }
@@ -6734,6 +6735,47 @@
       },
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/vite-plugin-mkcert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-2.1.0.tgz",
+      "integrity": "sha512-UQS5iyknruwCsvqDPsKRyHIVSVfv/iGdRPmUPaM1JRwNJo8wo/MubzJ66ckWwOLxFU4wW90oZq9GviV87nRHsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "supports-color": "^10.2.2",
+        "undici": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "vite": ">=3"
+      }
+    },
+    "node_modules/vite-plugin-mkcert/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/vite-plugin-mkcert/node_modules/undici": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
+      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/vitest": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "typescript-eslint": "^8.60.0",
     "vite": "^8.0.16",
     "vite-plugin-devtools-json": "^1.0.0",
+    "vite-plugin-mkcert": "^2.1.0",
     "vitest": "^4.0.18",
     "vue-tsc": "^3.3.3"
   },

--- a/frontend/src/config/appConfig.ts
+++ b/frontend/src/config/appConfig.ts
@@ -11,7 +11,8 @@ export interface AppConfig {
 
 export function createAppConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
-    apiUrl: import.meta.env.VITE_API_URL || "http://localhost:5016",
+    // Dev defaults to the Vite HTTPS origin so /api and /hubs are same-origin (proxied).
+    apiUrl: import.meta.env.VITE_API_URL || "https://localhost:8095",
     env: import.meta.env.VITE_ENV || "development",
     ...overrides,
   };

--- a/frontend/src/pages/GoogleCallbackPage.vue
+++ b/frontend/src/pages/GoogleCallbackPage.vue
@@ -2,6 +2,7 @@
 import { onMounted, ref } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import { useAuthStore } from "../stores/authStore";
+import { secureTokenService } from "../services/secureTokenService";
 import { useNotifications } from "@/composables/useNotifications";
 import { useI18n } from "vue-i18n";
 
@@ -40,12 +41,11 @@ onMounted(async () => {
     }
 
     // Set user info cookies on frontend domain for router guard
-    const secure = window.location.protocol === "https:" ? "; secure" : "";
-    document.cookie = `user_email=${encodeURIComponent(userData.email)}; path=/; samesite=strict${secure}; max-age=2592000`;
-    if (userData.name) {
-      document.cookie = `user_name=${encodeURIComponent(userData.name)}; path=/; samesite=strict${secure}; max-age=2592000`;
-    }
-    document.cookie = `auth_method=${encodeURIComponent(userData.authMethod)}; path=/; samesite=strict${secure}; max-age=2592000`;
+    secureTokenService.setUserInfoCookies({
+      email: userData.email,
+      name: userData.name,
+      authMethod: userData.authMethod,
+    });
 
     const redirectPath = route.query.redirect
       ? decodeURIComponent(route.query.redirect as string)

--- a/frontend/src/services/__tests__/secureTokenService.test.ts
+++ b/frontend/src/services/__tests__/secureTokenService.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { secureTokenService } from "../secureTokenService";
+
+describe("secureTokenService", () => {
+  let cookieJar: string[];
+
+  beforeEach(() => {
+    cookieJar = [];
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get: () => cookieJar.join("; "),
+      set: (value: string) => {
+        cookieJar.push(value);
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("setCookie always includes secure and samesite=strict", () => {
+    secureTokenService.setCookie("user_name", "Ada Lovelace");
+
+    expect(cookieJar).toHaveLength(1);
+    const written = cookieJar[0].toLowerCase();
+    expect(written).toContain("secure");
+    expect(written).toContain("samesite=strict");
+    expect(written).toContain("path=/");
+    expect(written).toContain("max-age=");
+    expect(cookieJar[0]).toContain(
+      `user_name=${encodeURIComponent("Ada Lovelace")}`,
+    );
+  });
+
+  it("setUserInfoCookies writes only provided fields with secure flags", () => {
+    secureTokenService.setUserInfoCookies({
+      email: "a@example.com",
+      name: "Ada",
+      authMethod: "Google",
+    });
+
+    expect(cookieJar).toHaveLength(3);
+    for (const entry of cookieJar) {
+      const lower = entry.toLowerCase();
+      expect(lower).toContain("; secure");
+      expect(lower).toContain("samesite=strict");
+    }
+    expect(cookieJar.some((c) => c.startsWith("user_email="))).toBe(true);
+    expect(cookieJar.some((c) => c.startsWith("user_name="))).toBe(true);
+    expect(cookieJar.some((c) => c.startsWith("auth_method="))).toBe(true);
+  });
+
+  it("setUserInfoCookies skips empty optional name", () => {
+    secureTokenService.setUserInfoCookies({
+      email: "a@example.com",
+      authMethod: "Local",
+    });
+
+    expect(cookieJar).toHaveLength(2);
+    expect(cookieJar.some((c) => c.startsWith("user_name="))).toBe(false);
+  });
+
+  it("setUserNameCookie clears with max-age=0 and secure flags", () => {
+    secureTokenService.setUserNameCookie(null);
+
+    expect(cookieJar).toHaveLength(1);
+    const written = cookieJar[0].toLowerCase();
+    expect(written).toContain("user_name=");
+    expect(written).toContain("max-age=0");
+    expect(written).toContain("secure");
+    expect(written).toContain("samesite=strict");
+  });
+
+  it("setUserEmailCookie sets and clears with secure flags", () => {
+    secureTokenService.setUserEmailCookie("b@example.com");
+    secureTokenService.setUserEmailCookie(null);
+
+    expect(cookieJar).toHaveLength(2);
+    expect(cookieJar[0]).toContain(
+      `user_email=${encodeURIComponent("b@example.com")}`,
+    );
+    expect(cookieJar[1].toLowerCase()).toContain("max-age=0");
+    expect(cookieJar[1].toLowerCase()).toContain("secure");
+  });
+
+  it("clearAuthData expires all identity cookies with secure flags", () => {
+    secureTokenService.clearAuthData();
+
+    expect(cookieJar).toHaveLength(3);
+    for (const entry of cookieJar) {
+      const lower = entry.toLowerCase();
+      expect(lower).toContain("max-age=0");
+      expect(lower).toContain("secure");
+      expect(lower).toContain("samesite=strict");
+    }
+  });
+
+  it("getCookie decodes URI-encoded values", () => {
+    // Simulate a previously set encoded cookie via jar get
+    cookieJar.length = 0;
+    Object.defineProperty(document, "cookie", {
+      configurable: true,
+      get: () => `user_name=${encodeURIComponent("Ada Lovelace")}`,
+      set: () => {},
+    });
+
+    expect(secureTokenService.getCookie("user_name")).toBe("Ada Lovelace");
+  });
+});

--- a/frontend/src/services/__tests__/secureTokenService.test.ts
+++ b/frontend/src/services/__tests__/secureTokenService.test.ts
@@ -16,6 +16,8 @@ describe("secureTokenService", () => {
   });
 
   afterEach(() => {
+    // Restore jsdom's default cookie implementation so this suite does not leak.
+    Reflect.deleteProperty(document, "cookie");
     vi.restoreAllMocks();
   });
 
@@ -97,13 +99,11 @@ describe("secureTokenService", () => {
   });
 
   it("getCookie decodes URI-encoded values", () => {
-    // Simulate a previously set encoded cookie via jar get
+    // Simulate a browser cookie store string (name=value pairs only; no attributes).
+    // Use the shared mock jar so we do not reassign document.cookie without Secure
+    // (which triggers CodeQL js/clear-text-cookie on sensitive names).
     cookieJar.length = 0;
-    Object.defineProperty(document, "cookie", {
-      configurable: true,
-      get: () => `user_name=${encodeURIComponent("Ada Lovelace")}`,
-      set: () => {},
-    });
+    cookieJar.push(`user_name=${encodeURIComponent("Ada Lovelace")}`);
 
     expect(secureTokenService.getCookie("user_name")).toBe("Ada Lovelace");
   });

--- a/frontend/src/services/secureTokenService.ts
+++ b/frontend/src/services/secureTokenService.ts
@@ -1,7 +1,16 @@
 /**
  * Service for managing secure authentication cookies.
- * Provides methods to read authentication data from httpOnly cookies set by the backend.
+ * Provides methods to read authentication data from httpOnly cookies set by the backend,
+ * and to set/clear client-readable identity cookies on the SPA origin.
+ *
+ * Identity cookies (`user_email`, `user_name`, `auth_method`) are intentionally NOT HttpOnly
+ * so the SPA can read them for router guards and initial store state. Access/refresh tokens
+ * are HttpOnly and are only set by the backend.
+ *
+ * All client-written cookies always include Secure + SameSite=Strict (production is HTTPS;
+ * local HTTPS / modern localhost Secure exceptions are assumed for development).
  */
+
 export interface AuthCookieData {
   token: string | null;
   refreshToken: string | null;
@@ -9,6 +18,15 @@ export interface AuthCookieData {
   name: string | null;
   authMethod: string | null;
 }
+
+export interface UserInfoCookieData {
+  email?: string | null;
+  name?: string | null;
+  authMethod?: string | null;
+}
+
+/** Default lifetime for identity cookies (30 days), matching backend user cookie expiry. */
+const DEFAULT_MAX_AGE_DAYS = 30;
 
 export const secureTokenService = {
   /**
@@ -60,10 +78,47 @@ export const secureTokenService = {
    * HttpOnly cookies are cleared by the backend logout endpoint.
    */
   clearAuthData(): void {
-    // Clear readable cookies by setting them to expire
     this.setCookie(this.cookieNames.userEmail, "", -1);
     this.setCookie(this.cookieNames.userName, "", -1);
     this.setCookie(this.cookieNames.authMethod, "", -1);
+  },
+
+  /**
+   * Sets SPA-origin identity cookies after OAuth /me (or similar) when backend cookies
+   * may be on a different host. Only non-empty string fields are written.
+   */
+  setUserInfoCookies(data: UserInfoCookieData): void {
+    if (data.email) {
+      this.setCookie(this.cookieNames.userEmail, data.email);
+    }
+    if (data.name) {
+      this.setCookie(this.cookieNames.userName, data.name);
+    }
+    if (data.authMethod) {
+      this.setCookie(this.cookieNames.authMethod, data.authMethod);
+    }
+  },
+
+  /**
+   * Sets or clears the user_name identity cookie (profile display-name updates).
+   */
+  setUserNameCookie(name: string | null): void {
+    if (name) {
+      this.setCookie(this.cookieNames.userName, name);
+    } else {
+      this.setCookie(this.cookieNames.userName, "", -1);
+    }
+  },
+
+  /**
+   * Sets or clears the user_email identity cookie (email-change confirmation).
+   */
+  setUserEmailCookie(email: string | null): void {
+    if (email) {
+      this.setCookie(this.cookieNames.userEmail, email);
+    } else {
+      this.setCookie(this.cookieNames.userEmail, "", -1);
+    }
   },
 
   /**
@@ -80,13 +135,20 @@ export const secureTokenService = {
   },
 
   /**
-   * Sets a cookie with the given name, value, and max age in days.
+   * Sets a cookie with Secure + SameSite=Strict always applied.
+   * @param maxAgeDays Positive days for lifetime; use 0 or negative to expire immediately.
    */
-  setCookie(name: string, value: string, maxAgeDays: number = 30): void {
-    const maxAge =
-      maxAgeDays > 0 ? `; max-age=${maxAgeDays * 24 * 60 * 60}` : "; max-age=0";
-    const secure = window.location.protocol === "https:" ? "; secure" : "";
-    document.cookie = `${name}=${value}; path=/; samesite=strict${secure}${maxAge}`;
+  setCookie(
+    name: string,
+    value: string,
+    maxAgeDays: number = DEFAULT_MAX_AGE_DAYS,
+  ): void {
+    const maxAgeSeconds =
+      maxAgeDays > 0 ? Math.floor(maxAgeDays * 24 * 60 * 60) : 0;
+    const encoded = encodeURIComponent(value);
+    // Always Secure + SameSite=Strict so sensitive identity cookies are never sent over cleartext.
+    // Local HTTP on non-localhost is unsupported; prefer HTTPS for local development.
+    document.cookie = `${name}=${encoded}; path=/; samesite=strict; secure; max-age=${maxAgeSeconds}`;
   },
 
   /**

--- a/frontend/src/stores/authStore.test.ts
+++ b/frontend/src/stores/authStore.test.ts
@@ -9,6 +9,9 @@ vi.mock("../services/secureTokenService", () => ({
     clearAuthData: vi.fn(),
     refreshAuthData: vi.fn(),
     isAuthenticated: vi.fn(),
+    setUserInfoCookies: vi.fn(),
+    setUserNameCookie: vi.fn(),
+    setUserEmailCookie: vi.fn(),
   },
 }));
 

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -181,12 +181,11 @@ export const useAuthStore = defineStore("auth", () => {
 
       if (userData) {
         // Set readable cookies on the SPA origin for router guards
-        const secure = window.location.protocol === "https:" ? "; secure" : "";
-        document.cookie = `user_email=${encodeURIComponent(userData.email)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        if (userData.name) {
-          document.cookie = `user_name=${encodeURIComponent(userData.name)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        }
-        document.cookie = `auth_method=${encodeURIComponent(userData.authMethod)}; path=/; samesite=strict${secure}; max-age=2592000`;
+        secureTokenService.setUserInfoCookies({
+          email: userData.email,
+          name: userData.name,
+          authMethod: userData.authMethod,
+        });
       } else {
         // Fallback to response data and refresh cookies
         const cookieData = secureTokenService.refreshAuthData();
@@ -218,12 +217,11 @@ export const useAuthStore = defineStore("auth", () => {
       const userData = await fetchUserInfo();
 
       if (userData) {
-        const secure = window.location.protocol === "https:" ? "; secure" : "";
-        document.cookie = `user_email=${encodeURIComponent(userData.email)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        if (userData.name) {
-          document.cookie = `user_name=${encodeURIComponent(userData.name)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        }
-        document.cookie = `auth_method=${encodeURIComponent(userData.authMethod)}; path=/; samesite=strict${secure}; max-age=2592000`;
+        secureTokenService.setUserInfoCookies({
+          email: userData.email,
+          name: userData.name,
+          authMethod: userData.authMethod,
+        });
       } else {
         const cookieData = secureTokenService.refreshAuthData();
         email.value = cookieData.email || response.email;
@@ -253,12 +251,11 @@ export const useAuthStore = defineStore("auth", () => {
       const userData = await fetchUserInfo();
 
       if (userData) {
-        const secure = window.location.protocol === "https:" ? "; secure" : "";
-        document.cookie = `user_email=${encodeURIComponent(userData.email)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        if (userData.name) {
-          document.cookie = `user_name=${encodeURIComponent(userData.name)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        }
-        document.cookie = `auth_method=${encodeURIComponent(userData.authMethod)}; path=/; samesite=strict${secure}; max-age=2592000`;
+        secureTokenService.setUserInfoCookies({
+          email: userData.email,
+          name: userData.name,
+          authMethod: userData.authMethod,
+        });
       } else {
         const cookieData = secureTokenService.refreshAuthData();
         email.value = cookieData.email || response.email;
@@ -292,12 +289,11 @@ export const useAuthStore = defineStore("auth", () => {
       const userData = await fetchUserInfo();
 
       if (userData) {
-        const secure = window.location.protocol === "https:" ? "; secure" : "";
-        document.cookie = `user_email=${encodeURIComponent(userData.email)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        if (userData.name) {
-          document.cookie = `user_name=${encodeURIComponent(userData.name)}; path=/; samesite=strict${secure}; max-age=2592000`;
-        }
-        document.cookie = `auth_method=${encodeURIComponent(userData.authMethod)}; path=/; samesite=strict${secure}; max-age=2592000`;
+        secureTokenService.setUserInfoCookies({
+          email: userData.email,
+          name: userData.name,
+          authMethod: userData.authMethod,
+        });
       } else {
         const cookieData = secureTokenService.refreshAuthData();
         email.value = cookieData.email || response.email;
@@ -361,22 +357,12 @@ export const useAuthStore = defineStore("auth", () => {
 
   function setDisplayName(newName: string | null) {
     name.value = newName;
-    const secure = window.location.protocol === "https:" ? "; secure" : "";
-    if (newName) {
-      document.cookie = `user_name=${encodeURIComponent(newName)}; path=/; samesite=strict${secure}; max-age=2592000`;
-    } else {
-      document.cookie = `user_name=; path=/; samesite=strict${secure}; max-age=0`;
-    }
+    secureTokenService.setUserNameCookie(newName);
   }
 
   function setEmail(newEmail: string | null) {
     email.value = newEmail;
-    const secure = window.location.protocol === "https:" ? "; secure" : "";
-    if (newEmail) {
-      document.cookie = `user_email=${encodeURIComponent(newEmail)}; path=/; samesite=strict${secure}; max-age=2592000`;
-    } else {
-      document.cookie = `user_email=; path=/; samesite=strict${secure}; max-age=0`;
-    }
+    secureTokenService.setUserEmailCookie(newEmail);
   }
 
   async function updateDisplayName(displayName: string) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,7 @@ import { fileURLToPath, URL } from "node:url";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import devtoolsJson from "vite-plugin-devtools-json";
+import mkcert from "vite-plugin-mkcert";
 
 // ---------------------------------------------------------------------------
 // Build-time guard for language support
@@ -243,30 +244,57 @@ export default defineConfig(() => {
       },
     },
     server: {
+      // HTTPS so Secure identity cookies work in local dev.
+      // Certs come from vite-plugin-mkcert (local CA trusted by Chrome/OS).
+      https: true,
       port: 8095,
       hmr: {
+        protocol: "wss",
         port: 8095,
       },
-      // Proxy /clientEnv.json during `npm run dev` to the real backend
+      // Proxy API/SignalR to the HTTP backend so the browser stays on HTTPS (no mixed content).
       proxy: {
         "/clientEnv.json": {
           target: process.env.VITE_API_TARGET || "http://localhost:5016",
           changeOrigin: true,
         },
+        "/api": {
+          target: process.env.VITE_API_TARGET || "http://localhost:5016",
+          changeOrigin: true,
+        },
+        "/hubs": {
+          target: process.env.VITE_API_TARGET || "http://localhost:5016",
+          changeOrigin: true,
+          ws: true,
+        },
       },
     },
     preview: {
+      https: true,
       port: 4173,
-      // Proxy /clientEnv.json during `npm run preview` to the real backend
       proxy: {
         "/clientEnv.json": {
           target: process.env.VITE_API_TARGET || "http://localhost:5016",
           changeOrigin: true,
+        },
+        "/api": {
+          target: process.env.VITE_API_TARGET || "http://localhost:5016",
+          changeOrigin: true,
+        },
+        "/hubs": {
+          target: process.env.VITE_API_TARGET || "http://localhost:5016",
+          changeOrigin: true,
+          ws: true,
         },
       },
     },
     plugins: [
       vue(),
+      // Locally-trusted HTTPS certs (installs a dev CA into the OS trust store on first run).
+      // First start may prompt for admin elevation on Windows so Chrome trusts the cert.
+      mkcert({
+        hosts: ["localhost", "127.0.0.1"],
+      }),
       devtoolsJson(),
       VueI18nPlugin({}),
       // Bundle analyzer - generates stats.html


### PR DESCRIPTION
This pull request updates the development environment to use HTTPS for the frontend by default, improves cookie security for authentication data, and adds comprehensive tests for cookie handling. The most important changes are grouped below.

---

**Frontend HTTPS by Default**

* All documentation, environment files, and configuration now consistently use `https://localhost:8095` as the default frontend URL instead of HTTP. This includes updates in `README.md`, `E2E_TESTING_GUIDE.md`, `QUICK_START.md`, `AGENTS.md`, backend and frontend config files, and test cases. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L164-R164) [[2]](diffhunk://#diff-5f35f3964adc5c103cd1d7e46312a43bb9e3309a2ebc398b39072899c9a1ded0L296-R296) [[3]](diffhunk://#diff-5f35f3964adc5c103cd1d7e46312a43bb9e3309a2ebc398b39072899c9a1ded0L309-R309) [[4]](diffhunk://#diff-5f35f3964adc5c103cd1d7e46312a43bb9e3309a2ebc398b39072899c9a1ded0L322-R322) [[5]](diffhunk://#diff-452fd93d6b2f61357beb251ceb0092c56dea3fc0d7814f8582790b3ed49524b5L23-R23) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R48) [[7]](diffhunk://#diff-1952b3e36ad65e970880e3a9d750a874cd3480feecdb61abcee07242053f0838L961-R965) [[8]](diffhunk://#diff-1952b3e36ad65e970880e3a9d750a874cd3480feecdb61abcee07242053f0838L1640-R1640) [[9]](diffhunk://#diff-04cbe82d3d7c43a4ef7bf16e20ad5bdf3063ca639e877573bc776a220597bfb2L231-R231) [[10]](diffhunk://#diff-e08796d8efa83f6e7b1de6635ab9c951b8d5cebee9753dbb1f87b55e0136b610R16-R22) [[11]](diffhunk://#diff-62e91d3086c96fcc1f472738d7bc30a4eef33361af2bfeba2f43668428d717bfL28-R28) [[12]](diffhunk://#diff-62e91d3086c96fcc1f472738d7bc30a4eef33361af2bfeba2f43668428d717bfL65-R65) [[13]](diffhunk://#diff-8418659e03d1d6494d6c53bd2f591905fdc4369cf108de7b249bb796fb88aa1bL4-R5) [[14]](diffhunk://#diff-7b3b2052ac3e484bcffbb75d7ee140a9ebe7677fd7ea34ac17ca193dd3c0ecfcL4-R6) [[15]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L31-R35) [[16]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L40-R50) [[17]](diffhunk://#diff-a54d2dad1be5eea9e70f8514ae65d89b65357120a312bfb9f644ddeb1844ca0dL79-R79)

* The frontend dev server now uses `vite-plugin-mkcert` to generate and trust local HTTPS certificates, ensuring browsers recognize the local dev server as secure. This is reflected in `frontend/package.json`, `frontend/package-lock.json`, and related documentation. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR45) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR6740-R6780) [[3]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R57) [[4]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L31-R35)

---

**Secure Cookie Handling for Identity Data**

* All client-set identity cookies (`user_email`, `user_name`, `auth_method`) are now always written with `Secure` and `SameSite=Strict` attributes, regardless of environment. This prevents accidental insecure cookies and improves security. The logic for setting these cookies was centralized in the new `secureTokenService`. [[1]](diffhunk://#diff-10cc92efebd93eb665d356cef241d40a42fab3dd317a1d1b34a521887d5cf54fR5) [[2]](diffhunk://#diff-10cc92efebd93eb665d356cef241d40a42fab3dd317a1d1b34a521887d5cf54fL43-R48) [[3]](diffhunk://#diff-81cc816f9e8491c92d4f30dcbc1b26a80c552c7fc6654efb04911739ca9a8ea6L3-R13) [[4]](diffhunk://#diff-81cc816f9e8491c92d4f30dcbc1b26a80c552c7fc6654efb04911739ca9a8ea6R22-R30)

---

**Testing and Code Quality**

* A new test suite (`secureTokenService.test.ts`) was added to verify that all cookies set by the SPA include the correct security flags and that cookie values are handled correctly.

---

**Configuration Consistency**

* The default `VITE_API_URL` is now `https://localhost:8095` in both `.env.example` and `.env.development`, matching the new HTTPS frontend default. [[1]](diffhunk://#diff-8418659e03d1d6494d6c53bd2f591905fdc4369cf108de7b249bb796fb88aa1bL4-R5) [[2]](diffhunk://#diff-7b3b2052ac3e484bcffbb75d7ee140a9ebe7677fd7ea34ac17ca193dd3c0ecfcL4-R6) [[3]](diffhunk://#diff-be58e4f0e27f5aa52dbb45eb794b11de6b245632dc1de6fe94fe54fcb6b6c75bL14-R15)

---

These changes ensure a more secure, consistent, and modern local development environment, with improved documentation and test coverage for authentication-related cookies.