### PR TITLE
Align import SignalR event names via notification service (#226)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,8 @@ Group name patterns (constructed via `GetGroupName` statics in each hub + used f
 - `Main{electionGuid}` — MainHub (election updates, statusChanged, electionClosed). Also creates `Main{ guid }Known` / `Main{ guid }Guest` variants.
 - `Analyze{electionGuid}` — AnalyzeHub (tallyProgress / tallyComplete).
 - `FrontDesk{electionGuid}` — FrontDeskHub (PersonAdded/Updated/Deleted, PersonCheckedIn, PersonFlagsUpdated, VoterCountUpdated, PersonVoteCountUpdated, updateBallots, reloadPage, updateOnlineElection). See `context/realtime.md`.
-- `BallotImport{electionGuid}` — BallotImportHub (importProgress, importError, importComplete).
-- `PeopleImport{electionGuid}` — PeopleImportHub (same import events).
+- `BallotImport{electionGuid}` — BallotImportHub (importProgress, importError, importComplete; camelCase; via SignalRNotificationService).
+- `PeopleImport{electionGuid}` — PeopleImportHub (same event names; progress payload `{ processed, total, status }`).
 - `Public` (static group) — PublicHub for guest-teller joinable elections list updates.
 
 **Frontend side**: `src/services/signalrService.ts` provides `connectToMainHub()`, `connectToAnalyzeHub()`, `connectToFrontDeskHub()`, etc. + `joinElection(guid)`, `joinTallySession(guid)`, etc. Stores (electionStore, ballotStore, peopleStore, etc.) call these and wire `connection.on("eventName", handler)`.

--- a/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
@@ -1,13 +1,11 @@
 using System.Text;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Backend.Entities;
 using Backend.DTOs.Import;
 using Backend.Services;
 using Backend.Enumerations;
-using Backend.Hubs;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Tests.UnitTests.Services;
@@ -15,16 +13,14 @@ namespace Backend.Tests.UnitTests.Services;
 public class PeopleImportServiceTests : ServiceTestBase
 {
     private readonly PeopleImportService _service;
-    private readonly Mock<IHubContext<PeopleImportHub>> _hubContextMock;
     private readonly Mock<ISignalRNotificationService> _signalRMock;
     private readonly Mock<ILogger<PeopleImportService>> _loggerMock;
 
     public PeopleImportServiceTests()
     {
-        _hubContextMock = new Mock<IHubContext<PeopleImportHub>>();
         _signalRMock = new Mock<ISignalRNotificationService>();
         _loggerMock = new Mock<ILogger<PeopleImportService>>();
-        _service = new PeopleImportService(Context, _hubContextMock.Object, _signalRMock.Object);
+        _service = new PeopleImportService(Context, _signalRMock.Object);
     }
 
     [Fact]
@@ -362,12 +358,6 @@ public class PeopleImportServiceTests : ServiceTestBase
         Context.ImportFiles.Add(importFile);
         await Context.SaveChangesAsync();
 
-        // Setup SignalR mock
-        var mockClients = new Mock<IHubClients>();
-        var mockClientProxy = new Mock<IClientProxy>();
-        _hubContextMock.Setup(h => h.Clients).Returns(mockClients.Object);
-        mockClients.Setup(c => c.Group(It.IsAny<string>())).Returns(mockClientProxy.Object);
-
         // Act
         var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
 
@@ -382,7 +372,10 @@ public class PeopleImportServiceTests : ServiceTestBase
         Assert.Contains(people, p => p.FirstName == "John" && p.LastName == "Doe");
         Assert.Contains(people, p => p.FirstName == "Jane" && p.LastName == "Smith");
 
-        // Front desk (and related open screens) soft-refresh after bulk people import.
+        // Import complete + front desk soft-refresh after bulk people import.
+        _signalRMock.Verify(
+            s => s.SendPeopleImportCompleteAsync(electionGuid, It.IsAny<object>()),
+            Times.Once);
         _signalRMock.Verify(
             s => s.RequestFrontDeskReloadAsync(electionGuid),
             Times.Once);
@@ -413,12 +406,6 @@ public class PeopleImportServiceTests : ServiceTestBase
         };
         Context.ImportFiles.Add(importFile);
         await Context.SaveChangesAsync();
-
-        // Setup SignalR mock
-        var mockClients = new Mock<IHubClients>();
-        var mockClientProxy = new Mock<IClientProxy>();
-        _hubContextMock.Setup(h => h.Clients).Returns(mockClients.Object);
-        mockClients.Setup(c => c.Group(It.IsAny<string>())).Returns(mockClientProxy.Object);
 
         // Act
         var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
@@ -458,12 +445,6 @@ public class PeopleImportServiceTests : ServiceTestBase
         };
         Context.ImportFiles.Add(importFile);
         await Context.SaveChangesAsync();
-
-        // Setup SignalR mock
-        var mockClients = new Mock<IHubClients>();
-        var mockClientProxy = new Mock<IClientProxy>();
-        _hubContextMock.Setup(h => h.Clients).Returns(mockClients.Object);
-        mockClients.Setup(c => c.Group(It.IsAny<string>())).Returns(mockClientProxy.Object);
 
         // Act
         var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);

--- a/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
@@ -21,15 +21,20 @@ public class SignalRNotificationServiceTests
         SignalRNotificationService Service,
         Mock<IHubClients> MainClients,
         Mock<IHubClients> FrontDeskClients,
+        Mock<IHubClients> BallotImportClients,
+        Mock<IHubClients> PeopleImportClients,
         Dictionary<string, Mock<IClientProxy>> GroupProxies) CreateService()
     {
         var mainHub = new Mock<IHubContext<MainHub>>();
         var analyzeHub = new Mock<IHubContext<AnalyzeHub>>();
         var ballotImportHub = new Mock<IHubContext<BallotImportHub>>();
+        var peopleImportHub = new Mock<IHubContext<PeopleImportHub>>();
         var frontDeskHub = new Mock<IHubContext<FrontDeskHub>>();
         var publicHub = new Mock<IHubContext<PublicHub>>();
         var mainClients = new Mock<IHubClients>();
         var frontDeskClients = new Mock<IHubClients>();
+        var ballotImportClients = new Mock<IHubClients>();
+        var peopleImportClients = new Mock<IHubClients>();
         var groupProxies = new Dictionary<string, Mock<IClientProxy>>();
 
         Mock<IClientProxy> GetOrCreateProxy(string groupName)
@@ -51,10 +56,18 @@ public class SignalRNotificationServiceTests
 
         mainHub.Setup(h => h.Clients).Returns(mainClients.Object);
         frontDeskHub.Setup(h => h.Clients).Returns(frontDeskClients.Object);
+        ballotImportHub.Setup(h => h.Clients).Returns(ballotImportClients.Object);
+        peopleImportHub.Setup(h => h.Clients).Returns(peopleImportClients.Object);
         mainClients
             .Setup(c => c.Group(It.IsAny<string>()))
             .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
         frontDeskClients
+            .Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
+        ballotImportClients
+            .Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
+        peopleImportClients
             .Setup(c => c.Group(It.IsAny<string>()))
             .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
 
@@ -62,17 +75,18 @@ public class SignalRNotificationServiceTests
             mainHub.Object,
             analyzeHub.Object,
             ballotImportHub.Object,
+            peopleImportHub.Object,
             frontDeskHub.Object,
             publicHub.Object,
             NullLogger<SignalRNotificationService>.Instance);
 
-        return (service, mainClients, frontDeskClients, groupProxies);
+        return (service, mainClients, frontDeskClients, ballotImportClients, peopleImportClients, groupProxies);
     }
 
     [Fact]
     public async Task SendElectionUpdateAsync_sends_statusChanged_to_base_Main_group()
     {
-        var (service, mainClients, _, groupProxies) = CreateService();
+        var (service, mainClients, _, _, _, groupProxies) = CreateService();
         var update = new ElectionUpdateDto
         {
             ElectionGuid = _electionGuid,
@@ -110,7 +124,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task CloseOutGuestTellersAsync_sends_electionClosed_to_Guest_group_only()
     {
-        var (service, mainClients, _, groupProxies) = CreateService();
+        var (service, mainClients, _, _, _, groupProxies) = CreateService();
         var baseGroup = MainHub.GetGroupName(_electionGuid);
         var guestGroup = baseGroup + "Guest";
 
@@ -138,7 +152,7 @@ public class SignalRNotificationServiceTests
         string action,
         string expectedEvent)
     {
-        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, groupProxies) = CreateService();
         var personGuid = Guid.Parse("33333333-3333-3333-3333-333333333333");
         var update = new PersonUpdateDto
         {
@@ -175,7 +189,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task NotifyVoterCountUpdatedAsync_sends_VoterCountUpdated_to_FrontDesk_group()
     {
-        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, groupProxies) = CreateService();
         var stats = new FrontDeskStatsDto
         {
             TotalEligible = 100,
@@ -209,7 +223,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task SendOnlineElectionUpdateAsync_sends_updateOnlineElection_to_FrontDesk_group()
     {
-        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, groupProxies) = CreateService();
         var open = DateTimeOffset.Parse("2026-04-01T12:00:00Z");
         var close = DateTimeOffset.Parse("2026-04-02T12:00:00Z");
         var update = new OnlineElectionUpdateDto
@@ -249,7 +263,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task RequestFrontDeskReloadAsync_sends_reloadPage_to_FrontDesk_group()
     {
-        var (service, _, frontDeskClients, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, groupProxies) = CreateService();
         var expectedGroup = FrontDeskHub.GetGroupName(_electionGuid);
 
         await service.RequestFrontDeskReloadAsync(_electionGuid);
@@ -262,5 +276,127 @@ public class SignalRNotificationServiceTests
                 It.IsAny<object?[]>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task SendImportProgressAsync_sends_camelCase_importProgress_to_BallotImport_group()
+    {
+        var (service, _, _, ballotImportClients, _, groupProxies) = CreateService();
+        var progress = new ImportProgressDto
+        {
+            ElectionGuid = _electionGuid,
+            TotalRows = 10,
+            ProcessedRows = 4,
+            SuccessCount = 3,
+            ErrorCount = 1,
+            CurrentStatus = "Processing",
+            PercentComplete = 40,
+            IsComplete = false
+        };
+        var expectedGroup = BallotImportHub.GetGroupName(_electionGuid);
+
+        await service.SendImportProgressAsync(progress);
+
+        ballotImportClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "importProgress",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Must not use PascalCase names that miss SPA listeners
+        proxy.Verify(
+            p => p.SendCoreAsync(
+                "ImportProgress",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "importProgress"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Single(capturedArgs);
+        var dto = Assert.IsType<ImportProgressDto>(capturedArgs[0]);
+        Assert.Equal(4, dto.ProcessedRows);
+        Assert.Equal(10, dto.TotalRows);
+    }
+
+    [Fact]
+    public async Task SendImportCompleteAsync_sends_camelCase_importComplete_to_BallotImport_group()
+    {
+        var (service, _, _, ballotImportClients, _, groupProxies) = CreateService();
+        var expectedGroup = BallotImportHub.GetGroupName(_electionGuid);
+        var summary = new { ballotsCreated = 5 };
+
+        await service.SendImportCompleteAsync(_electionGuid, summary);
+
+        ballotImportClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "importComplete",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        proxy.Verify(
+            p => p.SendCoreAsync(
+                "ImportComplete",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SendImportErrorAsync_sends_importError_with_message_and_row()
+    {
+        var (service, _, _, ballotImportClients, _, groupProxies) = CreateService();
+        var expectedGroup = BallotImportHub.GetGroupName(_electionGuid);
+
+        await service.SendImportErrorAsync(_electionGuid, "bad row", 12);
+
+        ballotImportClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        var invocation = proxy!.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "importError"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Equal(2, capturedArgs.Length);
+        Assert.Equal("bad row", capturedArgs[0]);
+        Assert.Equal(12, capturedArgs[1]);
+    }
+
+    [Fact]
+    public async Task SendPeopleImportProgressAsync_sends_object_payload_to_PeopleImport_group()
+    {
+        var (service, _, _, _, peopleImportClients, groupProxies) = CreateService();
+        var expectedGroup = PeopleImportHub.GetGroupName(_electionGuid);
+
+        await service.SendPeopleImportProgressAsync(_electionGuid, 3, 10, "Processing row 3");
+
+        peopleImportClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "importProgress",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "importProgress"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Single(capturedArgs);
+        // Anonymous object: verify via reflection / dynamic
+        var payload = capturedArgs[0]!;
+        var processed = payload.GetType().GetProperty("processed")!.GetValue(payload);
+        var total = payload.GetType().GetProperty("total")!.GetValue(payload);
+        var status = payload.GetType().GetProperty("status")!.GetValue(payload);
+        Assert.Equal(3, processed);
+        Assert.Equal(10, total);
+        Assert.Equal("Processing row 3", status);
     }
 }

--- a/backend/Hubs/BallotImportHub.cs
+++ b/backend/Hubs/BallotImportHub.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Backend.Hubs;
 
 /// <summary>
 /// SignalR hub for real-time communication during ballot import operations.
-/// Provides progress updates, error notifications, and completion status for bulk ballot imports.
+/// Clients join/leave import sessions; server pushes progress via
+/// <see cref="Backend.Services.ISignalRNotificationService"/> / <c>IHubContext&lt;BallotImportHub&gt;</c>.
 /// </summary>
 [Authorize]
 public class BallotImportHub : Hub
@@ -47,62 +48,6 @@ public class BallotImportHub : Hub
             Context.ConnectionId, electionGuid);
     }
 
-    // Server-to-client methods for ballot import progress
-    /// <summary>
-    /// Broadcasts progress information about the ongoing ballot import operation.
-    /// Includes counts of processed rows and calculated percentage completion.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where ballots are being imported.</param>
-    /// <param name="processedRows">The number of rows that have been processed so far.</param>
-    /// <param name="totalRows">The total number of rows to be imported.</param>
-    /// <param name="status">A descriptive status message about the current import phase.</param>
-    public async Task ImportProgress(Guid electionGuid, int processedRows, int totalRows, string status)
-    {
-        var groupName = GetGroupName(electionGuid);
-        var progress = new
-        {
-            processedRows,
-            totalRows,
-            status,
-            percentage = totalRows > 0 ? (processedRows * 100.0 / totalRows) : 0
-        };
-
-        await Clients.Group(groupName).SendAsync("importProgress", progress);
-
-        _logger.LogInformation("Ballot import progress for election {ElectionGuid}: {Processed}/{Total} rows - {Status}",
-            electionGuid, processedRows, totalRows, status);
-    }
-
-    /// <summary>
-    /// Broadcasts an error that occurred during ballot import to all monitoring clients.
-    /// Includes the error message and the row number where the error occurred.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where the import error occurred.</param>
-    /// <param name="errorMessage">A description of the error that occurred during import.</param>
-    /// <param name="rowNumber">The row number in the import file where the error occurred.</param>
-    public async Task ImportError(Guid electionGuid, string errorMessage, int rowNumber)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("importError", errorMessage, rowNumber);
-
-        _logger.LogWarning("Ballot import error for election {ElectionGuid} at row {RowNumber}: {Error}",
-            electionGuid, rowNumber, errorMessage);
-    }
-
-    /// <summary>
-    /// Broadcasts the completion of the ballot import operation to all monitoring clients.
-    /// Includes a summary of the import results and statistics.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where the import was completed.</param>
-    /// <param name="summary">A summary object containing import statistics and results.</param>
-    public async Task ImportComplete(Guid electionGuid, object summary)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("importComplete", summary);
-
-        _logger.LogInformation("Ballot import completed for election {ElectionGuid}", electionGuid);
-    }
-
     /// <summary>
     /// Called when a client disconnects from the BallotImportHub.
     /// Logs the disconnection event for monitoring purposes.
@@ -115,8 +60,8 @@ public class BallotImportHub : Hub
         await base.OnDisconnectedAsync(exception);
     }
 
-    private static string GetGroupName(Guid electionGuid) => $"BallotImport{electionGuid}";
+    /// <summary>
+    /// Group name for ballot import progress for an election.
+    /// </summary>
+    public static string GetGroupName(Guid electionGuid) => $"BallotImport{electionGuid}";
 }
-
-
-

--- a/backend/Hubs/PeopleImportHub.cs
+++ b/backend/Hubs/PeopleImportHub.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Backend.Hubs;
 
 /// <summary>
 /// SignalR hub for real-time communication during people import operations.
-/// Provides progress updates, error notifications, and completion status for bulk people imports.
+/// Clients join/leave import sessions; server pushes progress via
+/// <see cref="Backend.Services.ISignalRNotificationService"/> / <c>IHubContext&lt;PeopleImportHub&gt;</c>.
 /// </summary>
 [Authorize]
 public class PeopleImportHub : Hub
@@ -47,62 +48,6 @@ public class PeopleImportHub : Hub
             Context.ConnectionId, electionGuid);
     }
 
-    // Server-to-client methods for people import progress
-    /// <summary>
-    /// Broadcasts progress information about the ongoing people import operation.
-    /// Includes counts of processed rows and calculated percentage completion.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where people are being imported.</param>
-    /// <param name="processedRows">The number of rows that have been processed so far.</param>
-    /// <param name="totalRows">The total number of rows to be imported.</param>
-    /// <param name="status">A descriptive status message about the current import phase.</param>
-    public async Task ImportProgress(Guid electionGuid, int processedRows, int totalRows, string status)
-    {
-        var groupName = GetGroupName(electionGuid);
-        var progress = new
-        {
-            processedRows,
-            totalRows,
-            status,
-            percentage = totalRows > 0 ? (processedRows * 100.0 / totalRows) : 0
-        };
-
-        await Clients.Group(groupName).SendAsync("importProgress", progress);
-
-        _logger.LogInformation("People import progress for election {ElectionGuid}: {Processed}/{Total} rows - {Status}",
-            electionGuid, processedRows, totalRows, status);
-    }
-
-    /// <summary>
-    /// Broadcasts an error that occurred during people import to all monitoring clients.
-    /// Includes the error message and the row number where the error occurred.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where the import error occurred.</param>
-    /// <param name="errorMessage">A description of the error that occurred during import.</param>
-    /// <param name="rowNumber">The row number in the import file where the error occurred.</param>
-    public async Task ImportError(Guid electionGuid, string errorMessage, int rowNumber)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("importError", errorMessage, rowNumber);
-
-        _logger.LogWarning("People import error for election {ElectionGuid} at row {RowNumber}: {Error}",
-            electionGuid, rowNumber, errorMessage);
-    }
-
-    /// <summary>
-    /// Broadcasts the completion of the people import operation to all monitoring clients.
-    /// Includes a summary of the import results and statistics.
-    /// </summary>
-    /// <param name="electionGuid">The unique identifier of the election where the import was completed.</param>
-    /// <param name="summary">A summary object containing import statistics and results.</param>
-    public async Task ImportComplete(Guid electionGuid, object summary)
-    {
-        var groupName = GetGroupName(electionGuid);
-        await Clients.Group(groupName).SendAsync("importComplete", summary);
-
-        _logger.LogInformation("People import completed for election {ElectionGuid}", electionGuid);
-    }
-
     /// <summary>
     /// Called when a client disconnects from the PeopleImportHub.
     /// Logs the disconnection event for monitoring purposes.
@@ -115,5 +60,8 @@ public class PeopleImportHub : Hub
         await base.OnDisconnectedAsync(exception);
     }
 
-    private static string GetGroupName(Guid electionGuid) => $"PeopleImport{electionGuid}";
+    /// <summary>
+    /// Group name for people import progress for an election.
+    /// </summary>
+    public static string GetGroupName(Guid electionGuid) => $"PeopleImport{electionGuid}";
 }

--- a/backend/Services/ISignalRNotificationService.cs
+++ b/backend/Services/ISignalRNotificationService.cs
@@ -23,10 +23,41 @@ public interface ISignalRNotificationService
     Task SendTallyProgressAsync(TallyProgressDto progress);
 
     /// <summary>
-    /// Sends ballot import progress updates to monitoring clients.
+    /// Sends ballot import progress to BallotImportHub clients (event <c>importProgress</c>).
     /// </summary>
     /// <param name="progress">The import progress information to broadcast.</param>
     Task SendImportProgressAsync(ImportProgressDto progress);
+
+    /// <summary>
+    /// Sends a ballot import row/fatal error to BallotImportHub clients (event <c>importError</c>).
+    /// </summary>
+    /// <param name="electionGuid">Election whose import session to notify.</param>
+    /// <param name="errorMessage">Error description.</param>
+    /// <param name="rowNumber">Source row number (0 when not row-specific).</param>
+    Task SendImportErrorAsync(Guid electionGuid, string errorMessage, int rowNumber);
+
+    /// <summary>
+    /// Sends ballot import completion to BallotImportHub clients (event <c>importComplete</c>).
+    /// </summary>
+    /// <param name="electionGuid">Election whose import session to notify.</param>
+    /// <param name="summary">Import summary payload for the SPA.</param>
+    Task SendImportCompleteAsync(Guid electionGuid, object summary);
+
+    /// <summary>
+    /// Sends people import progress to PeopleImportHub clients (event <c>importProgress</c>).
+    /// Payload shape: <c>{ processed, total, status }</c> (matches SPA PeopleImportProgressEvent).
+    /// </summary>
+    Task SendPeopleImportProgressAsync(Guid electionGuid, int processed, int total, string status);
+
+    /// <summary>
+    /// Sends a people import error to PeopleImportHub clients (event <c>importError</c>).
+    /// </summary>
+    Task SendPeopleImportErrorAsync(Guid electionGuid, string errorMessage, int rowNumber = 0);
+
+    /// <summary>
+    /// Sends people import completion to PeopleImportHub clients (event <c>importComplete</c>).
+    /// </summary>
+    Task SendPeopleImportCompleteAsync(Guid electionGuid, object summary);
 
     /// <summary>
     /// Sends person/voter update notifications to relevant clients.

--- a/backend/Services/ImportService.cs
+++ b/backend/Services/ImportService.cs
@@ -2,8 +2,7 @@ using Backend.Context;
 using Backend.Entities;
 using Backend.Enumerations;
 using Backend.DTOs.Import;
-using Backend.Hubs;
-using Microsoft.AspNetCore.SignalR;
+using Backend.DTOs.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Services;
@@ -14,22 +13,18 @@ namespace Backend.Services;
 public class ImportService
 {
     private readonly MainDbContext _context;
-    private readonly IHubContext<BallotImportHub> _hubContext;
     private readonly ISignalRNotificationService _signalRNotificationService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ImportService"/> class.
     /// </summary>
     /// <param name="context">The database context.</param>
-    /// <param name="hubContext">The SignalR hub context for ballot import notifications.</param>
-    /// <param name="signalRNotificationService">Broadcasts post-import refresh to FrontDesk clients.</param>
+    /// <param name="signalRNotificationService">Import progress and FrontDesk reload broadcasts.</param>
     public ImportService(
         MainDbContext context,
-        IHubContext<BallotImportHub> hubContext,
         ISignalRNotificationService signalRNotificationService)
     {
         _context = context;
-        _hubContext = hubContext;
         _signalRNotificationService = signalRNotificationService;
     }
 
@@ -73,7 +68,7 @@ public class ImportService
     public async Task<ImportResultDto> ImportBallotDataAsync(ImportBallotRequestDto request)
     {
         var result = new ImportResultDto();
-        var groupName = GetGroupName(request.ElectionGuid);
+        var electionGuid = request.ElectionGuid;
 
         try
         {
@@ -139,10 +134,11 @@ public class ImportService
                 int rowNumber = i + 1;
                 var values = ParseCsvLine(lines[i], request.Configuration.Delimiter);
 
-                await ReportProgress(groupName, i - request.Configuration.FirstDataRow + 2, result.TotalRows,
-                    $"Processing row {rowNumber}");
+                var processed = i - request.Configuration.FirstDataRow + 2;
+                await ReportProgress(electionGuid, processed, result);
 
-                if (!ValidateRow(values, ballotCodeIndex, votesIndex, rowNumber, result, request.Configuration.SkipInvalidRows))
+                if (!ValidateRow(values, ballotCodeIndex, votesIndex, rowNumber, result,
+                        request.Configuration.SkipInvalidRows, electionGuid))
                 {
                     result.SkippedRows++;
                     continue;
@@ -156,7 +152,7 @@ public class ImportService
                 if (string.IsNullOrEmpty(ballotCode) || string.IsNullOrEmpty(votesText))
                 {
                     HandleRowError($"Row {rowNumber}: Missing ballot code or votes", result,
-                        request.Configuration.SkipInvalidRows, rowNumber);
+                        request.Configuration.SkipInvalidRows, rowNumber, electionGuid);
                     if (request.Configuration.SkipInvalidRows)
                     {
                         result.SkippedRows++;
@@ -219,7 +215,7 @@ public class ImportService
             await _context.SaveChangesAsync();
             result.Success = true;
 
-            await _hubContext.Clients.Group(groupName).SendAsync("importComplete", new
+            await _signalRNotificationService.SendImportCompleteAsync(electionGuid, new
             {
                 ballotsCreated = result.BallotsCreated,
                 votesCreated = result.VotesCreated,
@@ -234,24 +230,25 @@ public class ImportService
         catch (Exception ex)
         {
             result.Errors.Add($"Ballot Import failed: {ex.Message}");
-            await _hubContext.Clients.Group(groupName).SendAsync("importError", ex.Message, 0);
+            await _signalRNotificationService.SendImportErrorAsync(electionGuid, ex.Message, 0);
         }
 
         return result;
     }
 
     private bool ValidateRow(string[] values, int ballotCodeIndex, int votesIndex, int rowNumber,
-        ImportResultDto result, bool skipInvalidRows)
+        ImportResultDto result, bool skipInvalidRows, Guid electionGuid)
     {
         if (values.Length <= Math.Max(ballotCodeIndex, votesIndex))
         {
-            HandleRowError($"Row {rowNumber}: Insufficient columns", result, skipInvalidRows, rowNumber);
+            HandleRowError($"Row {rowNumber}: Insufficient columns", result, skipInvalidRows, rowNumber, electionGuid);
             return false;
         }
         return true;
     }
 
-    private void HandleRowError(string error, ImportResultDto result, bool skipInvalidRows, int rowNumber)
+    private void HandleRowError(string error, ImportResultDto result, bool skipInvalidRows, int rowNumber,
+        Guid electionGuid)
     {
         if (skipInvalidRows)
         {
@@ -261,12 +258,26 @@ public class ImportService
         {
             result.Errors.Add(error);
         }
-        _ = _hubContext.Clients.Group(GetGroupName(Guid.Empty)).SendAsync("importError", error, rowNumber);
+
+        _ = _signalRNotificationService.SendImportErrorAsync(electionGuid, error, rowNumber);
     }
 
-    private async Task ReportProgress(string groupName, int processed, int total, string status)
+    private async Task ReportProgress(Guid electionGuid, int processed, ImportResultDto result)
     {
-        await _hubContext.Clients.Group(groupName).SendAsync("importProgress", processed, total, status);
+        var total = result.TotalRows;
+        var percent = total > 0 ? (int)(processed * 100.0 / total) : 0;
+        await _signalRNotificationService.SendImportProgressAsync(new ImportProgressDto
+        {
+            ElectionGuid = electionGuid,
+            TotalRows = total,
+            ProcessedRows = processed,
+            SuccessCount = result.BallotsCreated,
+            ErrorCount = result.Errors.Count,
+            CurrentStatus = $"Processing row {processed}",
+            PercentComplete = Math.Clamp(percent, 0, 100),
+            IsComplete = false,
+            Errors = result.Errors.ToList()
+        });
     }
 
     private int GetColumnIndex(string[] headers, string columnName)
@@ -328,9 +339,4 @@ public class ImportService
         result.Add(current);
         return result.ToArray();
     }
-
-    private static string GetGroupName(Guid electionGuid) => $"BallotImport{electionGuid}";
 }
-
-
-

--- a/backend/Services/PeopleImportService.cs
+++ b/backend/Services/PeopleImportService.cs
@@ -10,9 +10,7 @@ using Backend.Entities;
 using Backend.Enumerations;
 using Backend.Helpers;
 using Backend.DTOs.Import;
-using Backend.Hubs;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Services;
@@ -23,7 +21,6 @@ namespace Backend.Services;
 public class PeopleImportService : IPeopleImportService
 {
     private readonly MainDbContext _context;
-    private readonly IHubContext<PeopleImportHub> _hubContext;
     private readonly ISignalRNotificationService _signalRNotificationService;
 
     // Scoring weights for header detection
@@ -50,15 +47,12 @@ public class PeopleImportService : IPeopleImportService
     /// Initializes a new instance of the <see cref="PeopleImportService"/> class.
     /// </summary>
     /// <param name="context">The database context.</param>
-    /// <param name="hubContext">The SignalR hub context for people import notifications.</param>
-    /// <param name="signalRNotificationService">Broadcasts post-import FrontDesk refresh (same as ballot import).</param>
+    /// <param name="signalRNotificationService">Import progress and FrontDesk reload broadcasts.</param>
     public PeopleImportService(
         MainDbContext context,
-        IHubContext<PeopleImportHub> hubContext,
         ISignalRNotificationService signalRNotificationService)
     {
         _context = context;
-        _hubContext = hubContext;
         _signalRNotificationService = signalRNotificationService;
     }
 
@@ -349,7 +343,6 @@ public class PeopleImportService : IPeopleImportService
     public async Task<ImportPeopleResult> ImportPeopleAsync(Guid electionGuid, int rowId)
     {
         var result = new ImportPeopleResult();
-        var groupName = GetGroupName(electionGuid);
         var startTime = DateTimeOffset.UtcNow;
 
         var importFile = await _context.ImportFiles
@@ -453,7 +446,7 @@ public class PeopleImportService : IPeopleImportService
                 var row = dataRows[i];
                 rowNumber = i + firstRowNum + 1; // Calculate actual row number in the file for error reporting
 
-                await ReportProgress(groupName, i + 1, dataRows.Count, $"Processing row {rowNumber}");
+                await ReportProgress(electionGuid, i + 1, dataRows.Count, $"Processing row {rowNumber}");
 
                 try
                 {
@@ -522,7 +515,7 @@ public class PeopleImportService : IPeopleImportService
                 result.Success = true;
                 result.TimeElapsedSeconds = (DateTimeOffset.UtcNow - startTime).TotalSeconds;
 
-                await _hubContext.Clients.Group(groupName).SendAsync("importComplete", result);
+                await _signalRNotificationService.SendPeopleImportCompleteAsync(electionGuid, result);
 
                 // Open front desk / people / ballot-entry sessions re-fetch lists
                 // (parity with single-person PersonAdded/Updated from People Management).
@@ -563,7 +556,7 @@ public class PeopleImportService : IPeopleImportService
                     }
                 });
             }
-            await _hubContext.Clients.Group(groupName).SendAsync("importError", ex.Message);
+            await _signalRNotificationService.SendPeopleImportErrorAsync(electionGuid, ex.Message);
         }
 
         return result;
@@ -1132,10 +1125,8 @@ public class PeopleImportService : IPeopleImportService
         }
     }
 
-    private async Task ReportProgress(string groupName, int processed, int total, string status)
+    private async Task ReportProgress(Guid electionGuid, int processed, int total, string status)
     {
-        await _hubContext.Clients.Group(groupName).SendAsync("importProgress", processed, total, status);
+        await _signalRNotificationService.SendPeopleImportProgressAsync(electionGuid, processed, total, status);
     }
-
-    private static string GetGroupName(Guid electionGuid) => $"PeopleImport{electionGuid}";
 }

--- a/backend/Services/SignalRNotificationService.cs
+++ b/backend/Services/SignalRNotificationService.cs
@@ -15,6 +15,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     private readonly IHubContext<MainHub> _mainHubContext;
     private readonly IHubContext<AnalyzeHub> _analyzeHubContext;
     private readonly IHubContext<BallotImportHub> _ballotImportHubContext;
+    private readonly IHubContext<PeopleImportHub> _peopleImportHubContext;
     private readonly IHubContext<FrontDeskHub> _frontDeskHubContext;
     private readonly IHubContext<PublicHub> _publicHubContext;
     private readonly ILogger<SignalRNotificationService> _logger;
@@ -25,6 +26,7 @@ public class SignalRNotificationService : ISignalRNotificationService
     /// <param name="mainHubContext">Hub context for the main SignalR hub.</param>
     /// <param name="analyzeHubContext">Hub context for the analysis SignalR hub.</param>
     /// <param name="ballotImportHubContext">Hub context for the ballot import SignalR hub.</param>
+    /// <param name="peopleImportHubContext">Hub context for the people import SignalR hub.</param>
     /// <param name="frontDeskHubContext">Hub context for the front desk SignalR hub.</param>
     /// <param name="publicHubContext">Hub context for PublicHub (guest-teller join list).</param>
     /// <param name="logger">Logger for recording notification service operations.</param>
@@ -32,6 +34,7 @@ public class SignalRNotificationService : ISignalRNotificationService
         IHubContext<MainHub> mainHubContext,
         IHubContext<AnalyzeHub> analyzeHubContext,
         IHubContext<BallotImportHub> ballotImportHubContext,
+        IHubContext<PeopleImportHub> peopleImportHubContext,
         IHubContext<FrontDeskHub> frontDeskHubContext,
         IHubContext<PublicHub> publicHubContext,
         ILogger<SignalRNotificationService> logger)
@@ -39,6 +42,7 @@ public class SignalRNotificationService : ISignalRNotificationService
         _mainHubContext = mainHubContext;
         _analyzeHubContext = analyzeHubContext;
         _ballotImportHubContext = ballotImportHubContext;
+        _peopleImportHubContext = peopleImportHubContext;
         _frontDeskHubContext = frontDeskHubContext;
         _publicHubContext = publicHubContext;
         _logger = logger;
@@ -84,21 +88,110 @@ public class SignalRNotificationService : ISignalRNotificationService
     }
 
     /// <summary>
-    /// Sends import progress notifications to connected clients.
+    /// Sends ballot import progress (camelCase event names matching SPA importStore).
     /// </summary>
     /// <param name="progress">The import progress data to send.</param>
     public async Task SendImportProgressAsync(ImportProgressDto progress)
     {
         try
         {
-            var groupName = $"BallotImport{progress.ElectionGuid}";
-            var eventName = progress.IsComplete ? "ImportComplete" : "ImportProgress";
-            await _ballotImportHubContext.Clients.Group(groupName).SendAsync(eventName, progress);
-            _logger.LogInformation("Sent {EventName} notification to group {GroupName}", eventName, groupName);
+            var groupName = BallotImportHub.GetGroupName(progress.ElectionGuid);
+            // SPA listens for camelCase; ASP.NET Core SignalR event names are case-sensitive.
+            await _ballotImportHubContext.Clients.Group(groupName).SendAsync("importProgress", progress);
+            _logger.LogInformation("Sent importProgress notification to group {GroupName}", groupName);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error sending ImportProgress notification for election {ElectionGuid}", progress.ElectionGuid);
+            _logger.LogError(ex, "Error sending importProgress notification for election {ElectionGuid}", progress.ElectionGuid);
+        }
+    }
+
+    /// <summary>
+    /// Sends a ballot import error (event <c>importError</c>, message + row number args).
+    /// </summary>
+    public async Task SendImportErrorAsync(Guid electionGuid, string errorMessage, int rowNumber)
+    {
+        try
+        {
+            var groupName = BallotImportHub.GetGroupName(electionGuid);
+            await _ballotImportHubContext.Clients.Group(groupName)
+                .SendAsync("importError", errorMessage, rowNumber);
+            _logger.LogInformation("Sent importError notification to group {GroupName}", groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending importError notification for election {ElectionGuid}", electionGuid);
+        }
+    }
+
+    /// <summary>
+    /// Sends ballot import completion (event <c>importComplete</c>).
+    /// </summary>
+    public async Task SendImportCompleteAsync(Guid electionGuid, object summary)
+    {
+        try
+        {
+            var groupName = BallotImportHub.GetGroupName(electionGuid);
+            await _ballotImportHubContext.Clients.Group(groupName).SendAsync("importComplete", summary);
+            _logger.LogInformation("Sent importComplete notification to group {GroupName}", groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending importComplete notification for election {ElectionGuid}", electionGuid);
+        }
+    }
+
+    /// <summary>
+    /// Sends people import progress (event <c>importProgress</c>, thin progress payload).
+    /// </summary>
+    public async Task SendPeopleImportProgressAsync(Guid electionGuid, int processed, int total, string status)
+    {
+        try
+        {
+            var groupName = PeopleImportHub.GetGroupName(electionGuid);
+            // SPA PeopleImportPage expects { processed, total, status } (not multi-arg).
+            var progress = new { processed, total, status };
+            await _peopleImportHubContext.Clients.Group(groupName).SendAsync("importProgress", progress);
+            _logger.LogInformation("Sent people importProgress notification to group {GroupName}", groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending people importProgress for election {ElectionGuid}", electionGuid);
+        }
+    }
+
+    /// <summary>
+    /// Sends a people import error (event <c>importError</c>).
+    /// </summary>
+    public async Task SendPeopleImportErrorAsync(Guid electionGuid, string errorMessage, int rowNumber = 0)
+    {
+        try
+        {
+            var groupName = PeopleImportHub.GetGroupName(electionGuid);
+            await _peopleImportHubContext.Clients.Group(groupName)
+                .SendAsync("importError", errorMessage, rowNumber);
+            _logger.LogInformation("Sent people importError notification to group {GroupName}", groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending people importError for election {ElectionGuid}", electionGuid);
+        }
+    }
+
+    /// <summary>
+    /// Sends people import completion (event <c>importComplete</c>).
+    /// </summary>
+    public async Task SendPeopleImportCompleteAsync(Guid electionGuid, object summary)
+    {
+        try
+        {
+            var groupName = PeopleImportHub.GetGroupName(electionGuid);
+            await _peopleImportHubContext.Clients.Group(groupName).SendAsync("importComplete", summary);
+            _logger.LogInformation("Sent people importComplete notification to group {GroupName}", groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending people importComplete for election {ElectionGuid}", electionGuid);
         }
     }
 

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -105,3 +105,32 @@ Group: `FrontDesk{electionGuid}`.
 - **Rejected alternative:** keep `location.reload()` for exact v3 parity. Rejected as unnecessary disruption when list/stats APIs already return authoritative post-import state.
 - **Also wired:** `updateOnlineElection` with open/close/estimate/selection process when election online settings change (not on every unrelated election field update).
 - **People import:** bulk people CSV/XLSX import does **not** emit per-row `PersonAdded` (would flood the hub). After successful import (or delete-all-people), the server fires the same `reloadPage` signal so open front desks re-fetch eligible voters — same end result as single-person CRUD, without N SignalR events.
+
+## Import hub event catalog (#226)
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #226; `SignalRNotificationService` import methods; `importStore` / `PeopleImportPage` listeners  
+**Revisit when:** changing progress payload shape, or adding election-package load progress (#231)
+
+Server pushes only via `IHubContext` in `SignalRNotificationService`. Both import hubs expose **join/leave only** — no client-callable broadcast methods (same pattern as MainHub / FrontDeskHub after #227 / #232).
+
+ASP.NET Core SignalR **event names are case-sensitive**. SPA listeners use **camelCase** only.
+
+### BallotImportHub — group `BallotImport{electionGuid}`
+
+| Event | Payload | Producer | Primary listeners |
+| ----- | ------- | -------- | ----------------- |
+| `importProgress` | `ImportProgressDto` (object: processedRows, totalRows, successCount, errorCount, currentStatus, percentComplete, …) | `SendImportProgressAsync` ← `ImportService` | `importStore` → `ImportProgressDialog` |
+| `importError` | `(errorMessage, rowNumber)` two args | `SendImportErrorAsync` ← `ImportService` | `importStore` |
+| `importComplete` | summary object (ballotsCreated, votesCreated, …) | `SendImportCompleteAsync` ← `ImportService` | `importStore` |
+
+### PeopleImportHub — group `PeopleImport{electionGuid}`
+
+| Event | Payload | Producer | Primary listeners |
+| ----- | ------- | -------- | ----------------- |
+| `importProgress` | `{ processed, total, status }` | `SendPeopleImportProgressAsync` ← `PeopleImportService` | `PeopleImportPage` |
+| `importError` | `(errorMessage, rowNumber)` | `SendPeopleImportErrorAsync` ← `PeopleImportService` | `PeopleImportPage` |
+| `importComplete` | `ImportPeopleResult` (success, peopleAdded, …) | `SendPeopleImportCompleteAsync` ← `PeopleImportService` | `PeopleImportPage` |
+
+**Rejected alternative:** dual path — `ImportService` / `PeopleImportService` calling `IHubContext` directly while `SendImportProgressAsync` used different PascalCase names (`ImportProgress` / `ImportComplete`). Rejected — case-sensitive mismatch would miss SPA listeners; two producers drift. **Chosen:** one producer (`ISignalRNotificationService`) with camelCase event names matching the SPA.

--- a/docs/Hubs-v3-vs-v4.md
+++ b/docs/Hubs-v3-vs-v4.md
@@ -142,14 +142,16 @@ Catalog: `context/realtime.md` § FrontDeskHub event catalog.
 
 Catalog: `context/realtime.md` § FrontDeskHub event catalog.
 
-#### 4. Ballot import progress dual path
+#### 4. Ballot import progress dual path — **fixed** ([#226](https://github.com/glittle/TallyJ-4/issues/226))
 
-| Path | Event names |
-|------|-------------|
-| `ImportService` → hub | camelCase `importProgress` / `importComplete` (matches FE) |
-| `SendImportProgressAsync` | PascalCase `ImportProgress` / `ImportComplete` (would miss FE) |
+| Piece | Status |
+|-------|--------|
+| Event names | camelCase only: `importProgress` / `importError` / `importComplete` |
+| Producer | `ISignalRNotificationService` (ballot + people methods) |
+| Hubs | join/leave only; no client-callable broadcast methods |
+| FE | `importStore` (ballot) and `PeopleImportPage` (people) |
 
-→ Issue [#226](https://github.com/glittle/TallyJ-4/issues/226)
+Catalog: `context/realtime.md` § Import hub event catalog.
 
 ### B. Operator feature gaps
 

--- a/frontend/src/pages/people/PeopleImportPage.vue
+++ b/frontend/src/pages/people/PeopleImportPage.vue
@@ -140,9 +140,9 @@ async function initializeSignalR() {
     connection.on("importComplete", (data: PeopleImportCompleteEvent) => {
       importing.value = false;
       importProgress.value = null;
-      if (data.result.success) {
+      if (data.success) {
         showSuccessMessage(
-          `Import completed: ${data.result.peopleAdded} people added, ${data.result.peopleSkipped} skipped`,
+          `Import completed: ${data.peopleAdded} people added, ${data.peopleSkipped} skipped`,
         );
       } else {
         showErrorMessage(

--- a/frontend/src/types/SignalREvents.ts
+++ b/frontend/src/types/SignalREvents.ts
@@ -69,14 +69,13 @@ export interface PeopleImportProgressEvent {
   status: string;
 }
 
+/** Matches backend ImportPeopleResult pushed on importComplete. */
 export interface PeopleImportCompleteEvent {
-  result: {
-    success: boolean;
-    peopleAdded: number;
-    peopleSkipped: number;
-    totalRows: number;
-    warnings: string[];
-    errors: string[];
-    timeElapsedSeconds: number;
-  };
+  success: boolean;
+  peopleAdded: number;
+  peopleSkipped: number;
+  totalRows: number;
+  warnings?: unknown[];
+  errors?: unknown[];
+  timeElapsedSeconds: number;
 }


### PR DESCRIPTION
## Summary
- Consolidate ballot and people import progress through `ISignalRNotificationService` using camelCase `importProgress` / `importError` / `importComplete` (ASP.NET SignalR event names are case-sensitive).
- Make BallotImportHub and PeopleImportHub join/leave only; remove client-callable broadcast methods and the unused PascalCase dual path.
- Align progress payloads with SPA listeners, fix people `importComplete` handling, and document the contract in `context/realtime.md`.

## Test plan
- [x] Unit tests: `SignalRNotificationServiceTests` + `PeopleImportServiceTests` (30 passed)
- [ ] Manual: start ballot CSV import with SignalR connected; progress dialog updates; complete/error events fire
- [ ] Manual: people import progress bar and completion toast
- [ ] Confirm open Front Desk still soft-refreshes via `reloadPage` after successful import

Closes #226