### PR TITLE
Align FrontDesk person-update SignalR events (#232)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Group name patterns (constructed via `GetGroupName` statics in each hub + used f
 
 - `Main{electionGuid}` — MainHub (election updates, statusChanged, electionClosed). Also creates `Main{ guid }Known` / `Main{ guid }Guest` variants.
 - `Analyze{electionGuid}` — AnalyzeHub (tallyProgress / tallyComplete).
-- `FrontDesk{electionGuid}` — FrontDeskHub (updatePeople, reloadPage, updateBallots, updateOnlineElection, etc.).
+- `FrontDesk{electionGuid}` — FrontDeskHub (PersonAdded/Updated/Deleted, PersonCheckedIn, PersonFlagsUpdated, VoterCountUpdated, PersonVoteCountUpdated, updateBallots; reloadPage / updateOnlineElection reserved). See `context/realtime.md`.
 - `BallotImport{electionGuid}` — BallotImportHub (importProgress, importError, importComplete).
 - `PeopleImport{electionGuid}` — PeopleImportHub (same import events).
 - `Public` (static group) — PublicHub for guest-teller joinable elections list updates.

--- a/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
@@ -1,3 +1,4 @@
+using Backend.DTOs.FrontDesk;
 using Backend.DTOs.SignalR;
 using Backend.Enumerations;
 using Backend.Hubs;
@@ -10,7 +11,7 @@ using Xunit;
 namespace Backend.Tests.UnitTests.Services;
 
 /// <summary>
-/// Contract tests for MainHub fan-out: event names and group targets must match the SPA.
+/// Contract tests for hub fan-out: event names and group targets must match the SPA.
 /// </summary>
 public class SignalRNotificationServiceTests
 {
@@ -19,6 +20,7 @@ public class SignalRNotificationServiceTests
     private (
         SignalRNotificationService Service,
         Mock<IHubClients> MainClients,
+        Mock<IHubClients> FrontDeskClients,
         Dictionary<string, Mock<IClientProxy>> GroupProxies) CreateService()
     {
         var mainHub = new Mock<IHubContext<MainHub>>();
@@ -27,27 +29,34 @@ public class SignalRNotificationServiceTests
         var frontDeskHub = new Mock<IHubContext<FrontDeskHub>>();
         var publicHub = new Mock<IHubContext<PublicHub>>();
         var mainClients = new Mock<IHubClients>();
+        var frontDeskClients = new Mock<IHubClients>();
         var groupProxies = new Dictionary<string, Mock<IClientProxy>>();
 
+        Mock<IClientProxy> GetOrCreateProxy(string groupName)
+        {
+            if (!groupProxies.TryGetValue(groupName, out var proxy))
+            {
+                proxy = new Mock<IClientProxy>();
+                proxy
+                    .Setup(p => p.SendCoreAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<object?[]>(),
+                        It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                groupProxies[groupName] = proxy;
+            }
+
+            return proxy;
+        }
+
         mainHub.Setup(h => h.Clients).Returns(mainClients.Object);
+        frontDeskHub.Setup(h => h.Clients).Returns(frontDeskClients.Object);
         mainClients
             .Setup(c => c.Group(It.IsAny<string>()))
-            .Returns((string groupName) =>
-            {
-                if (!groupProxies.TryGetValue(groupName, out var proxy))
-                {
-                    proxy = new Mock<IClientProxy>();
-                    proxy
-                        .Setup(p => p.SendCoreAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<object?[]>(),
-                            It.IsAny<CancellationToken>()))
-                        .Returns(Task.CompletedTask);
-                    groupProxies[groupName] = proxy;
-                }
-
-                return proxy.Object;
-            });
+            .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
+        frontDeskClients
+            .Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
 
         var service = new SignalRNotificationService(
             mainHub.Object,
@@ -57,13 +66,13 @@ public class SignalRNotificationServiceTests
             publicHub.Object,
             NullLogger<SignalRNotificationService>.Instance);
 
-        return (service, mainClients, groupProxies);
+        return (service, mainClients, frontDeskClients, groupProxies);
     }
 
     [Fact]
     public async Task SendElectionUpdateAsync_sends_statusChanged_to_base_Main_group()
     {
-        var (service, mainClients, groupProxies) = CreateService();
+        var (service, mainClients, _, groupProxies) = CreateService();
         var update = new ElectionUpdateDto
         {
             ElectionGuid = _electionGuid,
@@ -101,7 +110,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task CloseOutGuestTellersAsync_sends_electionClosed_to_Guest_group_only()
     {
-        var (service, mainClients, groupProxies) = CreateService();
+        var (service, mainClients, _, groupProxies) = CreateService();
         var baseGroup = MainHub.GetGroupName(_electionGuid);
         var guestGroup = baseGroup + "Guest";
 
@@ -118,5 +127,82 @@ public class SignalRNotificationServiceTests
                 It.IsAny<object?[]>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Theory]
+    [InlineData("added", "PersonAdded")]
+    [InlineData("updated", "PersonUpdated")]
+    [InlineData("deleted", "PersonDeleted")]
+    [InlineData("unknown", "PersonUpdated")]
+    public async Task SendPersonUpdateAsync_sends_action_event_to_FrontDesk_group(
+        string action,
+        string expectedEvent)
+    {
+        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var personGuid = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var update = new PersonUpdateDto
+        {
+            ElectionGuid = _electionGuid,
+            PersonGuid = personGuid,
+            Action = action,
+            FirstName = "Ada",
+            LastName = "Lovelace",
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+        var expectedGroup = FrontDeskHub.GetGroupName(_electionGuid);
+
+        await service.SendPersonUpdateAsync(update);
+
+        frontDeskClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                expectedEvent,
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], expectedEvent));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Single(capturedArgs);
+        var dto = Assert.IsType<PersonUpdateDto>(capturedArgs[0]);
+        Assert.Equal(personGuid, dto.PersonGuid);
+        Assert.Equal(action, dto.Action);
+    }
+
+    [Fact]
+    public async Task NotifyVoterCountUpdatedAsync_sends_VoterCountUpdated_to_FrontDesk_group()
+    {
+        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var stats = new FrontDeskStatsDto
+        {
+            TotalEligible = 100,
+            CheckedIn = 40,
+            NotYetCheckedIn = 60
+        };
+        var expectedGroup = FrontDeskHub.GetGroupName(_electionGuid);
+
+        await service.NotifyVoterCountUpdatedAsync(_electionGuid, stats);
+
+        frontDeskClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "VoterCountUpdated",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "VoterCountUpdated"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Single(capturedArgs);
+        var dto = Assert.IsType<FrontDeskStatsDto>(capturedArgs[0]);
+        Assert.Equal(100, dto.TotalEligible);
+        Assert.Equal(40, dto.CheckedIn);
+        Assert.Equal(60, dto.NotYetCheckedIn);
     }
 }

--- a/backend/Hubs/FrontDeskHub.cs
+++ b/backend/Hubs/FrontDeskHub.cs
@@ -5,7 +5,10 @@ namespace Backend.Hubs;
 
 /// <summary>
 /// SignalR hub for front desk operations in election management.
-/// Handles real-time communication for voter registration, people updates, and election status changes.
+/// Handles client join/leave for the election front-desk group.
+/// Server-to-client broadcasts go through
+/// <see cref="Services.ISignalRNotificationService"/> / <c>IHubContext&lt;FrontDeskHub&gt;</c>,
+/// not hub instance methods.
 /// </summary>
 [Authorize]
 public class FrontDeskHub : Hub
@@ -47,62 +50,6 @@ public class FrontDeskHub : Hub
             Context.ConnectionId, electionGuid);
     }
 
-    // Server-to-client methods for voter registration updates
-    /// <summary>
-    /// Broadcasts updates about people/voters to all front desk clients.
-    /// Used to notify clients when voter information has been added, updated, or changed.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where people were updated.</param>
-    /// <param name="message">The update message containing information about the people changes.</param>
-    public async Task UpdatePeople(Guid electionGuid, object message)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("updatePeople", message);
-
-        _logger.LogInformation("People update broadcast for election {ElectionGuid}", electionGuid);
-    }
-
-    /// <summary>
-    /// Broadcasts a page reload command to all front desk clients for the specified election.
-    /// Used to force clients to refresh their interface when critical data has changed.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where clients should reload their pages.</param>
-    public async Task ReloadPage(Guid electionGuid)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("reloadPage");
-
-        _logger.LogInformation("Page reload broadcast for election {ElectionGuid}", electionGuid);
-    }
-
-    /// <summary>
-    /// Broadcasts updates about online election status to all front desk clients.
-    /// Used to notify clients when online voting settings or election parameters have changed.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where online settings were updated.</param>
-    /// <param name="message">The update message containing information about the online election changes.</param>
-    public async Task UpdateOnlineElection(Guid electionGuid, object message)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("updateOnlineElection", message);
-
-        _logger.LogInformation("Online election update broadcast for election {ElectionGuid}", electionGuid);
-    }
-
-    /// <summary>
-    /// Broadcasts updates about ballot status changes to all front desk clients.
-    /// Used to notify clients when ballot information has been added, updated, or changed.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where ballots were updated.</param>
-    /// <param name="message">The update message containing information about the ballot changes.</param>
-    public async Task UpdateBallots(Guid electionGuid, object message)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("updateBallots", message);
-
-        _logger.LogInformation("Ballot update broadcast for election {ElectionGuid}", electionGuid);
-    }
-
     /// <summary>
     /// Called when a client disconnects from the FrontDeskHub.
     /// Logs the disconnection event for monitoring purposes.
@@ -116,7 +63,8 @@ public class FrontDeskHub : Hub
     }
 
     /// <summary>
-    /// Gets the SignalR group name for front desk clients in the specified election.
+    /// FrontDeskHub group for an election. Server pushes person, check-in, ballot, and
+    /// related events via <see cref="Services.ISignalRNotificationService"/>.
     /// </summary>
     public static string GetGroupName(Guid electionGuid) => $"FrontDesk{electionGuid}";
 }

--- a/backend/Hubs/FrontDeskHub.cs
+++ b/backend/Hubs/FrontDeskHub.cs
@@ -7,7 +7,7 @@ namespace Backend.Hubs;
 /// SignalR hub for front desk operations in election management.
 /// Handles client join/leave for the election front-desk group.
 /// Server-to-client broadcasts go through
-/// <see cref="Services.ISignalRNotificationService"/> / <c>IHubContext&lt;FrontDeskHub&gt;</c>,
+/// <see cref="Backend.Services.ISignalRNotificationService"/> / <c>IHubContext&lt;FrontDeskHub&gt;</c>,
 /// not hub instance methods.
 /// </summary>
 [Authorize]
@@ -64,7 +64,7 @@ public class FrontDeskHub : Hub
 
     /// <summary>
     /// FrontDeskHub group for an election. Server pushes person, check-in, ballot, and
-    /// related events via <see cref="Services.ISignalRNotificationService"/>.
+    /// related events via <see cref="Backend.Services.ISignalRNotificationService"/>.
     /// </summary>
     public static string GetGroupName(Guid electionGuid) => $"FrontDesk{electionGuid}";
 }

--- a/backend/Services/SignalRNotificationService.cs
+++ b/backend/Services/SignalRNotificationService.cs
@@ -110,7 +110,8 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var groupName = $"FrontDesk{update.ElectionGuid}";
+            var groupName = FrontDeskHub.GetGroupName(update.ElectionGuid);
+            // FE peopleStore + FrontDeskPage listen for these exact event names (not v3 updatePeople).
             var eventName = update.Action switch
             {
                 "added" => "PersonAdded",
@@ -190,7 +191,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var groupName = $"FrontDesk{update.ElectionGuid}";
+            var groupName = FrontDeskHub.GetGroupName(update.ElectionGuid);
             await _frontDeskHubContext.Clients.Group(groupName).SendAsync("updateBallots", update);
             _logger.LogInformation("Sent ballot update notification to group {GroupName}", groupName);
         }
@@ -209,7 +210,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var groupName = $"FrontDesk{electionGuid}";
+            var groupName = FrontDeskHub.GetGroupName(electionGuid);
             await _frontDeskHubContext.Clients.Group(groupName).SendAsync("PersonCheckedIn", voter);
             _logger.LogInformation("Sent PersonCheckedIn notification to group {GroupName}", groupName);
         }
@@ -228,7 +229,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var groupName = $"FrontDesk{electionGuid}";
+            var groupName = FrontDeskHub.GetGroupName(electionGuid);
             await _frontDeskHubContext.Clients.Group(groupName).SendAsync("VoterCountUpdated", stats);
             _logger.LogInformation("Sent VoterCountUpdated notification to group {GroupName}", groupName);
         }
@@ -246,7 +247,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     {
         try
         {
-            var groupName = $"FrontDesk{update.ElectionGuid}";
+            var groupName = FrontDeskHub.GetGroupName(update.ElectionGuid);
             await _frontDeskHubContext.Clients.Group(groupName).SendAsync("PersonVoteCountUpdated", update);
             _logger.LogInformation("Sent PersonVoteCountUpdated notification to group {GroupName}", groupName);
         }

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -62,3 +62,33 @@ Anonymous clients must not learn election results (or other election detail) jus
 **Rejected alternative:** per-election `public-display-{guid}` groups + `GET /api/Public/{guid}/publicDisplay` + full-screen public results page. Removed — no business need for random users to view election data; authenticated results presentation (e.g. in-app results/presentation views) covers operator needs.
 
 Election detail over HTTP follows the same rule: `GET /api/Elections/{guid}/status` (and other election-scoped routes) require `ElectionAccess` (full or guest teller joined to that election). Anonymous public endpoints stay limited to guest-join discovery (`/api/Public/elections`, hub `Public` group) and non-sensitive health/home.
+
+## FrontDeskHub event catalog
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #232 fix; `SignalRNotificationService` FrontDesk methods; `peopleStore` / `FrontDeskPage` listeners  
+**Revisit when:** adding online-window / post-import producers (#228), or changing person payload shape
+
+Server pushes only via `IHubContext<FrontDeskHub>` in `SignalRNotificationService` (and future service producers). The hub exposes **join/leave only** — no client-callable broadcast methods (same pattern as MainHub after #227).
+
+Group: `FrontDesk{electionGuid}`.
+
+| Event | Payload | Producer | Primary listeners |
+| ----- | ------- | -------- | ----------------- |
+| `PersonAdded` | `PersonUpdateDto` (`action: "added"`) | `SendPersonUpdateAsync` ← PeopleService create | `peopleStore` (list + ballot cache); Front Desk refreshes eligible list |
+| `PersonUpdated` | `PersonUpdateDto` (`action: "updated"`) | `SendPersonUpdateAsync` ← PeopleService update | same |
+| `PersonDeleted` | `PersonUpdateDto` (`action: "deleted"`) | `SendPersonUpdateAsync` ← PeopleService delete | same |
+| `PersonCheckedIn` | `FrontDeskVoterDto` | `NotifyPersonCheckedInAsync` ← check-in / unregister / envelope | Front Desk page (row patch) |
+| `PersonFlagsUpdated` | `FrontDeskVoterDto` | `SendPersonFlagsUpdatedAsync` | Front Desk page |
+| `VoterCountUpdated` | `FrontDeskStatsDto` | `NotifyVoterCountUpdatedAsync` ← after check-in / unregister | Front Desk page (`frontDeskStats`) |
+| `PersonVoteCountUpdated` | `PersonVoteCountUpdateDto` | `SendPersonVoteCountUpdateAsync` | `peopleStore` ballot cache |
+| `updateBallots` | `BallotUpdateDto` | `SendBallotUpdateAsync` | `ballotStore` |
+| `reloadPage` | (none) | **none yet** (#228) | `peopleStore` (full reload when produced) |
+| `updateOnlineElection` | online window info | **none yet** (#228) | **none yet** |
+
+**Person list contract:** v4 uses fine-grained `PersonAdded` / `PersonUpdated` / `PersonDeleted`, not v3’s single `updatePeople` stream. Handlers refetch the affected person (or drop the row on delete) rather than applying a partial patch from the thin DTO.
+
+**Rejected alternative:** re-emit v3 `updatePeople` from the notification service to match an old `peopleStore` listener. Rejected — other Front Desk events already use PascalCase names; handlers for add/update/delete already existed; dual event names would keep the contract ambiguous.
+
+**Rejected alternative:** leave unused hub instance methods (`UpdatePeople`, `ReloadPage`, …) as the “documented” push path. Rejected — they were client-invokable, never called by services, and misled readers (same lesson as MainHub #227).

--- a/docs/Hubs-v3-vs-v4.md
+++ b/docs/Hubs-v3-vs-v4.md
@@ -119,16 +119,16 @@ These look “implemented” until exercised.
 
 Unused hub instance methods (`StatusChanged` / `ElectionClosed` / `CloseOutGuestTellers`) were removed; producers use `IHubContext` via `SignalRNotificationService` (and computer-assignment timeout for guest kick).
 
-#### 2. Person list updates
+#### 2. Person list updates — **fixed** ([#232](https://github.com/glittle/TallyJ-4/issues/232))
 
 | Layer | Actual |
 |-------|--------|
-| Notification service | `PersonAdded` / `PersonUpdated` / `PersonDeleted` |
-| `peopleStore` | Listens for **`updatePeople`** |
-| Front desk page | `PersonCheckedIn`, `PersonFlagsUpdated` (good) |
-| `VoterCountUpdated` | Server sends; front desk UI does **not** subscribe |
+| Notification service | `PersonAdded` / `PersonUpdated` / `PersonDeleted` to `FrontDesk{guid}` |
+| `peopleStore` | Listens for those three events (+ `PersonVoteCountUpdated`, `reloadPage`) |
+| Front desk page | `PersonCheckedIn`, `PersonFlagsUpdated`, `VoterCountUpdated`, and Person\* (silent eligible-list refresh) |
+| Unused hub methods | Removed (`UpdatePeople` / `ReloadPage` / …); producers use `IHubContext` |
 
-→ Issue [#232](https://github.com/glittle/TallyJ-4/issues/232)
+Catalog: `context/realtime.md` § FrontDeskHub event catalog.
 
 #### 3. `updateOnlineElection` and post-import `reloadPage`
 

--- a/frontend/src/pages/frontdesk/FrontDeskPage.vue
+++ b/frontend/src/pages/frontdesk/FrontDeskPage.vue
@@ -10,6 +10,7 @@ import { useElectionStore } from "@/stores/electionStore";
 import { useLocationStore } from "@/stores/locationStore";
 import type {
   CheckInVoterDto,
+  FrontDeskStatsDto,
   FrontDeskVoterDto,
   RegistrationHistoryEntryDto,
   UnregisterVoterDto,
@@ -126,6 +127,8 @@ const voters = ref<FrontDeskVoterDto[]>([]);
 const loading = ref(false);
 const error = ref<string | null>(null);
 const signalrInitialized = ref(false);
+/** Authoritative check-in totals from `VoterCountUpdated` (not search-filtered). */
+const frontDeskStats = ref<FrontDeskStatsDto | null>(null);
 const searchQuery = ref("");
 
 const currentElection = computed(() => electionStore.currentElection);
@@ -254,6 +257,23 @@ const checkedInVoters = computed(() =>
 const notCheckedInVoters = computed(() =>
   filteredVoters.value.filter((v) => !v.isCheckedIn),
 );
+
+/** Prefer server stats for filter badges when the list is unfiltered (authoritative totals). */
+const registrationFilterCounts = computed(() => {
+  const stats = frontDeskStats.value;
+  if (!searchQuery.value.trim() && stats) {
+    return {
+      all: stats.totalEligible,
+      notRegistered: stats.notYetCheckedIn,
+      registered: stats.checkedIn,
+    };
+  }
+  return {
+    all: filteredVoters.value.length,
+    notRegistered: notCheckedInVoters.value.length,
+    registered: checkedInVoters.value.length,
+  };
+});
 
 const filteredByRegistration = computed(() => {
   switch (registrationFilter.value) {
@@ -417,8 +437,13 @@ const flagCounts = computed(() => {
   return counts;
 });
 
-async function fetchEligibleVoters(guid: string) {
-  loading.value = true;
+async function fetchEligibleVoters(
+  guid: string,
+  options: { silent?: boolean } = {},
+) {
+  if (!options.silent) {
+    loading.value = true;
+  }
   error.value = null;
   try {
     voters.value = (await frontDeskService.getEligibleVoters(guid)).sort(
@@ -428,7 +453,9 @@ async function fetchEligibleVoters(guid: string) {
     error.value = e.message || t("frontDesk.errors.fetchVoters");
     throw e;
   } finally {
-    loading.value = false;
+    if (!options.silent) {
+      loading.value = false;
+    }
   }
 }
 
@@ -605,6 +632,26 @@ async function initializeSignalR() {
     connection.on("PersonFlagsUpdated", (voter: FrontDeskVoterDto) => {
       updateVoterInList(voter);
     });
+
+    // Authoritative eligible/checked-in totals (paired with check-in/unregister).
+    connection.on("VoterCountUpdated", (stats: FrontDeskStatsDto) => {
+      frontDeskStats.value = stats;
+    });
+
+    // Person CRUD uses finer-grained events; refresh the eligible list so
+    // multi-station front desks stay aligned when people are added/edited/removed.
+    // Drop server stats until the next VoterCountUpdated so badges use the list.
+    const refreshEligibleVoters = () => {
+      frontDeskStats.value = null;
+      void fetchEligibleVoters(electionGuid.value, { silent: true }).catch(
+        (e) => {
+          console.error("Failed to refresh voters after person update:", e);
+        },
+      );
+    };
+    connection.on("PersonAdded", refreshEligibleVoters);
+    connection.on("PersonUpdated", refreshEligibleVoters);
+    connection.on("PersonDeleted", refreshEligibleVoters);
 
     signalrInitialized.value = true;
   } catch (e) {
@@ -1253,21 +1300,21 @@ function openEnvelopeDialog(voter: FrontDeskVoterDto) {
               <el-radio-button value="all">
                 {{
                   $t("frontDesk.filters.registrationAll", {
-                    count: formatNumber(filteredVoters.length),
+                    count: formatNumber(registrationFilterCounts.all),
                   })
                 }}
               </el-radio-button>
               <el-radio-button value="notRegistered">
                 {{
                   $t("frontDesk.filters.registrationNotRegistered", {
-                    count: formatNumber(notCheckedInVoters.length),
+                    count: formatNumber(registrationFilterCounts.notRegistered),
                   })
                 }}
               </el-radio-button>
               <el-radio-button value="registered">
                 {{
                   $t("frontDesk.filters.registrationRegistered", {
-                    count: formatNumber(checkedInVoters.length),
+                    count: formatNumber(registrationFilterCounts.registered),
                   })
                 }}
               </el-radio-button>

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -256,11 +256,10 @@ export const useElectionStore = defineStore("election", () => {
   }
 
   function showElectionStageNotification(newStage: string) {
-    // Prefer `in` over Object.hasOwn so TS can narrow against STAGE_META keys.
-    const meta =
-      newStage in STAGE_META
-        ? STAGE_META[newStage as ElectionStage]
-        : undefined;
+    // Own-property check (not `in`) so prototype keys like "toString" never match.
+    const meta = Object.hasOwn(STAGE_META, newStage)
+      ? STAGE_META[newStage as ElectionStage]
+      : undefined;
     const stageKey = meta ? meta.i18nKey : `elections.stage.${newStage}`;
     const stageLabel = i18n.global.t(stageKey);
     const message = i18n.global.t("elections.stageAdvanced", {

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -18,10 +18,7 @@ import {
   getActiveElectionHubGuid,
   setActiveElectionHubGuid,
 } from "../utils/activeElectionHubStorage";
-import {
-  STAGE_META,
-  type ElectionStage,
-} from "../domain/electionStages";
+import { STAGE_META, type ElectionStage } from "../domain/electionStages";
 import { i18n } from "../locales";
 
 /** How long to suppress remote stage toasts after a local setStage (covers SignalR racing HTTP). */
@@ -204,7 +201,7 @@ export const useElectionStore = defineStore("election", () => {
 
   function isRemoteStageNotifySuppressed(electionGuid: string): boolean {
     const until = suppressRemoteStageNotifyUntil.get(electionGuid);
-    if (until == null) {
+    if (until === undefined) {
       return false;
     }
     if (Date.now() >= until) {
@@ -259,10 +256,12 @@ export const useElectionStore = defineStore("election", () => {
   }
 
   function showElectionStageNotification(newStage: string) {
-    const stageKey =
-      Object.hasOwn(STAGE_META, newStage)
-        ? STAGE_META[newStage as ElectionStage].i18nKey
-        : `elections.stage.${newStage}`;
+    // Prefer `in` over Object.hasOwn so TS can narrow against STAGE_META keys.
+    const meta =
+      newStage in STAGE_META
+        ? STAGE_META[newStage as ElectionStage]
+        : undefined;
+    const stageKey = meta ? meta.i18nKey : `elections.stage.${newStage}`;
     const stageLabel = i18n.global.t(stageKey);
     const message = i18n.global.t("elections.stageAdvanced", {
       stage: stageLabel,

--- a/frontend/src/stores/peopleStore.test.ts
+++ b/frontend/src/stores/peopleStore.test.ts
@@ -352,4 +352,89 @@ describe("People Store - People Cache", () => {
       }).not.toThrow();
     });
   });
+
+  describe("initializeSignalR person-update wiring", () => {
+    it("registers PersonAdded/Updated/Deleted (not updatePeople)", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      vi.mocked(signalrService.connectToFrontDeskHub).mockResolvedValue(
+        mockConnection as never,
+      );
+
+      await store.initializeSignalR();
+
+      expect(handlers.has("PersonAdded")).toBe(true);
+      expect(handlers.has("PersonUpdated")).toBe(true);
+      expect(handlers.has("PersonDeleted")).toBe(true);
+      expect(handlers.has("PersonVoteCountUpdated")).toBe(true);
+      expect(handlers.has("updatePeople")).toBe(false);
+    });
+
+    it("PersonAdded event fetches person into cache", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      vi.mocked(signalrService.connectToFrontDeskHub).mockResolvedValue(
+        mockConnection as never,
+      );
+      vi.mocked(peopleService.getById).mockResolvedValue(mockPerson);
+
+      store.isCacheInitialized = true;
+      store.peopleCache = [];
+
+      await store.initializeSignalR();
+      await handlers.get("PersonAdded")!({
+        electionGuid: "election-123",
+        personGuid: mockPerson.personGuid,
+        action: "added",
+        firstName: mockPerson.firstName,
+        lastName: mockPerson.lastName,
+        updatedAt: new Date().toISOString(),
+      });
+
+      // Handler is async; wait a tick for fetchPersonById
+      await vi.waitFor(() => {
+        expect(store.peopleCache).toHaveLength(1);
+      });
+      expect(store.peopleCache[0]?.personGuid).toBe(mockPerson.personGuid);
+    });
+
+    it("PersonDeleted event removes person from cache", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      vi.mocked(signalrService.connectToFrontDeskHub).mockResolvedValue(
+        mockConnection as never,
+      );
+
+      const enriched = store.enrichPersonForSearch(mockPerson);
+      store.isCacheInitialized = true;
+      store.peopleCache = [enriched];
+
+      await store.initializeSignalR();
+      handlers.get("PersonDeleted")!({
+        electionGuid: "election-123",
+        personGuid: mockPerson.personGuid,
+        action: "deleted",
+        firstName: mockPerson.firstName,
+        lastName: mockPerson.lastName,
+        updatedAt: new Date().toISOString(),
+      });
+
+      expect(store.peopleCache).toHaveLength(0);
+    });
+  });
 });

--- a/frontend/src/stores/peopleStore.ts
+++ b/frontend/src/stores/peopleStore.ts
@@ -247,6 +247,31 @@ export const usePeopleStore = defineStore("people", () => {
     }
   }
 
+  function normalizePersonUpdateEvent(data: unknown): PersonUpdateEvent | null {
+    if (!data || typeof data !== "object") {
+      return null;
+    }
+    const raw = data as Record<string, unknown>;
+    const personGuid = String(raw.personGuid ?? "");
+    if (!personGuid) {
+      return null;
+    }
+    const actionRaw = String(raw.action ?? "updated");
+    const action: PersonUpdateEvent["action"] =
+      actionRaw === "added" || actionRaw === "deleted" ? actionRaw : "updated";
+    return {
+      electionGuid: String(raw.electionGuid ?? ""),
+      personGuid,
+      action,
+      firstName: typeof raw.firstName === "string" ? raw.firstName : undefined,
+      lastName: typeof raw.lastName === "string" ? raw.lastName : undefined,
+      updatedAt:
+        typeof raw.updatedAt === "string"
+          ? raw.updatedAt
+          : new Date().toISOString(),
+    };
+  }
+
   async function initializeSignalR() {
     if (signalrInitialized.value) {
       return;
@@ -255,37 +280,31 @@ export const usePeopleStore = defineStore("people", () => {
     try {
       const connection = await signalrService.connectToFrontDeskHub();
 
-      connection.on("updatePeople", (data: any) => {
-        // FrontDeskHub sends updatePeople with person update information
-        // The data structure should contain action, personGuid, and other person details
-        if (data && typeof data === "object") {
-          const updateEvent: PersonUpdateEvent = {
-            electionGuid: data.electionGuid || "",
-            personGuid: data.personGuid || "",
-            action: data.action || "updated",
-            firstName: data.firstName,
-            lastName: data.lastName,
-            updatedAt: data.updatedAt || new Date().toISOString(),
-          };
+      // Server contract (SignalRNotificationService.SendPersonUpdateAsync):
+      // PersonAdded / PersonUpdated / PersonDeleted with PersonUpdateDto payload.
+      connection.on("PersonAdded", (data: unknown) => {
+        const event = normalizePersonUpdateEvent(data);
+        if (event) {
+          void handlePersonAdded({ ...event, action: "added" });
+        }
+      });
 
-          switch (updateEvent.action) {
-            case "added":
-              handlePersonAdded(updateEvent);
-              break;
-            case "updated":
-              handlePersonUpdated(updateEvent);
-              break;
-            case "deleted":
-              handlePersonDeleted(updateEvent);
-              break;
-          }
+      connection.on("PersonUpdated", (data: unknown) => {
+        const event = normalizePersonUpdateEvent(data);
+        if (event) {
+          void handlePersonUpdated({ ...event, action: "updated" });
+        }
+      });
+
+      connection.on("PersonDeleted", (data: unknown) => {
+        const event = normalizePersonUpdateEvent(data);
+        if (event) {
+          handlePersonDeleted({ ...event, action: "deleted" });
         }
       });
 
       connection.on("reloadPage", () => {
-        // Handle page reload command from server
-        console.log("Server requested page reload");
-        // Could trigger a page refresh or data reload
+        // Thin signal from server (e.g. post-import); full client reload.
         window.location.reload();
       });
 


### PR DESCRIPTION
## Summary
- Wire `peopleStore` to `PersonAdded` / `PersonUpdated` / `PersonDeleted` (server contract) instead of the unused v3 `updatePeople` event.
- Front Desk listens for `VoterCountUpdated` (registration filter badges) and Person* (silent eligible-list refresh for multi-station CRUD).
- Remove unused client-callable FrontDeskHub broadcast methods; producers use `IHubContext` via `SignalRNotificationService` (same pattern as MainHub #227).
- Document FrontDesk event catalog in `context/realtime.md`; mark gap fixed in `docs/Hubs-v3-vs-v4.md`.
- Lint/type fixes in `electionStore` (eqeqeq, prettier, safer stage meta lookup).

## Test plan
- [x] Backend: `SignalRNotificationServiceTests` (person update events + `VoterCountUpdated`)
- [x] Frontend: `peopleStore` unit tests including SignalR wiring
- [x] `npm run check` clean
- [ ] Manual: two stations — add/edit/delete person on People page; ballot entry cache and Front Desk list update live
- [ ] Manual: check-in on station A; station B sees row update and registration counts via `VoterCountUpdated`

Closes #232