### PR TITLE
Fix guest teller page on election stage change (#242)

### DIFF
--- a/context/election-state.md
+++ b/context/election-state.md
@@ -10,3 +10,27 @@ State transitions affect what every teller can see and do. Silent or partial fai
 
 ### Design posture
 Treat state changes as high-consequence operations. Prefer clear, atomic transitions and strong feedback over optimistic updates.
+
+## GuestTeller page on stage change
+
+**Status:** active  
+**Evidence:** confirmed (issue #242)
+
+When election stage changes, GuestTellers are redirected to the stage’s primary work page (same idea as “move all tellers to this state” for navigation):
+
+| Stage | GuestTeller destination |
+|-------|-------------------------|
+| GatheringBallots | Front Desk |
+| ProcessingBallots | Enter Ballots (`/ballots`) |
+| SettingUp / Finalized | election landing (and results links when Finalized) |
+
+**Rejected alternative:** keep ProcessingBallots GuestTellers on election landing only, with ballot entry only via per-ballot deep links (phase-2 restriction). That left guests stuck on Front Desk after a stage advance (or with no stage work page), while Gathering already auto-moved them to Front Desk.
+
+**Reason:** symmetric stage landing for guests; Enter Ballots is the Processing counterpart to Front Desk. Tally/monitor/results stay FullTeller-only (`adminOnly`). Per-ballot `/ballots/:id/entry` routes remain allowed.
+
+Implementation:
+- Rules: `guestTellerAccess.ts`
+- Live redirect: `useGuestTellerStageRedirect` in `MainLayout` (not only the lazy sidebar menu)
+- Secondary: sidebar watch + router `beforeEach`
+- Stage source: MainHub `statusChanged` → `electionStore.currentStage`
+- Main hub membership must stay for the whole election session (`electionStore`); ballots/people pages only join/leave FrontDesk (see `context/realtime.md`)

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -33,6 +33,17 @@ Do **not** assume a single `election-{guid}` convention for all realtime traffic
 
 Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElection`, etc.) and store subscriptions.
 
+### Who owns Main vs FrontDesk membership
+
+**Status:** active  
+**Evidence:** confirmed (issue #242 — guest stage redirects stopped after leaving ballots)
+
+- **Main hub** (`joinElection` / `leaveElection`): owned by `electionStore` / `MainLayout` for the active election session (`statusChanged`, computer code, guest close-out).
+- **FrontDesk hub** (`joinFrontDeskElection` / `leaveFrontDeskElection`): owned by page stores that listen for FD events (`ballotStore`, `peopleStore`, Front Desk page).
+- **Do not** call full `leaveElection` from ballots/people unmount — that drops Main group membership and stops stage updates for the rest of the session.
+
+**Rejected alternative:** page-level stores share `joinElection`/`leaveElection` for convenience. Rejected — unmount of one page tears down session-level Main membership.
+
 **Reason:** different surfaces need different fan-out and sometimes different membership (known vs guest). One flat `election-{guid}` group would over-notify or under-notify and couple unrelated UI areas.
 
 **Rejected alternative:** one shared election group for every event type. Rejected because Main, Front Desk, Analyze, and Public have different listeners and update cadences.

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { isGuestTeller } from "@/domain/guestTellerAccess";
 import {
   ArrowLeft,
   Expand,
@@ -49,7 +48,12 @@ const authStore = useAuthStore();
 
 const isSuperAdmin = computed(() => authStore.isSuperAdmin);
 
-const isGuest = computed(() => isGuestTeller());
+// Prefer reactive authStore fields over cookie reads so guest detection updates
+// with the session and stays correct for the whole layout tree.
+const isGuest = computed(
+  () =>
+    authStore.name === "Teller" && authStore.authMethod === "AccessCode",
+);
 
 const isInElectionContext = computed(() => {
   return route.path.startsWith("/elections/") && route.params.id;

--- a/frontend/src/components/nav/StageGroupedSidebarMenu.vue
+++ b/frontend/src/components/nav/StageGroupedSidebarMenu.vue
@@ -99,7 +99,7 @@ watch(
   <div
     class="stage-grouped-menu"
     role="navigation"
-    :aria-label="$t('common.electionNavigation')"
+    :aria-label="t('common.electionNavigation')"
   >
     <!-- Guest view: no group headers, just the filtered page list for current stage -->
     <template v-if="isGuestTeller">

--- a/frontend/src/components/nav/__tests__/StageGroupedSidebarMenu.test.ts
+++ b/frontend/src/components/nav/__tests__/StageGroupedSidebarMenu.test.ts
@@ -196,13 +196,17 @@ describe("StageGroupedSidebarMenu", () => {
       expect(pages).toHaveLength(expectedPages.length);
     });
 
-    it("renders no menu pages during ProcessingBallots (ballot entry uses per-ballot URLs)", () => {
+    it("renders Enter Ballots during ProcessingBallots", () => {
       const wrapper = mountMenu({
         isGuestTeller: true,
         currentStage: "ProcessingBallots",
       });
       const pages = wrapper.findAll(".stage-group__page");
-      expect(pages).toHaveLength(0);
+      const expectedPages = STAGE_PAGES["ProcessingBallots"].filter(
+        (p) => !p.adminOnly,
+      );
+      expect(pages).toHaveLength(expectedPages.length);
+      expect(expectedPages.map((p) => p.key)).toEqual(["ballots"]);
     });
 
     it("renders landing and final results during Finalized", () => {
@@ -242,6 +246,21 @@ describe("StageGroupedSidebarMenu", () => {
       );
     });
 
+    it("redirects teller from Front Desk to Enter Ballots when stage is ProcessingBallots", () => {
+      mockRoutePath.mockReturnValue("/elections/test-id/frontdesk");
+
+      mountMenu({
+        isGuestTeller: true,
+        currentStage: "ProcessingBallots",
+        electionGuid: "test-id",
+      });
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        getGuestTellerRedirectPath("test-id", "ProcessingBallots"),
+      );
+      expect(mockRouterPush).toHaveBeenCalledWith("/elections/test-id/ballots");
+    });
+
     it("does not redirect teller when already on a valid stage page", () => {
       const tellerPages = STAGE_PAGES["GatheringBallots"].filter(
         (p) => !p.adminOnly,
@@ -255,6 +274,16 @@ describe("StageGroupedSidebarMenu", () => {
         });
         expect(mockRouterPush).not.toHaveBeenCalled();
       }
+    });
+
+    it("does not redirect teller already on Enter Ballots during ProcessingBallots", () => {
+      mockRoutePath.mockReturnValue("/elections/test-id/ballots");
+      mountMenu({
+        isGuestTeller: true,
+        currentStage: "ProcessingBallots",
+        electionGuid: "test-id",
+      });
+      expect(mockRouterPush).not.toHaveBeenCalled();
     });
 
     it("does not redirect admins regardless of route", () => {

--- a/frontend/src/composables/__tests__/useGuestTellerStageRedirect.spec.ts
+++ b/frontend/src/composables/__tests__/useGuestTellerStageRedirect.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { defineComponent, h, nextTick, ref } from "vue";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { useGuestTellerStageRedirect } from "../useGuestTellerStageRedirect";
+import { useElectionStore } from "@/stores/electionStore";
+import type { ElectionDto } from "@/types";
+
+const mockRouterPush = vi.fn();
+const routePath = ref("/elections/elec-1/frontdesk");
+const routeId = ref("elec-1");
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({
+    get path() {
+      return routePath.value;
+    },
+    params: {
+      get id() {
+        return routeId.value;
+      },
+    },
+  }),
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
+vi.mock("@/domain/guestTellerAccess", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/domain/guestTellerAccess")
+  >("@/domain/guestTellerAccess");
+  return {
+    ...actual,
+    isGuestTeller: vi.fn(() => true),
+  };
+});
+
+let wrapper: VueWrapper | null = null;
+
+function mountHarness() {
+  wrapper?.unmount();
+  wrapper = mount(
+    defineComponent({
+      setup() {
+        useGuestTellerStageRedirect();
+        return () => h("div");
+      },
+    }),
+  );
+  return wrapper;
+}
+
+describe("useGuestTellerStageRedirect", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockRouterPush.mockReset();
+    routePath.value = "/elections/elec-1/frontdesk";
+    routeId.value = "elec-1";
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  it("does not redirect before current election is loaded for the route", async () => {
+    mountHarness();
+    await nextTick();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("redirects GuestTeller from Front Desk to Enter Ballots when stage becomes ProcessingBallots", async () => {
+    const store = useElectionStore();
+    store.currentElection = {
+      electionGuid: "elec-1",
+      name: "Test",
+      electionStage: "GatheringBallots",
+    } as ElectionDto;
+
+    mountHarness();
+    await nextTick();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    store.currentElection = {
+      ...store.currentElection!,
+      electionStage: "ProcessingBallots",
+    };
+    await nextTick();
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/elections/elec-1/ballots");
+  });
+
+  it("redirects GuestTeller to Front Desk when stage becomes GatheringBallots", async () => {
+    routePath.value = "/elections/elec-1";
+    const store = useElectionStore();
+    store.currentElection = {
+      electionGuid: "elec-1",
+      name: "Test",
+      electionStage: "SettingUp",
+    } as ElectionDto;
+
+    mountHarness();
+    await nextTick();
+    // SettingUp on landing is allowed — no redirect yet
+    mockRouterPush.mockReset();
+
+    store.currentElection = {
+      ...store.currentElection!,
+      electionStage: "GatheringBallots",
+    };
+    await nextTick();
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/elections/elec-1/frontdesk");
+  });
+
+  it("does not redirect when already on the correct ProcessingBallots page", async () => {
+    routePath.value = "/elections/elec-1/ballots";
+    const store = useElectionStore();
+    store.currentElection = {
+      electionGuid: "elec-1",
+      name: "Test",
+      electionStage: "ProcessingBallots",
+    } as ElectionDto;
+
+    mountHarness();
+    await nextTick();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/composables/useGuestTellerStageRedirect.ts
+++ b/frontend/src/composables/useGuestTellerStageRedirect.ts
@@ -1,0 +1,56 @@
+import {
+  getGuestTellerRedirectPath,
+  isGuestTeller,
+  isGuestTellerRouteAllowed,
+} from "@/domain/guestTellerAccess";
+import { useElectionStore } from "@/stores/electionStore";
+import { storeToRefs } from "pinia";
+import { watch, type WatchStopHandle } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+/**
+ * Keeps GuestTellers on the stage-appropriate page when election stage changes
+ * over SignalR (or any store update). Lives in the layout so redirects do not
+ * depend on the lazy-loaded sidebar menu being mounted.
+ */
+export function useGuestTellerStageRedirect(): WatchStopHandle {
+  const route = useRoute();
+  const router = useRouter();
+  const electionStore = useElectionStore();
+  const { currentStage, currentElection } = storeToRefs(electionStore);
+
+  return watch(
+    [currentStage, () => route.path, currentElection],
+    () => {
+      if (!isGuestTeller()) {
+        return;
+      }
+
+      const routeGuid =
+        typeof route.params.id === "string" ? route.params.id : undefined;
+      if (!routeGuid) {
+        return;
+      }
+
+      // Wait until the store has the election for this route so we do not
+      // redirect using the default SettingUp stage before fetch completes.
+      const loaded = currentElection.value;
+      if (
+        !loaded?.electionGuid ||
+        loaded.electionGuid.toLowerCase() !== routeGuid.toLowerCase()
+      ) {
+        return;
+      }
+
+      const stage = currentStage.value;
+      const destination = getGuestTellerRedirectPath(routeGuid, stage);
+      if (
+        !isGuestTellerRouteAllowed(route.path, routeGuid, stage) &&
+        route.path !== destination
+      ) {
+        void router.push(destination);
+      }
+    },
+    { immediate: true },
+  );
+}

--- a/frontend/src/domain/__tests__/electionStages.test.ts
+++ b/frontend/src/domain/__tests__/electionStages.test.ts
@@ -56,12 +56,12 @@ describe("electionStages", () => {
       expect(frontdesk?.adminOnly).toBeFalsy();
     });
 
-    it("marks Enter Ballots as admin-only (FullTeller only)", () => {
+    it("does not mark Enter Ballots as admin-only (Guest-visible)", () => {
       const ballots = STAGE_PAGES.ProcessingBallots.find(
         (p) => p.key === "ballots",
       );
       expect(ballots).toBeDefined();
-      expect(ballots?.adminOnly).toBe(true);
+      expect(ballots?.adminOnly).toBeFalsy();
     });
 
     it("has Finalized stage pages for FullTellers", () => {

--- a/frontend/src/domain/__tests__/guestTellerAccess.test.ts
+++ b/frontend/src/domain/__tests__/guestTellerAccess.test.ts
@@ -56,8 +56,10 @@ describe("guestTellerAccess", () => {
       expect(pages[0]!.key).toBe("frontdesk");
     });
 
-    it("returns no menu items during ProcessingBallots (entry uses per-ballot URLs)", () => {
-      expect(getGuestTellerMenuPages("ProcessingBallots", GUID)).toEqual([]);
+    it("returns Enter Ballots during ProcessingBallots", () => {
+      const pages = getGuestTellerMenuPages("ProcessingBallots", GUID);
+      expect(pages).toHaveLength(1);
+      expect(pages[0]!.key).toBe("ballots");
     });
 
     it("returns landing and final results during Finalized", () => {
@@ -100,6 +102,11 @@ describe("guestTellerAccess", () => {
       {
         stage: "ProcessingBallots",
         path: `/elections/${GUID}/ballots`,
+        allowed: true,
+      },
+      {
+        stage: "ProcessingBallots",
+        path: `/elections/${GUID}/frontdesk`,
         allowed: false,
       },
       {
@@ -131,6 +138,12 @@ describe("guestTellerAccess", () => {
     it("redirects GatheringBallots to Front Desk", () => {
       expect(getGuestTellerRedirectPath(GUID, "GatheringBallots")).toBe(
         `/elections/${GUID}/frontdesk`,
+      );
+    });
+
+    it("redirects ProcessingBallots to Enter Ballots", () => {
+      expect(getGuestTellerRedirectPath(GUID, "ProcessingBallots")).toBe(
+        `/elections/${GUID}/ballots`,
       );
     });
 

--- a/frontend/src/domain/electionStages.ts
+++ b/frontend/src/domain/electionStages.ts
@@ -137,7 +137,7 @@ export const STAGE_PAGES: Record<NavElectionStage, NavPageDef[]> = {
       i18nKey: "ballots.management",
       icon: Tickets,
       routePath: (g) => `/elections/${g}/ballots`,
-      adminOnly: true,
+      // Guest-visible: counterpart to Front Desk during GatheringBallots (#242)
     },
     {
       key: "tally",

--- a/frontend/src/domain/guestTellerAccess.ts
+++ b/frontend/src/domain/guestTellerAccess.ts
@@ -28,9 +28,9 @@ const GUEST_TELLER_ROUTE_PATTERNS: Record<ElectionStage, RegExp[]> = {
   SettingUp: [/^\/elections\/[^/]+$/],
   GatheringBallots: [/^\/elections\/[^/]+\/frontdesk$/],
   ProcessingBallots: [
+    // Enter Ballots list (menu destination) plus per-ballot entry deep links
+    /^\/elections\/[^/]+\/ballots$/,
     /^\/elections\/[^/]+\/ballots\/[^/]+\/entry$/,
-    // Fallback landing while awaiting a ballot entry URL from coordinators
-    /^\/elections\/[^/]+$/,
   ],
   Finalized: [
     /^\/elections\/[^/]+$/,
@@ -70,8 +70,8 @@ export function getGuestTellerMenuPages(
     case "GatheringBallots":
       return STAGE_PAGES.GatheringBallots.filter((p) => !p.adminOnly);
     case "ProcessingBallots":
-      // Ballot entry uses per-ballot URLs; no fixed menu destination.
-      return [];
+      // Enter Ballots is Guest-visible; tally/monitor/results remain admin-only.
+      return STAGE_PAGES.ProcessingBallots.filter((p) => !p.adminOnly);
     case "Finalized":
       return [landingPage(), showFinalResultsPage()];
   }
@@ -82,20 +82,26 @@ export function isGuestTellerRouteAllowed(
   electionGuid: string,
   stage: ElectionStage,
 ): boolean {
-  const prefix = `/elections/${electionGuid}`;
-  if (!path.startsWith(prefix)) {
+  const electionPathMatch = path.match(/^\/elections\/([^/]+)(.*)$/i);
+  if (
+    !electionPathMatch ||
+    electionPathMatch[1]!.toLowerCase() !== electionGuid.toLowerCase()
+  ) {
     return false;
   }
+
+  // Canonicalize GUID casing so menu paths and route patterns match the URL.
+  const canonicalPath = `/elections/${electionGuid}${electionPathMatch[2] ?? ""}`;
 
   const menuPaths = getGuestTellerMenuPages(stage, electionGuid).map((p) =>
     p.routePath(electionGuid),
   );
-  if (menuPaths.includes(path)) {
+  if (menuPaths.includes(canonicalPath)) {
     return true;
   }
 
   return GUEST_TELLER_ROUTE_PATTERNS[stage].some((pattern) =>
-    pattern.test(path),
+    pattern.test(canonicalPath),
   );
 }
 

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useGuestTellerStageRedirect } from "@/composables/useGuestTellerStageRedirect";
 import { useResponsive } from "@/composables/useResponsive";
 import { computed, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
@@ -18,6 +19,9 @@ const route = useRoute();
 const electionStore = useElectionStore();
 const navUiStore = useNavUiStore();
 const { isMobile } = useResponsive();
+
+// GuestTeller stage→page moves must not depend on the lazy sidebar menu.
+useGuestTellerStageRedirect();
 
 const isFrontDeskLayout = computed(() => route.path.includes("/frontdesk"));
 

--- a/frontend/src/stores/__tests__/ballotStore.spec.ts
+++ b/frontend/src/stores/__tests__/ballotStore.spec.ts
@@ -27,6 +27,8 @@ vi.mock("@/services/voteService", () => ({
 vi.mock("@/services/signalrService", () => ({
   signalrService: {
     connectToFrontDeskHub: vi.fn(),
+    joinFrontDeskElection: vi.fn(),
+    leaveFrontDeskElection: vi.fn(),
     joinElection: vi.fn(),
     leaveElection: vi.fn(),
   },

--- a/frontend/src/stores/__tests__/peopleStore.spec.ts
+++ b/frontend/src/stores/__tests__/peopleStore.spec.ts
@@ -24,6 +24,8 @@ vi.mock("@/services/signalrService", () => ({
     connectToFrontDeskHub: vi.fn().mockResolvedValue({
       on: vi.fn(),
     }),
+    joinFrontDeskElection: vi.fn().mockResolvedValue(undefined),
+    leaveFrontDeskElection: vi.fn().mockResolvedValue(undefined),
     joinElection: vi.fn().mockResolvedValue(undefined),
     leaveElection: vi.fn().mockResolvedValue(undefined),
   },

--- a/frontend/src/stores/ballotStore.ts
+++ b/frontend/src/stores/ballotStore.ts
@@ -539,9 +539,14 @@ export const useBallotStore = defineStore("ballot", () => {
     }
   }
 
+  /**
+   * FrontDesk hub only. Main hub membership is owned by electionStore /
+   * MainLayout — leaving Main here would stop statusChanged for the session
+   * after navigating away from ballots (guest stage redirects #242).
+   */
   async function joinElection(electionGuid: string) {
     try {
-      await signalrService.joinElection(electionGuid);
+      await signalrService.joinFrontDeskElection(electionGuid);
     } catch (e) {
       console.error("Failed to join election group for ballot updates:", e);
     }
@@ -549,7 +554,7 @@ export const useBallotStore = defineStore("ballot", () => {
 
   async function leaveElection(electionGuid: string) {
     try {
-      await signalrService.leaveElection(electionGuid);
+      await signalrService.leaveFrontDeskElection(electionGuid);
     } catch (e) {
       console.error("Failed to leave election group for ballot updates:", e);
     }

--- a/frontend/src/stores/electionStore.test.ts
+++ b/frontend/src/stores/electionStore.test.ts
@@ -468,6 +468,37 @@ describe("Election Store", () => {
       );
     });
 
+    it("statusChanged accepts PascalCase payload and case-insensitive electionGuid", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
+
+      electionStore.currentElection = {
+        electionGuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        name: "Case Test",
+        electionStage: "GatheringBallots",
+      } as ElectionDto;
+
+      await electionStore.initializeSignalR();
+      handlers.get("statusChanged")!({
+        ElectionGuid: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+        Name: "Case Test",
+        ElectionStage: "ProcessingBallots",
+        UpdatedAt: new Date().toISOString(),
+      });
+
+      expect(electionStore.currentElection?.electionStage).toBe(
+        "ProcessingBallots",
+      );
+      expect(elMessageMock).toHaveBeenCalledTimes(1);
+    });
+
     it("statusChanged does not toast when local setStage already suppressed echo", async () => {
       const { signalrService } = await import("../services/signalrService");
       const { electionService } = await import("../services/electionService");

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -27,6 +27,46 @@ import { i18n } from "../locales";
 /** How long to suppress remote stage toasts after a local setStage (covers SignalR racing HTTP). */
 const LOCAL_STAGE_NOTIFY_SUPPRESS_MS = 5000;
 
+function sameElectionGuid(a?: string | null, b?: string | null): boolean {
+  return !!a && !!b && a.toLowerCase() === b.toLowerCase();
+}
+
+function parseStage(value: unknown): ElectionStage | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return Object.hasOwn(STAGE_META, value)
+    ? (value as ElectionStage)
+    : undefined;
+}
+
+/** Accept camelCase or PascalCase payloads from SignalR JSON. */
+function parseElectionUpdatePayload(data: unknown): ElectionUpdateEvent | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+  const record = data as Record<string, unknown>;
+  const electionGuid = String(
+    record.electionGuid ?? record.ElectionGuid ?? "",
+  ).trim();
+  if (!electionGuid) {
+    return null;
+  }
+  return {
+    electionGuid,
+    name:
+      typeof record.name === "string"
+        ? record.name
+        : typeof record.Name === "string"
+          ? record.Name
+          : undefined,
+    electionStage: parseStage(record.electionStage ?? record.ElectionStage),
+    updatedAt: String(
+      record.updatedAt ?? record.UpdatedAt ?? new Date().toISOString(),
+    ),
+  };
+}
+
 export const useElectionStore = defineStore("election", () => {
   const elections = ref<ElectionDto[]>([]);
   const currentElection = ref<ElectionDto | null>(null);
@@ -168,14 +208,9 @@ export const useElectionStore = defineStore("election", () => {
       // (signalrService.joinElection); monitor needs updateOnlineElection.
       const frontDeskConnection = await signalrService.connectToFrontDeskHub();
 
-      connection.on("statusChanged", (data: any) => {
-        if (data && typeof data === "object") {
-          const updateEvent: ElectionUpdateEvent = {
-            electionGuid: data.electionGuid || "",
-            name: data.name,
-            electionStage: data.electionStage,
-            updatedAt: data.updatedAt || new Date().toISOString(),
-          };
+      connection.on("statusChanged", (data: unknown) => {
+        const updateEvent = parseElectionUpdatePayload(data);
+        if (updateEvent) {
           handleElectionUpdate(updateEvent);
         }
       });
@@ -261,14 +296,16 @@ export const useElectionStore = defineStore("election", () => {
   }
 
   function handleElectionUpdate(data: ElectionUpdateEvent) {
-    const index = elections.value.findIndex(
-      (e) => e.electionGuid === data.electionGuid,
+    const index = elections.value.findIndex((e) =>
+      sameElectionGuid(e.electionGuid, data.electionGuid),
     );
     const listMatch = index !== -1 ? elections.value[index] : undefined;
-    const currentMatch =
-      currentElection.value?.electionGuid === data.electionGuid
-        ? currentElection.value
-        : undefined;
+    const currentMatch = sameElectionGuid(
+      currentElection.value?.electionGuid,
+      data.electionGuid,
+    )
+      ? currentElection.value
+      : undefined;
 
     // Prefer list stage when both exist (they should match); fall back to current.
     const previousStage =

--- a/frontend/src/stores/peopleStore.test.ts
+++ b/frontend/src/stores/peopleStore.test.ts
@@ -21,6 +21,8 @@ vi.mock("../services/peopleService", () => ({
 vi.mock("../services/signalrService", () => ({
   signalrService: {
     connectToFrontDeskHub: vi.fn(),
+    joinFrontDeskElection: vi.fn(),
+    leaveFrontDeskElection: vi.fn(),
     joinElection: vi.fn(),
     leaveElection: vi.fn(),
   },

--- a/frontend/src/stores/peopleStore.ts
+++ b/frontend/src/stores/peopleStore.ts
@@ -413,9 +413,14 @@ export const usePeopleStore = defineStore("people", () => {
     }
   }
 
+  /**
+   * FrontDesk hub only. Main hub membership is owned by electionStore /
+   * MainLayout — do not call leaveElection (Main+FrontDesk) or stage
+   * statusChanged stops after leaving people/ballots pages.
+   */
   async function joinElection(electionGuid: string) {
     try {
-      await signalrService.joinElection(electionGuid);
+      await signalrService.joinFrontDeskElection(electionGuid);
     } catch (e) {
       console.error("Failed to join election group for people updates:", e);
     }
@@ -423,7 +428,7 @@ export const usePeopleStore = defineStore("people", () => {
 
   async function leaveElection(electionGuid: string) {
     try {
-      await signalrService.leaveElection(electionGuid);
+      await signalrService.leaveFrontDeskElection(electionGuid);
     } catch (e) {
       console.error("Failed to leave election group for people updates:", e);
     }


### PR DESCRIPTION
## Summary
- GuestTellers now move to **Front Desk** during Gathering Ballots and **Enter Ballots** during Processing Ballots when the election stage changes.
- Stage redirects run from MainLayout via `useGuestTellerStageRedirect` so they do not depend on the lazy-loaded sidebar.
- Ballots/people stores join and leave only the Front Desk hub, so Main hub `statusChanged` keeps working for the whole session after navigating between pages.
- Hardened SignalR stage payloads (camelCase/PascalCase, case-insensitive GUID) and documented the ownership split in `context/`.

## Test plan
- [x] Unit: guestTellerAccess, electionStages, StageGroupedSidebarMenu, useGuestTellerStageRedirect, electionStore, ballot/people stores
- [x] Manual: guest on Front Desk; officer advances Gathering → Processing → Finalized and back; guest lands on Front Desk / Enter Ballots / landing each time
- [x] Manual: after several stage changes, guest still receives stage toasts and keeps navigating

Fixes #242