### PR TITLE
Wire FrontDesk updateOnlineElection + reloadPage after imports (#228)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Group name patterns (constructed via `GetGroupName` statics in each hub + used f
 
 - `Main{electionGuid}` — MainHub (election updates, statusChanged, electionClosed). Also creates `Main{ guid }Known` / `Main{ guid }Guest` variants.
 - `Analyze{electionGuid}` — AnalyzeHub (tallyProgress / tallyComplete).
-- `FrontDesk{electionGuid}` — FrontDeskHub (PersonAdded/Updated/Deleted, PersonCheckedIn, PersonFlagsUpdated, VoterCountUpdated, PersonVoteCountUpdated, updateBallots; reloadPage / updateOnlineElection reserved). See `context/realtime.md`.
+- `FrontDesk{electionGuid}` — FrontDeskHub (PersonAdded/Updated/Deleted, PersonCheckedIn, PersonFlagsUpdated, VoterCountUpdated, PersonVoteCountUpdated, updateBallots, reloadPage, updateOnlineElection). See `context/realtime.md`.
 - `BallotImport{electionGuid}` — BallotImportHub (importProgress, importError, importComplete).
 - `PeopleImport{electionGuid}` — PeopleImportHub (same import events).
 - `Public` (static group) — PublicHub for guest-teller joinable elections list updates.

--- a/Backend.Tests/UnitTests/ElectionServiceTests.cs
+++ b/Backend.Tests/UnitTests/ElectionServiceTests.cs
@@ -286,6 +286,57 @@ public class ElectionServiceTests : ServiceTestBase
         Assert.Equal("Updated Name", result.Name);
         Assert.Equal(7, result.NumberToElect);
         Assert.Equal(ElectionStage.GatheringBallots, result.ElectionStage);
+        _signalRMock.Verify(
+            s => s.SendOnlineElectionUpdateAsync(It.IsAny<Backend.DTOs.SignalR.OnlineElectionUpdateDto>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateElectionAsync_WhenOnlineWindowChanges_SendsOnlineElectionUpdate()
+    {
+        var election = new Election
+        {
+            ElectionGuid = Guid.NewGuid(),
+            Name = "Online Election",
+            ElectionType = "LSA",
+            NumberToElect = 3,
+            ElectionStage = ElectionStage.GatheringBallots,
+            DateOfElection = DateTime.UtcNow.AddDays(10),
+            OnlineWhenOpen = DateTimeOffset.UtcNow.AddDays(-1),
+            OnlineWhenClose = DateTimeOffset.UtcNow.AddDays(1),
+            OnlineCloseIsEstimate = true,
+            OnlineSelectionProcess = "A",
+            RowVersion = new byte[8]
+        };
+
+        Context.Elections.Add(election);
+        await Context.SaveChangesAsync();
+
+        var originalClose = election.OnlineWhenClose;
+        var newClose = DateTimeOffset.UtcNow.AddDays(2);
+        var updateDto = new UpdateElectionDto
+        {
+            Name = election.Name,
+            OnlineWhenClose = newClose
+        };
+
+        Backend.DTOs.SignalR.OnlineElectionUpdateDto? captured = null;
+        _signalRMock
+            .Setup(s => s.SendOnlineElectionUpdateAsync(It.IsAny<Backend.DTOs.SignalR.OnlineElectionUpdateDto>()))
+            .Callback<Backend.DTOs.SignalR.OnlineElectionUpdateDto>(u => captured = u)
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.UpdateElectionAsync(election.ElectionGuid, updateDto);
+
+        Assert.NotNull(result);
+        Assert.NotNull(captured);
+        Assert.Equal(election.ElectionGuid, captured!.ElectionGuid);
+        Assert.True(captured.OnlineWhenClose.HasValue);
+        Assert.True(captured.OnlineWhenClose > originalClose);
+        Assert.Equal("A", captured.OnlineSelectionProcess);
+        _signalRMock.Verify(
+            s => s.SendOnlineElectionUpdateAsync(It.IsAny<Backend.DTOs.SignalR.OnlineElectionUpdateDto>()),
+            Times.Once);
     }
 
     [Fact]

--- a/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
@@ -16,13 +16,15 @@ public class PeopleImportServiceTests : ServiceTestBase
 {
     private readonly PeopleImportService _service;
     private readonly Mock<IHubContext<PeopleImportHub>> _hubContextMock;
+    private readonly Mock<ISignalRNotificationService> _signalRMock;
     private readonly Mock<ILogger<PeopleImportService>> _loggerMock;
 
     public PeopleImportServiceTests()
     {
         _hubContextMock = new Mock<IHubContext<PeopleImportHub>>();
+        _signalRMock = new Mock<ISignalRNotificationService>();
         _loggerMock = new Mock<ILogger<PeopleImportService>>();
-        _service = new PeopleImportService(Context, _hubContextMock.Object);
+        _service = new PeopleImportService(Context, _hubContextMock.Object, _signalRMock.Object);
     }
 
     [Fact]
@@ -379,6 +381,11 @@ public class PeopleImportServiceTests : ServiceTestBase
         Assert.Equal(2, people.Count);
         Assert.Contains(people, p => p.FirstName == "John" && p.LastName == "Doe");
         Assert.Contains(people, p => p.FirstName == "Jane" && p.LastName == "Smith");
+
+        // Front desk (and related open screens) soft-refresh after bulk people import.
+        _signalRMock.Verify(
+            s => s.RequestFrontDeskReloadAsync(electionGuid),
+            Times.Once);
     }
 
     [Fact]
@@ -497,6 +504,9 @@ public class PeopleImportServiceTests : ServiceTestBase
         Assert.Equal(2, result.DeletedCount);
         var remainingPeople = await Context.People.Where(p => p.ElectionGuid == electionGuid).ToListAsync<Person>();
         Assert.Empty(remainingPeople);
+        _signalRMock.Verify(
+            s => s.RequestFrontDeskReloadAsync(electionGuid),
+            Times.Once);
     }
 
     [Fact]

--- a/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
@@ -205,4 +205,62 @@ public class SignalRNotificationServiceTests
         Assert.Equal(40, dto.CheckedIn);
         Assert.Equal(60, dto.NotYetCheckedIn);
     }
+
+    [Fact]
+    public async Task SendOnlineElectionUpdateAsync_sends_updateOnlineElection_to_FrontDesk_group()
+    {
+        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var open = DateTimeOffset.Parse("2026-04-01T12:00:00Z");
+        var close = DateTimeOffset.Parse("2026-04-02T12:00:00Z");
+        var update = new OnlineElectionUpdateDto
+        {
+            ElectionGuid = _electionGuid,
+            OnlineWhenOpen = open,
+            OnlineWhenClose = close,
+            OnlineCloseIsEstimate = true,
+            OnlineSelectionProcess = "A"
+        };
+        var expectedGroup = FrontDeskHub.GetGroupName(_electionGuid);
+
+        await service.SendOnlineElectionUpdateAsync(update);
+
+        frontDeskClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "updateOnlineElection",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "updateOnlineElection"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Single(capturedArgs);
+        var dto = Assert.IsType<OnlineElectionUpdateDto>(capturedArgs[0]);
+        Assert.Equal(_electionGuid, dto.ElectionGuid);
+        Assert.Equal(open, dto.OnlineWhenOpen);
+        Assert.Equal(close, dto.OnlineWhenClose);
+        Assert.True(dto.OnlineCloseIsEstimate);
+        Assert.Equal("A", dto.OnlineSelectionProcess);
+    }
+
+    [Fact]
+    public async Task RequestFrontDeskReloadAsync_sends_reloadPage_to_FrontDesk_group()
+    {
+        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var expectedGroup = FrontDeskHub.GetGroupName(_electionGuid);
+
+        await service.RequestFrontDeskReloadAsync(_electionGuid);
+
+        frontDeskClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "reloadPage",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/backend/DTOs/SignalR/OnlineElectionUpdateDto.cs
+++ b/backend/DTOs/SignalR/OnlineElectionUpdateDto.cs
@@ -1,0 +1,33 @@
+namespace Backend.DTOs.SignalR;
+
+/// <summary>
+/// Thin SignalR payload for operator-facing online voting window / process changes
+/// (FrontDeskHub <c>updateOnlineElection</c>). Clients re-apply these fields or re-fetch.
+/// </summary>
+public class OnlineElectionUpdateDto
+{
+    /// <summary>
+    /// The election whose online settings changed.
+    /// </summary>
+    public Guid ElectionGuid { get; set; }
+
+    /// <summary>
+    /// When online voting opens.
+    /// </summary>
+    public DateTimeOffset? OnlineWhenOpen { get; set; }
+
+    /// <summary>
+    /// When online voting closes.
+    /// </summary>
+    public DateTimeOffset? OnlineWhenClose { get; set; }
+
+    /// <summary>
+    /// Whether the close time is an estimate.
+    /// </summary>
+    public bool OnlineCloseIsEstimate { get; set; }
+
+    /// <summary>
+    /// Online ballot selection process code (e.g. simultaneous vs ranked).
+    /// </summary>
+    public string? OnlineSelectionProcess { get; set; }
+}

--- a/backend/Services/ElectionExportImportService.cs
+++ b/backend/Services/ElectionExportImportService.cs
@@ -17,24 +17,34 @@ public class ElectionExportImportService : ElectionImportExportBase
     private readonly CdnBallotImportService _cdnBallotImportService;
     private readonly TallyJv3ElectionImportService _tallyJv3ElectionImportService;
     private readonly JsonElectionImportExportService _jsonElectionImportExportService;
+    private readonly ISignalRNotificationService _signalRNotificationService;
 
     public ElectionExportImportService(
         MainDbContext context,
         IElectionService electionService,
         CdnBallotImportService cdnBallotImportService,
         TallyJv3ElectionImportService tallyJv3ElectionImportService,
-        JsonElectionImportExportService jsonElectionImportExportService)
+        JsonElectionImportExportService jsonElectionImportExportService,
+        ISignalRNotificationService signalRNotificationService)
         : base(context, electionService)
     {
         _cdnBallotImportService = cdnBallotImportService;
         _tallyJv3ElectionImportService = tallyJv3ElectionImportService;
         _jsonElectionImportExportService = jsonElectionImportExportService;
+        _signalRNotificationService = signalRNotificationService;
     }
 
     // Job 1: Import from CdnBallotImport.xsd format
     public async Task<ImportResultDto> ImportCdnBallotsAsync(Guid electionGuid, Stream xmlStream)
     {
-        return await _cdnBallotImportService.ImportCdnBallotsAsync(electionGuid, xmlStream);
+        var result = await _cdnBallotImportService.ImportCdnBallotsAsync(electionGuid, xmlStream);
+        if (result.Success)
+        {
+            // Same post-import FrontDesk refresh as CSV import (v3 ReloadPage).
+            await _signalRNotificationService.RequestFrontDeskReloadAsync(electionGuid);
+        }
+
+        return result;
     }
 
 

--- a/backend/Services/ElectionService.cs
+++ b/backend/Services/ElectionService.cs
@@ -227,6 +227,11 @@ public class ElectionService : IElectionService
             return null;
         }
 
+        var previousOnlineWhenOpen = election.OnlineWhenOpen;
+        var previousOnlineWhenClose = election.OnlineWhenClose;
+        var previousOnlineCloseIsEstimate = election.OnlineCloseIsEstimate;
+        var previousOnlineSelectionProcess = election.OnlineSelectionProcess;
+
         var listForPublic = updateDto.ListForPublic;
         updateDto.CopyMatchingPropertiesTo(election, ignoreNulls: true);
         ElectionTellerAccessHelper.ApplyListForPublicFlag(election, listForPublic);
@@ -241,6 +246,26 @@ public class ElectionService : IElectionService
             ElectionStage = election.ElectionStage,
             UpdatedAt = DateTimeOffset.UtcNow
         });
+
+        // Operator monitor / front desk need a live push when the online window or process changes
+        // (FrontDeskHub updateOnlineElection — v3 ElectionHelper parity).
+        var onlineSettingsChanged =
+            previousOnlineWhenOpen != election.OnlineWhenOpen
+            || previousOnlineWhenClose != election.OnlineWhenClose
+            || previousOnlineCloseIsEstimate != election.OnlineCloseIsEstimate
+            || !string.Equals(previousOnlineSelectionProcess, election.OnlineSelectionProcess, StringComparison.Ordinal);
+
+        if (onlineSettingsChanged)
+        {
+            await _signalRNotificationService.SendOnlineElectionUpdateAsync(new OnlineElectionUpdateDto
+            {
+                ElectionGuid = election.ElectionGuid,
+                OnlineWhenOpen = election.OnlineWhenOpen,
+                OnlineWhenClose = election.OnlineWhenClose,
+                OnlineCloseIsEstimate = election.OnlineCloseIsEstimate,
+                OnlineSelectionProcess = election.OnlineSelectionProcess
+            });
+        }
 
         return await GetElectionByGuidAsync(electionGuid);
     }

--- a/backend/Services/ISignalRNotificationService.cs
+++ b/backend/Services/ISignalRNotificationService.cs
@@ -79,6 +79,18 @@ public interface ISignalRNotificationService
     /// <param name="electionGuid">The election GUID.</param>
     /// <param name="voter">The voter with updated flags.</param>
     Task SendPersonFlagsUpdatedAsync(Guid electionGuid, FrontDeskVoterDto voter);
+
+    /// <summary>
+    /// Notifies front desk / monitor clients that online open/close (or related) settings changed.
+    /// </summary>
+    /// <param name="update">Thin online-window payload for the election.</param>
+    Task SendOnlineElectionUpdateAsync(OnlineElectionUpdateDto update);
+
+    /// <summary>
+    /// Asks front desk (and other FrontDeskHub clients) to re-fetch state after bulk ballot import.
+    /// </summary>
+    /// <param name="electionGuid">The election whose open sessions should refresh.</param>
+    Task RequestFrontDeskReloadAsync(Guid electionGuid);
 }
 
 

--- a/backend/Services/ImportService.cs
+++ b/backend/Services/ImportService.cs
@@ -15,16 +15,22 @@ public class ImportService
 {
     private readonly MainDbContext _context;
     private readonly IHubContext<BallotImportHub> _hubContext;
+    private readonly ISignalRNotificationService _signalRNotificationService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ImportService"/> class.
     /// </summary>
     /// <param name="context">The database context.</param>
     /// <param name="hubContext">The SignalR hub context for ballot import notifications.</param>
-    public ImportService(MainDbContext context, IHubContext<BallotImportHub> hubContext)
+    /// <param name="signalRNotificationService">Broadcasts post-import refresh to FrontDesk clients.</param>
+    public ImportService(
+        MainDbContext context,
+        IHubContext<BallotImportHub> hubContext,
+        ISignalRNotificationService signalRNotificationService)
     {
         _context = context;
         _hubContext = hubContext;
+        _signalRNotificationService = signalRNotificationService;
     }
 
     /// <summary>
@@ -221,6 +227,9 @@ public class ImportService
                 errors = result.Errors,
                 warnings = result.Warnings
             });
+
+            // Open front desk / ballot entry sessions re-fetch registration and ballot state (v3 ReloadPage).
+            await _signalRNotificationService.RequestFrontDeskReloadAsync(request.ElectionGuid);
         }
         catch (Exception ex)
         {

--- a/backend/Services/PeopleImportService.cs
+++ b/backend/Services/PeopleImportService.cs
@@ -24,6 +24,7 @@ public class PeopleImportService : IPeopleImportService
 {
     private readonly MainDbContext _context;
     private readonly IHubContext<PeopleImportHub> _hubContext;
+    private readonly ISignalRNotificationService _signalRNotificationService;
 
     // Scoring weights for header detection
     private const int TextCellScore = 2;
@@ -50,10 +51,15 @@ public class PeopleImportService : IPeopleImportService
     /// </summary>
     /// <param name="context">The database context.</param>
     /// <param name="hubContext">The SignalR hub context for people import notifications.</param>
-    public PeopleImportService(MainDbContext context, IHubContext<PeopleImportHub> hubContext)
+    /// <param name="signalRNotificationService">Broadcasts post-import FrontDesk refresh (same as ballot import).</param>
+    public PeopleImportService(
+        MainDbContext context,
+        IHubContext<PeopleImportHub> hubContext,
+        ISignalRNotificationService signalRNotificationService)
     {
         _context = context;
         _hubContext = hubContext;
+        _signalRNotificationService = signalRNotificationService;
     }
 
     /// <summary>
@@ -517,6 +523,10 @@ public class PeopleImportService : IPeopleImportService
                 result.TimeElapsedSeconds = (DateTimeOffset.UtcNow - startTime).TotalSeconds;
 
                 await _hubContext.Clients.Group(groupName).SendAsync("importComplete", result);
+
+                // Open front desk / people / ballot-entry sessions re-fetch lists
+                // (parity with single-person PersonAdded/Updated from People Management).
+                await _signalRNotificationService.RequestFrontDeskReloadAsync(electionGuid);
             }
             else
             {
@@ -614,6 +624,11 @@ public class PeopleImportService : IPeopleImportService
 
         _context.People.RemoveRange(peopleToDelete);
         await _context.SaveChangesAsync();
+
+        if (result.DeletedCount > 0)
+        {
+            await _signalRNotificationService.RequestFrontDeskReloadAsync(electionGuid);
+        }
 
         return result;
     }

--- a/backend/Services/SignalRNotificationService.cs
+++ b/backend/Services/SignalRNotificationService.cs
@@ -275,6 +275,41 @@ public class SignalRNotificationService : ISignalRNotificationService
             _logger.LogError(ex, "Error sending PersonFlagsUpdated notification for election {ElectionGuid}", electionGuid);
         }
     }
+
+    /// <summary>
+    /// Notifies front desk / monitor clients that online open/close settings changed.
+    /// Event name matches SPA: <c>updateOnlineElection</c> (v3 parity).
+    /// </summary>
+    public async Task SendOnlineElectionUpdateAsync(OnlineElectionUpdateDto update)
+    {
+        try
+        {
+            var groupName = FrontDeskHub.GetGroupName(update.ElectionGuid);
+            await _frontDeskHubContext.Clients.Group(groupName).SendAsync("updateOnlineElection", update);
+            _logger.LogInformation("Sent updateOnlineElection notification to group {GroupName}", groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending updateOnlineElection for election {ElectionGuid}", update.ElectionGuid);
+        }
+    }
+
+    /// <summary>
+    /// Asks FrontDeskHub clients to re-fetch after bulk ballot import (event <c>reloadPage</c>).
+    /// </summary>
+    public async Task RequestFrontDeskReloadAsync(Guid electionGuid)
+    {
+        try
+        {
+            var groupName = FrontDeskHub.GetGroupName(electionGuid);
+            await _frontDeskHubContext.Clients.Group(groupName).SendAsync("reloadPage");
+            _logger.LogInformation("Sent reloadPage notification to group {GroupName}", groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending reloadPage for election {ElectionGuid}", electionGuid);
+        }
+    }
 }
 
 

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -68,7 +68,7 @@ Election detail over HTTP follows the same rule: `GET /api/Elections/{guid}/stat
 **Status:** active  
 **Evidence:** confirmed  
 **Source:** issue #232 fix; `SignalRNotificationService` FrontDesk methods; `peopleStore` / `FrontDeskPage` listeners  
-**Revisit when:** adding online-window / post-import producers (#228), or changing person payload shape
+**Revisit when:** changing person payload shape, or adding more FrontDesk producers
 
 Server pushes only via `IHubContext<FrontDeskHub>` in `SignalRNotificationService` (and future service producers). The hub exposes **join/leave only** — no client-callable broadcast methods (same pattern as MainHub after #227).
 
@@ -84,11 +84,23 @@ Group: `FrontDesk{electionGuid}`.
 | `VoterCountUpdated` | `FrontDeskStatsDto` | `NotifyVoterCountUpdatedAsync` ← after check-in / unregister | Front Desk page (`frontDeskStats`) |
 | `PersonVoteCountUpdated` | `PersonVoteCountUpdateDto` | `SendPersonVoteCountUpdateAsync` | `peopleStore` ballot cache |
 | `updateBallots` | `BallotUpdateDto` | `SendBallotUpdateAsync` | `ballotStore` |
-| `reloadPage` | (none) | **none yet** (#228) | `peopleStore` (full reload when produced) |
-| `updateOnlineElection` | online window info | **none yet** (#228) | **none yet** |
+| `reloadPage` | (none) | `RequestFrontDeskReloadAsync` ← CSV / CDN ballot import success | Front Desk page, `peopleStore`, `ballotStore` (soft re-fetch, not `location.reload`) |
+| `updateOnlineElection` | `OnlineElectionUpdateDto` | `SendOnlineElectionUpdateAsync` ← `ElectionService.UpdateElectionAsync` when online fields change | `electionStore` (patch online fields); Monitoring dashboard re-fetches monitor info |
 
 **Person list contract:** v4 uses fine-grained `PersonAdded` / `PersonUpdated` / `PersonDeleted`, not v3’s single `updatePeople` stream. Handlers refetch the affected person (or drop the row on delete) rather than applying a partial patch from the thin DTO.
 
 **Rejected alternative:** re-emit v3 `updatePeople` from the notification service to match an old `peopleStore` listener. Rejected — other Front Desk events already use PascalCase names; handlers for add/update/delete already existed; dual event names would keep the contract ambiguous.
 
 **Rejected alternative:** leave unused hub instance methods (`UpdatePeople`, `ReloadPage`, …) as the “documented” push path. Rejected — they were client-invokable, never called by services, and misled readers (same lesson as MainHub #227).
+
+## FrontDesk `reloadPage` vs full browser reload (#228)
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #228; v3 used `location.reload()` after ballot import; v4 prefers soft re-fetch  
+**Revisit when:** a bulk op leaves client state that soft re-fetch cannot repair
+
+- **Chosen:** server still emits the v3 event name `reloadPage` (no payload). Clients re-fetch people lists, ballots, and front-desk eligible voters/stats instead of forcing `window.location.reload()`.
+- **Why:** full reload is disruptive on multi-station front desk and ballot entry; re-fetch keeps SignalR connections and dialog state.
+- **Rejected alternative:** keep `location.reload()` for exact v3 parity. Rejected as unnecessary disruption when list/stats APIs already return authoritative post-import state.
+- **Also wired:** `updateOnlineElection` with open/close/estimate/selection process when election online settings change (not on every unrelated election field update).

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -84,7 +84,7 @@ Group: `FrontDesk{electionGuid}`.
 | `VoterCountUpdated` | `FrontDeskStatsDto` | `NotifyVoterCountUpdatedAsync` ← after check-in / unregister | Front Desk page (`frontDeskStats`) |
 | `PersonVoteCountUpdated` | `PersonVoteCountUpdateDto` | `SendPersonVoteCountUpdateAsync` | `peopleStore` ballot cache |
 | `updateBallots` | `BallotUpdateDto` | `SendBallotUpdateAsync` | `ballotStore` |
-| `reloadPage` | (none) | `RequestFrontDeskReloadAsync` ← CSV / CDN ballot import success | Front Desk page, `peopleStore`, `ballotStore` (soft re-fetch, not `location.reload`) |
+| `reloadPage` | (none) | `RequestFrontDeskReloadAsync` ← CSV / CDN ballot import success; people import success; delete-all-people | Front Desk page, `peopleStore`, `ballotStore` (soft re-fetch, not `location.reload`) |
 | `updateOnlineElection` | `OnlineElectionUpdateDto` | `SendOnlineElectionUpdateAsync` ← `ElectionService.UpdateElectionAsync` when online fields change | `electionStore` (patch online fields); Monitoring dashboard re-fetches monitor info |
 
 **Person list contract:** v4 uses fine-grained `PersonAdded` / `PersonUpdated` / `PersonDeleted`, not v3’s single `updatePeople` stream. Handlers refetch the affected person (or drop the row on delete) rather than applying a partial patch from the thin DTO.
@@ -104,3 +104,4 @@ Group: `FrontDesk{electionGuid}`.
 - **Why:** full reload is disruptive on multi-station front desk and ballot entry; re-fetch keeps SignalR connections and dialog state.
 - **Rejected alternative:** keep `location.reload()` for exact v3 parity. Rejected as unnecessary disruption when list/stats APIs already return authoritative post-import state.
 - **Also wired:** `updateOnlineElection` with open/close/estimate/selection process when election online settings change (not on every unrelated election field update).
+- **People import:** bulk people CSV/XLSX import does **not** emit per-row `PersonAdded` (would flood the hub). After successful import (or delete-all-people), the server fires the same `reloadPage` signal so open front desks re-fetch eligible voters — same end result as single-person CRUD, without N SignalR events.

--- a/docs/Hubs-in-v3.md
+++ b/docs/Hubs-in-v3.md
@@ -279,9 +279,9 @@ All via `BeforeController.JoinFrontDeskHub` (class: `[AllowTellersInActiveElecti
 
 ### Rewrite checklist
 
-- [ ] Live person registration updates across front desk, ballot entry, sort, reconcile, monitor  
-- [ ] Online window time updates on monitor  
-- [ ] Force front-desk reload after bulk ballot import  
+- [x] Live person registration updates across front desk, ballot entry, sort, reconcile, monitor  
+- [x] Online window time updates on monitor (#228)  
+- [x] Force front-desk reload after bulk ballot import (#228; soft re-fetch, not full page reload)  
 
 ---
 

--- a/docs/Hubs-v3-vs-v4.md
+++ b/docs/Hubs-v3-vs-v4.md
@@ -130,16 +130,17 @@ Unused hub instance methods (`StatusChanged` / `ElectionClosed` / `CloseOutGuest
 
 Catalog: `context/realtime.md` § FrontDeskHub event catalog.
 
-#### 3. `updateOnlineElection` and post-import `reloadPage`
+#### 3. `updateOnlineElection` and post-import `reloadPage` — **fixed** ([#228](https://github.com/glittle/TallyJ-4/issues/228))
 
 | Piece | Status |
 |-------|--------|
-| Hub methods | Exist on FrontDeskHub |
-| Server producers | **None** for online window or post-import reload |
-| FE `reloadPage` | Handled in some stores; never triggered after import |
-| FE `updateOnlineElection` | No listener |
+| Producers | `SendOnlineElectionUpdateAsync` / `RequestFrontDeskReloadAsync` on notification service |
+| Online settings | `ElectionService.UpdateElectionAsync` when online window/process fields change |
+| Ballot import | CSV `ImportService` + CDN import path call `RequestFrontDeskReloadAsync` on success |
+| FE `reloadPage` | Soft re-fetch in front desk, `peopleStore`, `ballotStore` (not full page reload) |
+| FE `updateOnlineElection` | `electionStore` patches online fields; monitor page re-fetches |
 
-→ Issue [#228](https://github.com/glittle/TallyJ-4/issues/228)
+Catalog: `context/realtime.md` § FrontDeskHub event catalog.
 
 #### 4. Ballot import progress dual path
 

--- a/frontend/src/pages/frontdesk/FrontDeskPage.vue
+++ b/frontend/src/pages/frontdesk/FrontDeskPage.vue
@@ -653,6 +653,20 @@ async function initializeSignalR() {
     connection.on("PersonUpdated", refreshEligibleVoters);
     connection.on("PersonDeleted", refreshEligibleVoters);
 
+    // Post-import (and similar bulk ops): soft re-fetch eligible list + stats.
+    connection.on("reloadPage", () => {
+      void (async () => {
+        try {
+          await fetchEligibleVoters(electionGuid.value, { silent: true });
+          frontDeskStats.value = await frontDeskService.getStats(
+            electionGuid.value,
+          );
+        } catch (e) {
+          console.error("Failed to refresh front desk after reloadPage:", e);
+        }
+      })();
+    });
+
     signalrInitialized.value = true;
   } catch (e) {
     console.error("Failed to initialize SignalR for front desk:", e);

--- a/frontend/src/pages/results/MonitoringDashboardPage.vue
+++ b/frontend/src/pages/results/MonitoringDashboardPage.vue
@@ -252,6 +252,7 @@ import {
 } from "@element-plus/icons-vue";
 import { onMounted, onUnmounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { signalrService } from "../../services/signalrService";
 import { useResultStore } from "../../stores/resultStore";
 import type { MonitorInfoDto } from "../../types";
 
@@ -264,14 +265,20 @@ const electionGuid = route.params.id as string;
 const monitorInfo = ref<MonitorInfoDto | null>(null);
 const loading = ref(false);
 const refreshInterval = ref<number | null>(null);
+let frontDeskConnection: Awaited<
+  ReturnType<typeof signalrService.connectToFrontDeskHub>
+> | null = null;
+let onlineElectionHandler: ((data: unknown) => void) | null = null;
 
 onMounted(async () => {
   await loadData();
   startAutoRefresh();
+  await initializeOnlineElectionListener();
 });
 
-onUnmounted(() => {
+onUnmounted(async () => {
   stopAutoRefresh();
+  await teardownOnlineElectionListener();
 });
 
 async function loadData() {
@@ -288,6 +295,43 @@ async function loadData() {
 
 async function refreshData() {
   await loadData();
+}
+
+/** Soft refresh when operator changes online open/close (FrontDesk updateOnlineElection). */
+async function initializeOnlineElectionListener() {
+  try {
+    frontDeskConnection = await signalrService.connectToFrontDeskHub();
+    onlineElectionHandler = (data: unknown) => {
+      const payload = data as { electionGuid?: string } | null;
+      if (
+        payload?.electionGuid &&
+        String(payload.electionGuid).toLowerCase() !==
+          electionGuid.toLowerCase()
+      ) {
+        return;
+      }
+      void loadData();
+    };
+    frontDeskConnection.on("updateOnlineElection", onlineElectionHandler);
+    await signalrService.joinFrontDeskElection(electionGuid);
+  } catch (e) {
+    console.error("Failed to listen for updateOnlineElection on monitor:", e);
+  }
+}
+
+async function teardownOnlineElectionListener() {
+  // Only drop this page's handler. Group membership is owned by
+  // electionStore.setActiveElectionHub (joinElection joins FrontDesk too).
+  try {
+    if (frontDeskConnection && onlineElectionHandler) {
+      frontDeskConnection.off("updateOnlineElection", onlineElectionHandler);
+    }
+  } catch (e) {
+    console.error("Failed to remove updateOnlineElection handler:", e);
+  } finally {
+    onlineElectionHandler = null;
+    frontDeskConnection = null;
+  }
 }
 
 function handleImportCdn() {

--- a/frontend/src/pages/results/MonitoringDashboardPage.vue
+++ b/frontend/src/pages/results/MonitoringDashboardPage.vue
@@ -303,10 +303,11 @@ async function initializeOnlineElectionListener() {
     frontDeskConnection = await signalrService.connectToFrontDeskHub();
     onlineElectionHandler = (data: unknown) => {
       const payload = data as { electionGuid?: string } | null;
+      if (!payload?.electionGuid) {
+        return;
+      }
       if (
-        payload?.electionGuid &&
-        String(payload.electionGuid).toLowerCase() !==
-          electionGuid.toLowerCase()
+        String(payload.electionGuid).toLowerCase() !== electionGuid.toLowerCase()
       ) {
         return;
       }

--- a/frontend/src/pages/results/MonitoringDashboardPage.vue
+++ b/frontend/src/pages/results/MonitoringDashboardPage.vue
@@ -307,7 +307,8 @@ async function initializeOnlineElectionListener() {
         return;
       }
       if (
-        String(payload.electionGuid).toLowerCase() !== electionGuid.toLowerCase()
+        String(payload.electionGuid).toLowerCase() !==
+        electionGuid.toLowerCase()
       ) {
         return;
       }
@@ -320,10 +321,14 @@ async function initializeOnlineElectionListener() {
   }
 }
 
-  // Only drop this page's handler. This page joins the FrontDesk election group
-  // so it can receive updateOnlineElection events; we intentionally do not leave
-  // the group here because the FrontDesk connection/group membership may be
-  // shared with other parts of the app in the same tab.
+/**
+ * Drop this page's handler only. This page joins the FrontDesk election group
+ * so it can receive updateOnlineElection events; we intentionally do not leave
+ * the group here because FrontDesk connection/group membership may be shared
+ * with other parts of the app in the same tab.
+ */
+async function teardownOnlineElectionListener() {
+  try {
     if (frontDeskConnection && onlineElectionHandler) {
       frontDeskConnection.off("updateOnlineElection", onlineElectionHandler);
     }

--- a/frontend/src/pages/results/MonitoringDashboardPage.vue
+++ b/frontend/src/pages/results/MonitoringDashboardPage.vue
@@ -319,10 +319,10 @@ async function initializeOnlineElectionListener() {
   }
 }
 
-async function teardownOnlineElectionListener() {
-  // Only drop this page's handler. Group membership is owned by
-  // electionStore.setActiveElectionHub (joinElection joins FrontDesk too).
-  try {
+  // Only drop this page's handler. This page joins the FrontDesk election group
+  // so it can receive updateOnlineElection events; we intentionally do not leave
+  // the group here because the FrontDesk connection/group membership may be
+  // shared with other parts of the app in the same tab.
     if (frontDeskConnection && onlineElectionHandler) {
       frontDeskConnection.off("updateOnlineElection", onlineElectionHandler);
     }

--- a/frontend/src/services/signalrService.ts
+++ b/frontend/src/services/signalrService.ts
@@ -188,6 +188,8 @@ class SignalRService {
 
     const frontDeskConnection = this.getConnection("/hubs/front-desk");
     if (frontDeskConnection) {
+      // Track for auto-rejoin after reconnect (same as joinFrontDeskElection).
+      this.frontDeskElectionGuid = electionGuid;
       await frontDeskConnection.invoke("JoinElection", electionGuid);
     }
 
@@ -201,6 +203,9 @@ class SignalRService {
   async leaveElection(electionGuid: string): Promise<void> {
     if (this.mainElectionGuid === electionGuid) {
       this.mainElectionGuid = null;
+    }
+    if (this.frontDeskElectionGuid === electionGuid) {
+      this.frontDeskElectionGuid = null;
     }
 
     const mainConnection = this.getConnection("/hubs/main");

--- a/frontend/src/stores/ballotStore.ts
+++ b/frontend/src/stores/ballotStore.ts
@@ -483,7 +483,8 @@ export const useBallotStore = defineStore("ballot", () => {
       });
 
       connection.on("reloadPage", () => {
-        console.log("Server requested page reload for ballots");
+        // Soft re-fetch after bulk ballot import (prefer over location.reload).
+        void handleReloadPage();
       });
 
       signalrInitialized.value = true;
@@ -523,6 +524,18 @@ export const useBallotStore = defineStore("ballot", () => {
 
     if (currentBallot.value?.ballotGuid === data.ballotGuid) {
       currentBallot.value = null;
+    }
+  }
+
+  async function handleReloadPage() {
+    const guid = activeElectionGuid.value;
+    if (!guid) {
+      return;
+    }
+    try {
+      await fetchBallots(guid);
+    } catch (e) {
+      console.error("Failed to re-fetch ballots after reloadPage:", e);
     }
   }
 

--- a/frontend/src/stores/electionStore.test.ts
+++ b/frontend/src/stores/electionStore.test.ts
@@ -25,6 +25,7 @@ vi.mock("../services/electionService", () => ({
 vi.mock("../services/signalrService", () => ({
   signalrService: {
     connectToMainHub: vi.fn(),
+    connectToFrontDeskHub: vi.fn(),
     joinElection: vi.fn(),
     leaveElection: vi.fn(),
   },
@@ -325,23 +326,38 @@ describe("Election Store", () => {
   });
 
   describe("initializeSignalR", () => {
+    function mockHubConnections(signalrService: {
+      connectToMainHub: ReturnType<typeof vi.fn>;
+      connectToFrontDeskHub: ReturnType<typeof vi.fn>;
+    }) {
+      const mainConnection = { on: vi.fn() };
+      const frontDeskConnection = { on: vi.fn() };
+      signalrService.connectToMainHub.mockResolvedValue(mainConnection);
+      signalrService.connectToFrontDeskHub.mockResolvedValue(
+        frontDeskConnection,
+      );
+      return { mainConnection, frontDeskConnection };
+    }
+
     it("should initialize SignalR connection and set up event handlers", async () => {
       const { signalrService } = await import("../services/signalrService");
-      const mockConnection = {
-        on: vi.fn(),
-      };
-
-      signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+      const { mainConnection, frontDeskConnection } =
+        mockHubConnections(signalrService);
 
       await electionStore.initializeSignalR();
 
       expect(signalrService.connectToMainHub).toHaveBeenCalled();
-      expect(mockConnection.on).toHaveBeenCalledWith(
+      expect(signalrService.connectToFrontDeskHub).toHaveBeenCalled();
+      expect(mainConnection.on).toHaveBeenCalledWith(
         "statusChanged",
         expect.any(Function),
       );
-      expect(mockConnection.on).toHaveBeenCalledWith(
+      expect(mainConnection.on).toHaveBeenCalledWith(
         "electionClosed",
+        expect.any(Function),
+      );
+      expect(frontDeskConnection.on).toHaveBeenCalledWith(
+        "updateOnlineElection",
         expect.any(Function),
       );
     });
@@ -365,6 +381,46 @@ describe("Election Store", () => {
       consoleSpy.mockRestore();
     });
 
+    it("updateOnlineElection patches current election online window fields", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const frontDeskConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      signalrService.connectToMainHub.mockResolvedValue({ on: vi.fn() });
+      signalrService.connectToFrontDeskHub.mockResolvedValue(
+        frontDeskConnection,
+      );
+
+      electionStore.currentElection = {
+        electionGuid: "election-1",
+        name: "Test",
+        electionStage: "GatheringBallots",
+        onlineWhenOpen: "2026-01-01T00:00:00Z",
+        onlineWhenClose: "2026-01-02T00:00:00Z",
+      } as ElectionDto;
+
+      await electionStore.initializeSignalR();
+      handlers.get("updateOnlineElection")!({
+        electionGuid: "election-1",
+        onlineWhenOpen: "2026-04-01T12:00:00Z",
+        onlineWhenClose: "2026-04-02T12:00:00Z",
+        onlineCloseIsEstimate: false,
+        onlineSelectionProcess: "B",
+      });
+
+      expect(electionStore.currentElection?.onlineWhenOpen).toBe(
+        "2026-04-01T12:00:00Z",
+      );
+      expect(electionStore.currentElection?.onlineWhenClose).toBe(
+        "2026-04-02T12:00:00Z",
+      );
+      expect(electionStore.currentElection?.onlineCloseIsEstimate).toBe(false);
+      expect(electionStore.currentElection?.onlineSelectionProcess).toBe("B");
+    });
+
     it("statusChanged notifies once with i18n stage label when list and current both match", async () => {
       const { signalrService } = await import("../services/signalrService");
       const handlers = new Map<string, (data: unknown) => void>();
@@ -374,6 +430,7 @@ describe("Election Store", () => {
         }),
       };
       signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
 
       electionStore.elections = [
         {
@@ -421,6 +478,7 @@ describe("Election Store", () => {
         }),
       };
       signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
 
       electionStore.elections = [
         {
@@ -601,6 +659,7 @@ describe("Election Store", () => {
     it("stores the election guid and joins the main hub", async () => {
       const { signalrService } = await import("../services/signalrService");
       signalrService.connectToMainHub.mockResolvedValue({ on: vi.fn() });
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
       signalrService.joinElection.mockResolvedValue("A");
 
       await electionStore.setActiveElectionHub("1");
@@ -612,6 +671,7 @@ describe("Election Store", () => {
     it("leaves the previous election before joining a new one", async () => {
       const { signalrService } = await import("../services/signalrService");
       signalrService.connectToMainHub.mockResolvedValue({ on: vi.fn() });
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
       signalrService.joinElection.mockResolvedValue("A");
       setActiveElectionHubGuid("1");
 

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -11,7 +11,10 @@ import type {
   ElectionDto,
   UpdateElectionDto,
 } from "../types";
-import type { ElectionUpdateEvent } from "../types/SignalREvents";
+import type {
+  ElectionUpdateEvent,
+  OnlineElectionUpdateEvent,
+} from "../types/SignalREvents";
 import { setComputerCode } from "../utils/computerCodeStorage";
 import { extractApiErrorMessage } from "../utils/errorHandler";
 import {
@@ -161,6 +164,9 @@ export const useElectionStore = defineStore("election", () => {
 
     try {
       const connection = await signalrService.connectToMainHub();
+      // FrontDesk join path only runs when this hub is already connected
+      // (signalrService.joinElection); monitor needs updateOnlineElection.
+      const frontDeskConnection = await signalrService.connectToFrontDeskHub();
 
       connection.on("statusChanged", (data: any) => {
         if (data && typeof data === "object") {
@@ -188,9 +194,52 @@ export const useElectionStore = defineStore("election", () => {
         handleElectionUpdate(updateEvent);
       });
 
+      frontDeskConnection.on("updateOnlineElection", (data: any) => {
+        if (data && typeof data === "object") {
+          const updateEvent: OnlineElectionUpdateEvent = {
+            electionGuid: data.electionGuid || "",
+            onlineWhenOpen: data.onlineWhenOpen ?? null,
+            onlineWhenClose: data.onlineWhenClose ?? null,
+            onlineCloseIsEstimate: data.onlineCloseIsEstimate,
+            onlineSelectionProcess: data.onlineSelectionProcess ?? null,
+          };
+          handleOnlineElectionUpdate(updateEvent);
+        }
+      });
+
       signalrInitialized.value = true;
     } catch (e) {
       console.error("Failed to initialize SignalR for election store:", e);
+    }
+  }
+
+  function handleOnlineElectionUpdate(data: OnlineElectionUpdateEvent) {
+    if (!data.electionGuid) {
+      return;
+    }
+
+    const patch = {
+      onlineWhenOpen: data.onlineWhenOpen ?? undefined,
+      onlineWhenClose: data.onlineWhenClose ?? undefined,
+      onlineCloseIsEstimate: data.onlineCloseIsEstimate,
+      onlineSelectionProcess: data.onlineSelectionProcess ?? undefined,
+    };
+
+    if (currentElection.value?.electionGuid === data.electionGuid) {
+      currentElection.value = {
+        ...currentElection.value,
+        ...patch,
+      };
+    }
+
+    const index = elections.value.findIndex(
+      (e) => e.electionGuid === data.electionGuid,
+    );
+    if (index !== -1) {
+      elections.value[index] = {
+        ...elections.value[index],
+        ...patch,
+      };
     }
   }
 

--- a/frontend/src/stores/peopleStore.test.ts
+++ b/frontend/src/stores/peopleStore.test.ts
@@ -436,5 +436,69 @@ describe("People Store - People Cache", () => {
 
       expect(store.peopleCache).toHaveLength(0);
     });
+
+    it("reloadPage soft re-fetches lists and rebuilds ballot cache", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, () => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: () => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      vi.mocked(signalrService.connectToFrontDeskHub).mockResolvedValue(
+        mockConnection as never,
+      );
+
+      const refreshedList = [
+        {
+          personGuid: mockPerson.personGuid,
+          firstName: mockPerson.firstName,
+          lastName: mockPerson.lastName,
+          fullName: mockPerson.fullName,
+          canVote: true,
+          canReceiveVotes: true,
+        },
+      ];
+      const refreshedBallotEntry = [
+        {
+          ...mockPerson,
+          voteCount: 2,
+        },
+        mockPerson2,
+      ];
+      vi.mocked(peopleService.getAllPeople).mockResolvedValue(
+        refreshedList as never,
+      );
+      vi.mocked(peopleService.getAll).mockResolvedValue([mockPerson]);
+      vi.mocked(peopleService.getAllForBallotEntry).mockResolvedValue(
+        refreshedBallotEntry as never,
+      );
+
+      // activeElectionGuid is set by list fetches; seed via fetchPeopleList.
+      await store.fetchPeopleList("election-123");
+      store.isCacheInitialized = true;
+      store.peopleCache = [store.enrichPersonForSearch(mockPerson)];
+
+      await store.initializeSignalR();
+      expect(handlers.has("reloadPage")).toBe(true);
+
+      handlers.get("reloadPage")!();
+
+      await vi.waitFor(() => {
+        expect(peopleService.getAllPeople).toHaveBeenCalledWith("election-123");
+        expect(peopleService.getAll).toHaveBeenCalledWith("election-123");
+        expect(peopleService.getAllForBallotEntry).toHaveBeenCalledWith(
+          "election-123",
+        );
+      });
+
+      // Cache rebuilt from ballot-entry payload (not left with stale pre-import data).
+      expect(store.isCacheInitialized).toBe(true);
+      expect(store.peopleCache).toHaveLength(2);
+      expect(store.peopleCache.map((p) => p.personGuid)).toEqual([
+        mockPerson.personGuid,
+        mockPerson2.personGuid,
+      ]);
+    });
   });
 });

--- a/frontend/src/stores/peopleStore.ts
+++ b/frontend/src/stores/peopleStore.ts
@@ -304,8 +304,8 @@ export const usePeopleStore = defineStore("people", () => {
       });
 
       connection.on("reloadPage", () => {
-        // Thin signal from server (e.g. post-import); full client reload.
-        window.location.reload();
+        // Thin post-import (or bulk) signal: soft re-fetch instead of full page reload.
+        void handleReloadPage();
       });
 
       connection.on(
@@ -393,6 +393,23 @@ export const usePeopleStore = defineStore("people", () => {
       peopleCache.value = peopleCache.value.filter(
         (p) => p.personGuid !== data.personGuid,
       );
+    }
+  }
+
+  async function handleReloadPage() {
+    const guid = activeElectionGuid.value;
+    if (!guid) {
+      return;
+    }
+    try {
+      await Promise.all([fetchPeopleList(guid), fetchPeople(guid)]);
+      if (isCacheInitialized.value) {
+        // Force cache rebuild so ballot-entry search matches post-import state.
+        isCacheInitialized.value = false;
+        await initializePeopleCache(guid);
+      }
+    } catch (e) {
+      console.error("Failed to re-fetch people after reloadPage:", e);
     }
   }
 

--- a/frontend/src/types/SignalREvents.ts
+++ b/frontend/src/types/SignalREvents.ts
@@ -7,6 +7,15 @@ export interface ElectionUpdateEvent {
   updatedAt: string;
 }
 
+/** FrontDeskHub updateOnlineElection — online window / process thin payload. */
+export interface OnlineElectionUpdateEvent {
+  electionGuid: string;
+  onlineWhenOpen?: string | null;
+  onlineWhenClose?: string | null;
+  onlineCloseIsEstimate?: boolean;
+  onlineSelectionProcess?: string | null;
+}
+
 export interface TallyProgressEvent {
   electionGuid: string;
   totalBallots: number;


### PR DESCRIPTION
## Summary
- Wire FrontDeskHub server producers for `updateOnlineElection` (when online open/close/process settings change) and `reloadPage` after bulk changes that affect open operator screens.
- **Ballot import** (CSV + CDN) and **people import** (CSV/XLSX) + **delete-all-people** call `RequestFrontDeskReloadAsync` so open Front Desk / people / ballot-entry sessions soft re-fetch instead of a full browser reload.
- Frontend soft re-fetches on `reloadPage`; monitor and election store handle `updateOnlineElection`.
- Unit tests for notification fan-out, election online-window push, people import reload, and peopleStore `reloadPage` soft re-fetch; docs/context catalog updated.

## Why people import
Single-person CRUD already pushed `PersonAdded`/`PersonUpdated`/`PersonDeleted`. Bulk people import only notified PeopleImportHub, so a second browser on Front Desk mid-search did not see new names. Same `reloadPage` path as ballot import fixes that without flooding the hub with per-row events.

## Test plan
- [x] Change online open/close times; monitor updates without manual refresh
- [x] People import CSV with Front Desk open on another client; search list refreshes to include new names
- [ ] CSV ballot import with front desk / people / ballot entry open; soft re-fetch
- [ ] CDN ballot import; same FrontDesk reload behavior
- [ ] Unrelated election edit (name only) does not fire `updateOnlineElection`
- [x] `dotnet test --filter FullyQualifiedName~PeopleImportServiceTests|SignalRNotificationServiceTests|ElectionServiceTests.UpdateElectionAsync`
- [x] `cd frontend && npm run test:run -- src/stores/electionStore.test.ts src/stores/peopleStore.test.ts`

Closes #228