### PR TITLE
Fix js-yaml CVE-2026-53550 via npm override

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4443,10 +4443,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
   },
   "overrides": {
     "glob": "^11.0.0",
+    "js-yaml": "4.2.0",
     "minimatch": "^10.2.1",
     "vue-i18n": "^11.4.4",
     "vite-plugin-devtools-json": {


### PR DESCRIPTION
## Summary

- Closes Dependabot alert [#44](https://github.com/glittle/TallyJ-4/security/dependabot/44) (CVE-2026-53550 / GHSA-h67p-54hq-rp68): quadratic-complexity DoS in `js-yaml` merge-key handling.
- Forces resolved `js-yaml` to **4.2.0** (patched) via an `overrides` entry in `frontend/package.json`, matching the existing pattern for `glob` / `minimatch`.
- Leaves `@hey-api/openapi-ts` at `^0.97.3` (no codegen toolchain bump).

`js-yaml` is a **transitive devDependency** (via `@hey-api/json-schema-ref-parser` / `@hey-api/openapi-ts`) used only for OpenAPI client generation, not production runtime.

## Why not Dependabot PR #221?

[PR #221](https://github.com/glittle/TallyJ-4/pull/221) also reaches `js-yaml@4.2.0`, but by upgrading `@hey-api/openapi-ts` from `0.97.3` → `0.99.0` (and related packages / Node engine constraints). That is broader than needed for this advisory.

## Test plan

- [x] `npm install --package-lock-only` in `frontend/` — lockfile resolves `js-yaml@4.2.0`
- [x] `npm install` reports 0 vulnerabilities
- [ ] Confirm Dependabot alert #44 auto-closes after merge
- [ ] Optional: `npm run gen` still works with current openapi-ts version

Closes dependabot security update path covered by #221 (closing that PR in favor of this minimal fix).