### PR TITLE
Fix MainHub statusChanged wiring and stage-change toasts (#227)

### DIFF
--- a/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
@@ -1,0 +1,122 @@
+using Backend.DTOs.SignalR;
+using Backend.Enumerations;
+using Backend.Hubs;
+using Backend.Services;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Backend.Tests.UnitTests.Services;
+
+/// <summary>
+/// Contract tests for MainHub fan-out: event names and group targets must match the SPA.
+/// </summary>
+public class SignalRNotificationServiceTests
+{
+    private readonly Guid _electionGuid = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private (
+        SignalRNotificationService Service,
+        Mock<IHubClients> MainClients,
+        Dictionary<string, Mock<IClientProxy>> GroupProxies) CreateService()
+    {
+        var mainHub = new Mock<IHubContext<MainHub>>();
+        var analyzeHub = new Mock<IHubContext<AnalyzeHub>>();
+        var ballotImportHub = new Mock<IHubContext<BallotImportHub>>();
+        var frontDeskHub = new Mock<IHubContext<FrontDeskHub>>();
+        var publicHub = new Mock<IHubContext<PublicHub>>();
+        var mainClients = new Mock<IHubClients>();
+        var groupProxies = new Dictionary<string, Mock<IClientProxy>>();
+
+        mainHub.Setup(h => h.Clients).Returns(mainClients.Object);
+        mainClients
+            .Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string groupName) =>
+            {
+                if (!groupProxies.TryGetValue(groupName, out var proxy))
+                {
+                    proxy = new Mock<IClientProxy>();
+                    proxy
+                        .Setup(p => p.SendCoreAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<object?[]>(),
+                            It.IsAny<CancellationToken>()))
+                        .Returns(Task.CompletedTask);
+                    groupProxies[groupName] = proxy;
+                }
+
+                return proxy.Object;
+            });
+
+        var service = new SignalRNotificationService(
+            mainHub.Object,
+            analyzeHub.Object,
+            ballotImportHub.Object,
+            frontDeskHub.Object,
+            publicHub.Object,
+            NullLogger<SignalRNotificationService>.Instance);
+
+        return (service, mainClients, groupProxies);
+    }
+
+    [Fact]
+    public async Task SendElectionUpdateAsync_sends_statusChanged_to_base_Main_group()
+    {
+        var (service, mainClients, groupProxies) = CreateService();
+        var update = new ElectionUpdateDto
+        {
+            ElectionGuid = _electionGuid,
+            Name = "Test Election",
+            ElectionStage = ElectionStage.GatheringBallots,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        var expectedGroup = MainHub.GetGroupName(_electionGuid);
+
+        await service.SendElectionUpdateAsync(update);
+
+        mainClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        mainClients.Verify(c => c.Group(expectedGroup + "Known"), Times.Never);
+        mainClients.Verify(c => c.Group(expectedGroup + "Guest"), Times.Never);
+
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "statusChanged",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "statusChanged"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Single(capturedArgs);
+        var dto = Assert.IsType<ElectionUpdateDto>(capturedArgs[0]);
+        Assert.Equal(_electionGuid, dto.ElectionGuid);
+        Assert.Equal("Test Election", dto.Name);
+        Assert.Equal(ElectionStage.GatheringBallots, dto.ElectionStage);
+    }
+
+    [Fact]
+    public async Task CloseOutGuestTellersAsync_sends_electionClosed_to_Guest_group_only()
+    {
+        var (service, mainClients, groupProxies) = CreateService();
+        var baseGroup = MainHub.GetGroupName(_electionGuid);
+        var guestGroup = baseGroup + "Guest";
+
+        await service.CloseOutGuestTellersAsync(_electionGuid);
+
+        mainClients.Verify(c => c.Group(guestGroup), Times.Once);
+        mainClients.Verify(c => c.Group(baseGroup), Times.Never);
+        mainClients.Verify(c => c.Group(baseGroup + "Known"), Times.Never);
+
+        Assert.True(groupProxies.TryGetValue(guestGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "electionClosed",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/backend/Hubs/MainHub.cs
+++ b/backend/Hubs/MainHub.cs
@@ -7,7 +7,9 @@ namespace Backend.Hubs;
 
 /// <summary>
 /// Main SignalR hub for election-related real-time communication.
-/// Handles client connections, group management, and broadcasting election status updates.
+/// Handles client join/leave and Known/Guest group membership.
+/// Server-to-client broadcasts (status, guest close-out) go through
+/// <see cref="ISignalRNotificationService"/> / <c>IHubContext&lt;MainHub&gt;</c>, not hub instance methods.
 /// </summary>
 [Authorize]
 public class MainHub : Hub
@@ -76,51 +78,6 @@ public class MainHub : Hub
             Context.ConnectionId, electionGuid);
     }
 
-    // Server-to-client methods (called by business logic)
-    /// <summary>
-    /// Broadcasts election status changes to all clients in the election groups.
-    /// Sends different information to known users and guest users for security purposes.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election whose status changed.</param>
-    /// <param name="infoForKnown">Status information to send to authenticated/known users.</param>
-    /// <param name="infoForGuest">Status information to send to guest users (potentially filtered for security).</param>
-    public async Task StatusChanged(Guid electionGuid, object infoForKnown, object infoForGuest)
-    {
-        var knownGroup = GetGroupName(electionGuid) + "Known";
-        var guestGroup = GetGroupName(electionGuid) + "Guest";
-
-        await Clients.Group(knownGroup).SendAsync("statusChanged", infoForKnown);
-        await Clients.Group(guestGroup).SendAsync("statusChanged", infoForGuest);
-
-        _logger.LogInformation("Status changed broadcast for election {ElectionGuid}", electionGuid);
-    }
-
-    /// <summary>
-    /// Broadcasts that an election has been closed to all clients in the election group.
-    /// This notifies all connected clients that voting is no longer possible.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election that was closed.</param>
-    public async Task ElectionClosed(Guid electionGuid)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("electionClosed");
-
-        _logger.LogInformation("Election closed broadcast for election {ElectionGuid}", electionGuid);
-    }
-
-    /// <summary>
-    /// Notifies GuestTellers that they should be closed out from the election.
-    /// This is typically called when an election is being finalized or when guest access needs to be restricted.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where GuestTellers should be closed out.</param>
-    public async Task CloseOutGuestTellers(Guid electionGuid)
-    {
-        var guestGroup = GetGroupName(electionGuid) + "Guest";
-        await Clients.Group(guestGroup).SendAsync("electionClosed");
-
-        _logger.LogInformation("GuestTellers closed out for election {ElectionGuid}", electionGuid);
-    }
-
     /// <summary>
     /// Called when a client disconnects from the hub.
     /// Logs the disconnection event for monitoring purposes.
@@ -145,5 +102,10 @@ public class MainHub : Hub
         return !bool.TryParse(isTellerClaim, out var isGuestTeller) || !isGuestTeller;
     }
 
-    private static string GetGroupName(Guid electionGuid) => $"Main{electionGuid}";
+    /// <summary>
+    /// Base MainHub group for an election. Clients also join <c>{base}Known</c> or <c>{base}Guest</c>.
+    /// Server pushes shared status to the base group via <see cref="Services.ISignalRNotificationService"/>;
+    /// role-specific events (e.g. guest <c>electionClosed</c>) use the Known/Guest suffix groups.
+    /// </summary>
+    public static string GetGroupName(Guid electionGuid) => $"Main{electionGuid}";
 }

--- a/backend/Hubs/MainHub.cs
+++ b/backend/Hubs/MainHub.cs
@@ -104,7 +104,7 @@ public class MainHub : Hub
 
     /// <summary>
     /// Base MainHub group for an election. Clients also join <c>{base}Known</c> or <c>{base}Guest</c>.
-    /// Server pushes shared status to the base group via <see cref="Services.ISignalRNotificationService"/>;
+    /// Server pushes shared status to the base group via <see cref="ISignalRNotificationService"/>;
     /// role-specific events (e.g. guest <c>electionClosed</c>) use the Known/Guest suffix groups.
     /// </summary>
     public static string GetGroupName(Guid electionGuid) => $"Main{electionGuid}";

--- a/backend/Services/ComputerAssignmentService.cs
+++ b/backend/Services/ComputerAssignmentService.cs
@@ -381,7 +381,7 @@ public class ComputerAssignmentService : IComputerAssignmentService, IDisposable
             }
         }
 
-        var guestGroup = $"Main{electionGuid}Guest";
+        var guestGroup = MainHub.GetGroupName(electionGuid) + "Guest";
         await _mainHubContext.Clients.Group(guestGroup).SendAsync("electionClosed");
 
         lock (_stateLock)

--- a/backend/Services/SignalRNotificationService.cs
+++ b/backend/Services/SignalRNotificationService.cs
@@ -52,13 +52,15 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var groupName = $"Main{update.ElectionGuid}";
-            await _mainHubContext.Clients.Group(groupName).SendAsync("ElectionUpdated", update);
-            _logger.LogInformation("Sent ElectionUpdated notification to group {GroupName}", groupName);
+            // Base group: every joined client is in Main{guid} plus Known or Guest.
+            // FE electionStore listens for "statusChanged" (v3 parity); not "ElectionUpdated".
+            var groupName = MainHub.GetGroupName(update.ElectionGuid);
+            await _mainHubContext.Clients.Group(groupName).SendAsync("statusChanged", update);
+            _logger.LogInformation("Sent statusChanged notification to group {GroupName}", groupName);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error sending ElectionUpdated notification for election {ElectionGuid}", update.ElectionGuid);
+            _logger.LogError(ex, "Error sending statusChanged notification for election {ElectionGuid}", update.ElectionGuid);
         }
     }
 
@@ -152,7 +154,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var guestGroup = $"Main{electionGuid}Guest";
+            var guestGroup = MainHub.GetGroupName(electionGuid) + "Guest";
             await _mainHubContext.Clients.Group(guestGroup).SendAsync("electionClosed");
             _logger.LogInformation("Sent electionClosed notification to guest group {GroupName}", guestGroup);
         }
@@ -170,7 +172,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var groupName = $"Main{monitorInfo.ElectionGuid}";
+            var groupName = MainHub.GetGroupName(monitorInfo.ElectionGuid);
             await _mainHubContext.Clients.Group(groupName).SendAsync("MonitorUpdated", monitorInfo);
             _logger.LogInformation("Sent MonitorUpdated notification to group {GroupName}", groupName);
         }

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -11,7 +11,21 @@ Do **not** assume a single `election-{guid}` convention for all realtime traffic
 
 | Pattern                                                     | Hub / use                                               |
 | ----------------------------------------------------------- | ------------------------------------------------------- |
-| `Main{electionGuid}` (+ `…Known` / `…Guest`)                | MainHub — election updates, status, closed              |
+| `Main{electionGuid}` (+ `…Known` / `…Guest`)                | MainHub — shared status on **base**; role events on suffix |
+
+## MainHub status vs role groups
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #227 fix; `SignalRNotificationService.SendElectionUpdateAsync`; `MainHub.JoinElection`  
+**Revisit when:** Known vs Guest need different status payloads (v3 `infoForKnown` / `infoForGuest`)
+
+- Every client that joins an election is added to **base** `Main{electionGuid}` **and** either `…Known` or `…Guest`.
+- Shared election status (name, stage) is broadcast as **`statusChanged`** to the **base** group only — one payload, no double delivery.
+- Role-specific events use suffix groups (guest **`electionClosed`** → `Main{guid}Guest` only).
+- Server producers use `IHubContext<MainHub>` via `SignalRNotificationService` (and computer-assignment close-out), not client-callable hub methods.
+
+**Rejected alternative:** leave server event as `ElectionUpdated` while FE listens for `statusChanged` (broken live updates). **Rejected alternative:** keep unused hub methods `StatusChanged` / `ElectionClosed` / `CloseOutGuestTellers` as the documented push path — they were never called by services and were client-invokable.
 | `Analyze{electionGuid}`                                     | AnalyzeHub — tally progress/complete                    |
 | `FrontDesk{electionGuid}`                                   | FrontDeskHub — people, ballots, online election, reload |
 | `BallotImport{electionGuid}` / `PeopleImport{electionGuid}` | import hubs                                             |

--- a/docs/Hubs-v3-vs-v4.md
+++ b/docs/Hubs-v3-vs-v4.md
@@ -109,17 +109,15 @@ Documented in `context/realtime.md`:
 
 These look “implemented” until exercised.
 
-#### 1. MainHub election status
+#### 1. MainHub election status — **fixed** ([#227](https://github.com/glittle/TallyJ-4/issues/227))
 
 | Layer | Actual |
 |-------|--------|
-| Notification service | Sends **`ElectionUpdated`** to base `Main{guid}` |
-| Hub method `StatusChanged` | Would send **`statusChanged`** to Known/Guest; **unused** |
-| Frontend `electionStore` | Listens for **`statusChanged` only** |
+| Notification service | Sends **`statusChanged`** to base `Main{guid}` (`ElectionUpdateDto`: name, stage, …) |
+| Frontend `electionStore` | Listens for **`statusChanged`** |
+| Guest close-out | **`electionClosed`** to `Main{guid}Guest` only (unchanged) |
 
-Guest close-out works; routine status/stage updates likely do not reach the SPA.
-
-→ Issue [#227](https://github.com/glittle/TallyJ-4/issues/227)
+Unused hub instance methods (`StatusChanged` / `ElectionClosed` / `CloseOutGuestTellers`) were removed; producers use `IHubContext` via `SignalRNotificationService` (and computer-assignment timeout for guest kick).
 
 #### 2. Person list updates
 
@@ -199,7 +197,7 @@ If restored: prefer server-derived groups, high-entropy channel tokens for code 
 
 ## Suggested fix order
 
-1. [#227](https://github.com/glittle/TallyJ-4/issues/227) Main status wiring  
+1. ~~[#227](https://github.com/glittle/TallyJ-4/issues/227) Main status wiring~~ **fixed**  
 2. [#232](https://github.com/glittle/TallyJ-4/issues/232) Person event alignment  
 3. [#228](https://github.com/glittle/TallyJ-4/issues/228) Online window + import reload  
 4. [#226](https://github.com/glittle/TallyJ-4/issues/226) Import event name cleanup  

--- a/frontend/src/stores/electionStore.test.ts
+++ b/frontend/src/stores/electionStore.test.ts
@@ -30,11 +30,38 @@ vi.mock("../services/signalrService", () => ({
   },
 }));
 
-// Mock Element Plus
+const elMessageMock = vi.fn();
+
+// Mock Element Plus (store calls ElMessage as a function)
 vi.mock("element-plus", () => ({
-  ElMessage: {
+  ElMessage: Object.assign((opts: unknown) => elMessageMock(opts), {
     success: vi.fn(),
     info: vi.fn(),
+  }),
+}));
+
+vi.mock("../locales", () => ({
+  i18n: {
+    global: {
+      t: (key: string, opts?: Record<string, string>) => {
+        if (key === "elections.stageAdvanced" && opts?.stage) {
+          return `Election changed to ${opts.stage}`;
+        }
+        if (key === "elections.stage.GatheringBallots") {
+          return "Gathering Ballots";
+        }
+        if (key === "elections.stage.ProcessingBallots") {
+          return "Processing Ballots";
+        }
+        if (key === "elections.stage.SettingUp") {
+          return "Setting Up";
+        }
+        if (key === "elections.stage.Finalized") {
+          return "Finalized";
+        }
+        return key;
+      },
+    },
   },
 }));
 
@@ -44,6 +71,7 @@ describe("Election Store", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     electionStore = useElectionStore();
+    elMessageMock.mockClear();
   });
 
   afterEach(() => {
@@ -335,6 +363,96 @@ describe("Election Store", () => {
         expect.any(Error),
       );
       consoleSpy.mockRestore();
+    });
+
+    it("statusChanged notifies once with i18n stage label when list and current both match", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+
+      electionStore.elections = [
+        {
+          electionGuid: "election-1",
+          name: "Springfield LSA",
+          electionStage: "SettingUp",
+        } as ElectionDto,
+      ];
+      electionStore.currentElection = {
+        electionGuid: "election-1",
+        name: "Springfield LSA",
+        electionStage: "SettingUp",
+      } as ElectionDto;
+
+      await electionStore.initializeSignalR();
+      handlers.get("statusChanged")!({
+        electionGuid: "election-1",
+        name: "Springfield LSA",
+        electionStage: "GatheringBallots",
+        updatedAt: new Date().toISOString(),
+      });
+
+      expect(electionStore.currentElection?.electionStage).toBe(
+        "GatheringBallots",
+      );
+      expect(electionStore.elections[0]?.electionStage).toBe(
+        "GatheringBallots",
+      );
+      expect(elMessageMock).toHaveBeenCalledTimes(1);
+      expect(elMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Election changed to Gathering Ballots",
+          type: "info",
+        }),
+      );
+    });
+
+    it("statusChanged does not toast when local setStage already suppressed echo", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const { electionService } = await import("../services/electionService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+
+      electionStore.elections = [
+        {
+          electionGuid: "election-1",
+          name: "Springfield LSA",
+          electionStage: "SettingUp",
+        } as ElectionDto,
+      ];
+      electionStore.currentElection = electionStore.elections[0]!;
+
+      electionService.changeStage.mockImplementation(async () => {
+        // Simulate SignalR arriving before HTTP response updates store
+        handlers.get("statusChanged")!({
+          electionGuid: "election-1",
+          name: "Springfield LSA",
+          electionStage: "ProcessingBallots",
+          updatedAt: new Date().toISOString(),
+        });
+        return {
+          electionGuid: "election-1",
+          name: "Springfield LSA",
+          electionStage: "ProcessingBallots",
+        } as ElectionDto;
+      });
+
+      await electionStore.initializeSignalR();
+      await electionStore.setStage("election-1", "ProcessingBallots");
+
+      expect(elMessageMock).not.toHaveBeenCalled();
+      expect(electionStore.currentElection?.electionStage).toBe(
+        "ProcessingBallots",
+      );
     });
   });
 

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -18,7 +18,14 @@ import {
   getActiveElectionHubGuid,
   setActiveElectionHubGuid,
 } from "../utils/activeElectionHubStorage";
-import { type ElectionStage } from "../domain/electionStages";
+import {
+  STAGE_META,
+  type ElectionStage,
+} from "../domain/electionStages";
+import { i18n } from "../locales";
+
+/** How long to suppress remote stage toasts after a local setStage (covers SignalR racing HTTP). */
+const LOCAL_STAGE_NOTIFY_SUPPRESS_MS = 5000;
 
 export const useElectionStore = defineStore("election", () => {
   const elections = ref<ElectionDto[]>([]);
@@ -26,6 +33,8 @@ export const useElectionStore = defineStore("election", () => {
   const loading = ref(false);
   const error = ref<string | null>(null);
   const signalrInitialized = ref(false);
+  /** electionGuid → suppress remote stage toast until this timestamp (ms). */
+  const suppressRemoteStageNotifyUntil = new Map<string, number>();
 
   const activeElections = computed(() =>
     elections.value.filter((e) => e.electionStage !== "ProcessingBallots"),
@@ -193,53 +202,71 @@ export const useElectionStore = defineStore("election", () => {
     await authStore.logout("/teller-join?electionClosed=1");
   }
 
+  function isRemoteStageNotifySuppressed(electionGuid: string): boolean {
+    const until = suppressRemoteStageNotifyUntil.get(electionGuid);
+    if (until == null) {
+      return false;
+    }
+    if (Date.now() >= until) {
+      suppressRemoteStageNotifyUntil.delete(electionGuid);
+      return false;
+    }
+    return true;
+  }
+
   function handleElectionUpdate(data: ElectionUpdateEvent) {
     const index = elections.value.findIndex(
       (e) => e.electionGuid === data.electionGuid,
     );
-    if (index !== -1) {
-      const existingElection = elections.value[index]!;
-      const oldStage = existingElection.electionStage;
+    const listMatch = index !== -1 ? elections.value[index] : undefined;
+    const currentMatch =
+      currentElection.value?.electionGuid === data.electionGuid
+        ? currentElection.value
+        : undefined;
 
+    // Prefer list stage when both exist (they should match); fall back to current.
+    const previousStage =
+      listMatch?.electionStage ?? currentMatch?.electionStage;
+
+    if (listMatch && index !== -1) {
       elections.value[index] = {
-        ...existingElection,
-        name: data.name ?? existingElection.name,
-        electionStage: data.electionStage ?? existingElection.electionStage,
+        ...listMatch,
+        name: data.name ?? listMatch.name,
+        electionStage: data.electionStage ?? listMatch.electionStage,
       } as ElectionDto;
-
-      if (data.electionStage && data.electionStage !== oldStage) {
-        showElectionStageNotification(
-          data.name || "Election",
-          data.electionStage,
-        );
-      }
     }
 
-    if (currentElection.value?.electionGuid === data.electionGuid) {
-      const existingCurrentElection = currentElection.value!;
-      const oldStage = existingCurrentElection.electionStage;
-
+    if (currentMatch) {
       currentElection.value = {
-        ...existingCurrentElection,
-        name: data.name ?? existingCurrentElection.name,
-        electionStage:
-          data.electionStage ?? existingCurrentElection.electionStage,
+        ...currentMatch,
+        name: data.name ?? currentMatch.name,
+        electionStage: data.electionStage ?? currentMatch.electionStage,
       } as ElectionDto;
+    }
 
-      if (data.electionStage && data.electionStage !== oldStage) {
-        showElectionStageNotification(
-          data.name || "Election",
-          data.electionStage,
-        );
-      }
+    const stageChanged =
+      !!data.electionStage &&
+      previousStage !== undefined &&
+      data.electionStage !== previousStage;
+
+    if (
+      stageChanged &&
+      data.electionStage &&
+      !isRemoteStageNotifySuppressed(data.electionGuid)
+    ) {
+      showElectionStageNotification(data.electionStage);
     }
   }
 
-  function showElectionStageNotification(
-    electionName: string,
-    newStage: string,
-  ) {
-    const message = `${electionName} stage changed to: ${newStage}`;
+  function showElectionStageNotification(newStage: string) {
+    const stageKey =
+      newStage in STAGE_META
+        ? STAGE_META[newStage as ElectionStage].i18nKey
+        : `elections.stage.${newStage}`;
+    const stageLabel = i18n.global.t(stageKey);
+    const message = i18n.global.t("elections.stageAdvanced", {
+      stage: stageLabel,
+    });
     ElMessage({
       message,
       type: "info",
@@ -300,6 +327,12 @@ export const useElectionStore = defineStore("election", () => {
   async function setStage(electionGuid: string, stage: ElectionStage) {
     loading.value = true;
     error.value = null;
+    // StageControl shows the success toast; suppress the echo from statusChanged
+    // (SignalR often arrives before the HTTP response updates local state).
+    suppressRemoteStageNotifyUntil.set(
+      electionGuid,
+      Date.now() + LOCAL_STAGE_NOTIFY_SUPPRESS_MS,
+    );
     try {
       const election = await electionService.changeStage(electionGuid, stage);
 
@@ -316,6 +349,7 @@ export const useElectionStore = defineStore("election", () => {
 
       return election;
     } catch (e: any) {
+      suppressRemoteStageNotifyUntil.delete(electionGuid);
       error.value = extractApiErrorMessage(e);
       throw e;
     } finally {

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -260,7 +260,7 @@ export const useElectionStore = defineStore("election", () => {
 
   function showElectionStageNotification(newStage: string) {
     const stageKey =
-      newStage in STAGE_META
+      Object.hasOwn(STAGE_META, newStage)
         ? STAGE_META[newStage as ElectionStage].i18nKey
         : `elections.stage.${newStage}`;
     const stageLabel = i18n.global.t(stageKey);


### PR DESCRIPTION
## Summary
- Wire `SendElectionUpdateAsync` to emit **`statusChanged`** (matching the SPA) instead of unused `ElectionUpdated`, targeting the base `Main{guid}` group
- Remove dead client-callable MainHub methods (`StatusChanged`, `ElectionClosed`, `CloseOutGuestTellers`); producers stay on `IHubContext` / notification service
- Stage toasts: once per remote update, i18n stage labels, suppress SignalR echo for the teller who just changed stage locally
- Contract unit tests for event name + group targets; docs/context updated for #227

## Test plan
- [x] Unit: `SignalRNotificationServiceTests` + `ComputerAssignmentServiceTests` close-out
- [x] Unit: `electionStore.test.ts` (single toast, suppress local echo)
- [x] Manual: two browsers on same election — stage change updates other browser without refresh
- [x] Manual: initiator sees one success toast; remote sees one i18n stage toast
- [x] Manual: guest close-out (`electionClosed`) still works

Fixes #227