### PR TITLE
Add MainHub multi-election dashboard listen (#230)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Group name patterns (constructed via `GetGroupName` statics in each hub + used f
 - `PeopleImport{electionGuid}` — PeopleImportHub (same event names; progress payload `{ processed, total, status }`).
 - `Public` (static group) — PublicHub for guest-teller joinable elections list updates.
 
-**Frontend side**: `src/services/signalrService.ts` provides `connectToMainHub()`, `connectToAnalyzeHub()`, `connectToFrontDeskHub()`, etc. + `joinElection(guid)`, `joinTallySession(guid)`, etc. Stores (electionStore, ballotStore, peopleStore, etc.) call these and wire `connection.on("eventName", handler)`.
+**Frontend side**: `src/services/signalrService.ts` provides `connectToMainHub()`, `connectToAnalyzeHub()`, `connectToFrontDeskHub()`, etc. + `joinElection(guid)`, `joinDashboardElections(guids)` (known-teller multi-listen), `joinTallySession(guid)`, etc. Stores (electionStore, ballotStore, peopleStore, etc.) call these and wire `connection.on("eventName", handler)`.
 
 When adding or touching real-time features, update the matching hub + the corresponding method in `SignalRNotificationService.cs` (see examples at lines 55, 73, 92, 111, 135, 152, 170, 189) + the frontend service + any store subscriptions together.
 

--- a/Backend.Tests/UnitTests/Hubs/MainHubTests.cs
+++ b/Backend.Tests/UnitTests/Hubs/MainHubTests.cs
@@ -1,0 +1,150 @@
+using System.Security.Claims;
+using Backend.Entities;
+using Backend.Hubs;
+using Backend.Services;
+using Backend.Tests.UnitTests;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Backend.Tests.UnitTests.Hubs;
+
+public class MainHubTests : ServiceTestBase
+{
+    private readonly Guid _userId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private readonly Guid _electionA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private readonly Guid _electionB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private readonly Guid _electionOther = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    private (MainHub Hub, Mock<IGroupManager> Groups, Mock<IComputerAssignmentService> Assignment) CreateHub(
+        ClaimsPrincipal user)
+    {
+        var assignment = new Mock<IComputerAssignmentService>();
+        var hub = new MainHub(
+            NullLogger<MainHub>.Instance,
+            assignment.Object,
+            Context);
+
+        var context = new Mock<HubCallerContext>();
+        context.Setup(c => c.ConnectionId).Returns("conn-1");
+        context.Setup(c => c.User).Returns(user);
+
+        var groups = new Mock<IGroupManager>();
+        groups
+            .Setup(g => g.AddToGroupAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        groups
+            .Setup(g => g.RemoveFromGroupAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        hub.Context = context.Object;
+        hub.Groups = groups.Object;
+
+        return (hub, groups, assignment);
+    }
+
+    private ClaimsPrincipal KnownTellerPrincipal()
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, _userId.ToString()),
+            new Claim("isTeller", "false"),
+        ], "TestAuth"));
+    }
+
+    private ClaimsPrincipal GuestTellerPrincipal()
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, _userId.ToString()),
+            new Claim("isTeller", "true"),
+            new Claim("authMethod", "AccessCode"),
+            new Claim("electionGuid", _electionA.ToString()),
+        ], "TestAuth"));
+    }
+
+    private void SeedMembership()
+    {
+        Context.JoinElectionUsers.AddRange(
+            new JoinElectionUser { ElectionGuid = _electionA, UserId = _userId },
+            new JoinElectionUser { ElectionGuid = _electionB, UserId = _userId });
+        Context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task JoinElections_known_teller_joins_base_and_Known_for_member_elections_only()
+    {
+        SeedMembership();
+        var (hub, groups, assignment) = CreateHub(KnownTellerPrincipal());
+
+        var joined = await hub.JoinElections([_electionA, _electionOther, _electionB]);
+
+        Assert.Equal(2, joined.Count);
+        Assert.Contains(_electionA, joined);
+        Assert.Contains(_electionB, joined);
+        Assert.DoesNotContain(_electionOther, joined);
+
+        groups.Verify(
+            g => g.AddToGroupAsync("conn-1", MainHub.GetGroupName(_electionA), It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.AddToGroupAsync("conn-1", MainHub.GetGroupName(_electionA) + "Known", It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.AddToGroupAsync("conn-1", MainHub.GetGroupName(_electionB), It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.AddToGroupAsync("conn-1", MainHub.GetGroupName(_electionB) + "Known", It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.AddToGroupAsync("conn-1", MainHub.GetGroupName(_electionOther), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        assignment.Verify(
+            a => a.AssignCode(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task JoinElections_guest_teller_is_rejected()
+    {
+        SeedMembership();
+        var (hub, groups, _) = CreateHub(GuestTellerPrincipal());
+
+        await Assert.ThrowsAsync<HubException>(() => hub.JoinElections([_electionA]));
+
+        groups.Verify(
+            g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task LeaveElections_removes_groups_without_releasing_computer_assignment()
+    {
+        var (hub, groups, assignment) = CreateHub(KnownTellerPrincipal());
+
+        await hub.LeaveElections([_electionA, _electionB]);
+
+        groups.Verify(
+            g => g.RemoveFromGroupAsync("conn-1", MainHub.GetGroupName(_electionA), It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.RemoveFromGroupAsync("conn-1", MainHub.GetGroupName(_electionA) + "Known", It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.RemoveFromGroupAsync("conn-1", MainHub.GetGroupName(_electionA) + "Guest", It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.RemoveFromGroupAsync("conn-1", MainHub.GetGroupName(_electionB), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        assignment.Verify(a => a.ReleaseConnection(It.IsAny<string>()), Times.Never);
+    }
+}

--- a/backend/Hubs/MainHub.cs
+++ b/backend/Hubs/MainHub.cs
@@ -1,7 +1,9 @@
 using System.Security.Claims;
+using Backend.Context;
 using Backend.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Hubs;
 
@@ -16,14 +18,19 @@ public class MainHub : Hub
 {
     private readonly ILogger<MainHub> _logger;
     private readonly IComputerAssignmentService _assignmentService;
+    private readonly MainDbContext _dbContext;
 
     /// <summary>
     /// Initializes a new instance of the MainHub.
     /// </summary>
-    public MainHub(ILogger<MainHub> logger, IComputerAssignmentService assignmentService)
+    public MainHub(
+        ILogger<MainHub> logger,
+        IComputerAssignmentService assignmentService,
+        MainDbContext dbContext)
     {
         _logger = logger;
         _assignmentService = assignmentService;
+        _dbContext = dbContext;
     }
 
     /// <summary>
@@ -63,19 +70,107 @@ public class MainHub : Hub
     }
 
     /// <summary>
+    /// Listen-only multi-election join for known tellers on the dashboard (v3 <c>JoinAll</c> parity).
+    /// Joins base <c>Main{guid}</c> and <c>…Known</c> for each election the user is a member of.
+    /// Does not assign a computer code (active workstation join remains <see cref="JoinElection"/>).
+    /// Guests are rejected. Unauthorized GUIDs are skipped.
+    /// </summary>
+    /// <param name="electionGuids">Election GUIDs to listen to for status updates.</param>
+    /// <returns>GUIDs successfully joined (membership-verified known teller only).</returns>
+    public async Task<IReadOnlyList<Guid>> JoinElections(IEnumerable<Guid> electionGuids)
+    {
+        if (!IsMainTeller(Context.User))
+        {
+            throw new HubException("Only known tellers can join multiple elections.");
+        }
+
+        var userId = GetUserId(Context.User);
+        if (userId == null)
+        {
+            throw new HubException("Authenticated user id is required.");
+        }
+
+        var requested = (electionGuids ?? Enumerable.Empty<Guid>())
+            .Where(g => g != Guid.Empty)
+            .Distinct()
+            .ToList();
+
+        if (requested.Count == 0)
+        {
+            return Array.Empty<Guid>();
+        }
+
+        var allowed = await _dbContext.JoinElectionUsers
+            .AsNoTracking()
+            .Where(jeu => jeu.UserId == userId.Value && requested.Contains(jeu.ElectionGuid))
+            .Select(jeu => jeu.ElectionGuid)
+            .ToListAsync();
+
+        var allowedSet = allowed.ToHashSet();
+        var joined = new List<Guid>(allowedSet.Count);
+
+        foreach (var electionGuid in requested)
+        {
+            if (!allowedSet.Contains(electionGuid))
+            {
+                _logger.LogWarning(
+                    "Client {ConnectionId} skipped JoinElections for {ElectionGuid}: not a member",
+                    Context.ConnectionId,
+                    electionGuid);
+                continue;
+            }
+
+            var groupName = GetGroupName(electionGuid);
+            await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+            await Groups.AddToGroupAsync(Context.ConnectionId, groupName + "Known");
+            joined.Add(electionGuid);
+        }
+
+        _logger.LogInformation(
+            "Client {ConnectionId} joined {JoinedCount} of {RequestedCount} elections for dashboard listen",
+            Context.ConnectionId,
+            joined.Count,
+            requested.Count);
+
+        return joined;
+    }
+
+    /// <summary>
     /// Removes the current client from the SignalR group for the specified election.
     /// The client will no longer receive real-time updates about the election.
     /// </summary>
     /// <param name="electionGuid">The unique identifier of the election to leave.</param>
     public async Task LeaveElection(Guid electionGuid)
     {
-        var groupName = GetGroupName(electionGuid);
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName + "Known");
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName + "Guest");
+        await RemoveFromElectionGroupsAsync(electionGuid);
         _assignmentService.ReleaseConnection(Context.ConnectionId);
         _logger.LogInformation("Client {ConnectionId} left election {ElectionGuid}",
             Context.ConnectionId, electionGuid);
+    }
+
+    /// <summary>
+    /// Leaves multiple MainHub election groups without releasing computer assignment
+    /// (dashboard multi-listen cleanup; active workstation stays via <see cref="JoinElection"/>).
+    /// </summary>
+    public async Task LeaveElections(IEnumerable<Guid> electionGuids)
+    {
+        var toLeave = (electionGuids ?? Enumerable.Empty<Guid>())
+            .Where(g => g != Guid.Empty)
+            .Distinct()
+            .ToList();
+
+        foreach (var electionGuid in toLeave)
+        {
+            await RemoveFromElectionGroupsAsync(electionGuid);
+        }
+
+        if (toLeave.Count > 0)
+        {
+            _logger.LogInformation(
+                "Client {ConnectionId} left {Count} elections for dashboard listen",
+                Context.ConnectionId,
+                toLeave.Count);
+        }
     }
 
     /// <summary>
@@ -91,6 +186,14 @@ public class MainHub : Hub
         await base.OnDisconnectedAsync(exception);
     }
 
+    private async Task RemoveFromElectionGroupsAsync(Guid electionGuid)
+    {
+        var groupName = GetGroupName(electionGuid);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName + "Known");
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName + "Guest");
+    }
+
     private static bool IsMainTeller(ClaimsPrincipal? user)
     {
         if (user == null)
@@ -100,6 +203,18 @@ public class MainHub : Hub
 
         var isTellerClaim = user.FindFirst("isTeller")?.Value;
         return !bool.TryParse(isTellerClaim, out var isGuestTeller) || !isGuestTeller;
+    }
+
+    private static Guid? GetUserId(ClaimsPrincipal? user)
+    {
+        if (user == null)
+        {
+            return null;
+        }
+
+        var userIdString = user.FindFirst(ClaimTypes.NameIdentifier)?.Value
+                           ?? user.FindFirst("sub")?.Value;
+        return Guid.TryParse(userIdString, out var userId) ? userId : null;
     }
 
     /// <summary>

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -12,6 +12,12 @@ Do **not** assume a single `election-{guid}` convention for all realtime traffic
 | Pattern                                                     | Hub / use                                               |
 | ----------------------------------------------------------- | ------------------------------------------------------- |
 | `Main{electionGuid}` (+ `…Known` / `…Guest`)                | MainHub — shared status on **base**; role events on suffix |
+| `Analyze{electionGuid}`                                     | AnalyzeHub — tally progress/complete                    |
+| `FrontDesk{electionGuid}`                                   | FrontDeskHub — people, ballots, online election, reload |
+| `BallotImport{electionGuid}` / `PeopleImport{electionGuid}` | import hubs                                             |
+| `Public`                                                    | PublicHub — guest-teller joinable elections list        |
+
+Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElection`, `joinDashboardElections`, etc.) and store subscriptions.
 
 ## MainHub status vs role groups
 
@@ -26,12 +32,24 @@ Do **not** assume a single `election-{guid}` convention for all realtime traffic
 - Server producers use `IHubContext<MainHub>` via `SignalRNotificationService` (and computer-assignment close-out), not client-callable hub methods.
 
 **Rejected alternative:** leave server event as `ElectionUpdated` while FE listens for `statusChanged` (broken live updates). **Rejected alternative:** keep unused hub methods `StatusChanged` / `ElectionClosed` / `CloseOutGuestTellers` as the documented push path — they were never called by services and were client-invokable.
-| `Analyze{electionGuid}`                                     | AnalyzeHub — tally progress/complete                    |
-| `FrontDesk{electionGuid}`                                   | FrontDeskHub — people, ballots, online election, reload |
-| `BallotImport{electionGuid}` / `PeopleImport{electionGuid}` | import hubs                                             |
-| `Public`                                                    | PublicHub — guest-teller joinable elections list        |
 
-Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElection`, etc.) and store subscriptions.
+## MainHub multi-election dashboard listen (JoinElections)
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #230; v3 `JoinAll` / `Public/JoinMainHubAll`; `MainHub.JoinElections` / `LeaveElections`  
+**Revisit when:** dashboard needs different events per role, or multi-join is needed outside the elections list
+
+- **Who:** known (full) tellers only — guests must not multi-join (v3 parity).
+- **When:** elections dashboard load joins all managed election GUIDs; unmount and logout leave the multi-join set.
+- **Groups:** each allowed GUID → base `Main{guid}` + `Main{guid}Known` (status is on **base** after #227). No computer-code assignment.
+- **Auth:** per-GUID membership via `JoinElectionUsers`; unauthorized GUIDs are skipped (not a hard fail of the whole batch).
+- **FE:** `signalrService.joinDashboardElections` / `leaveDashboardElections`; reconnect re-invokes `JoinElections` for the tracked set. Leaving multi-join **excludes** the active workstation election (`mainElectionGuid`) so SignalR group membership is not dropped for the session open election (groups are not refcounted).
+- **UI effect:** existing `statusChanged` → `electionStore.handleElectionUpdate` already patches list cards; multi-join only expands who receives the event.
+
+**Rejected alternative:** loop `JoinElection` for every dashboard card. Rejected — that assigns computer codes and runs guest-join gates unsuitable for listen-only multi-election status.
+
+**Rejected alternative:** leave multi-join membership for the whole SPA session without leave-on-navigate. Rejected — would keep clients in many groups after leaving the list; v3 scoped multi-listen to the elections list.
 
 ### Who owns Main vs FrontDesk membership
 
@@ -39,6 +57,7 @@ Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElect
 **Evidence:** confirmed (issue #242 — guest stage redirects stopped after leaving ballots)
 
 - **Main hub** (`joinElection` / `leaveElection`): owned by `electionStore` / `MainLayout` for the active election session (`statusChanged`, computer code, guest close-out).
+- **Main hub multi-listen** (`joinDashboardElections` / `leaveDashboardElections`): owned by `DashboardPage` for known tellers only (issue #230).
 - **FrontDesk hub** (`joinFrontDeskElection` / `leaveFrontDeskElection`): owned by page stores that listen for FD events (`ballotStore`, `peopleStore`, Front Desk page).
 - **Do not** call full `leaveElection` from ballots/people unmount — that drops Main group membership and stops stage updates for the rest of the session.
 

--- a/docs/Hubs-v3-vs-v4.md
+++ b/docs/Hubs-v3-vs-v4.md
@@ -157,7 +157,7 @@ Catalog: `context/realtime.md` § Import hub event catalog.
 
 | Gap | v3 | v4 | Issue |
 |-----|----|----|-------|
-| Multi-election dashboard listen | MainHub `JoinAll` (known tellers) | Only current election | [#230](https://github.com/glittle/TallyJ-4/issues/230) |
+| Multi-election dashboard listen | MainHub `JoinAll` (known tellers) | **Fixed** — `JoinElections` / dashboard multi-join | [#230](https://github.com/glittle/TallyJ-4/issues/230) |
 | Election package load progress | ImportHub `loaderStatus` | No SignalR on load path | [#231](https://github.com/glittle/TallyJ-4/issues/231) |
 
 ### C. Online voter realtime (product-gated)
@@ -182,7 +182,7 @@ If restored: prefer server-derived groups, high-entropy channel tokens for code 
 
 | Capability | Hub(s) in v3 | v4 status |
 |------------|--------------|-----------|
-| Teller UI live election status | MainHub | **Partial** — guest close OK; status event mismatch |
+| Teller UI live election status | MainHub | **Yes** — status + multi-election dashboard listen |
 | Guest kick on close/unlist | MainHub | **Yes** |
 | Public landing joinable list | PublicHub | **Yes** |
 | Front desk registration live | FrontDeskHub | **Mostly** — check-in/flags/counts; person CRUD event mismatch |

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -7,7 +7,7 @@ import { useNotifications } from "@/composables/useNotifications";
 import { getActiveElectionHubGuid } from "@/utils/activeElectionHubStorage";
 import { formatNumber } from "@/utils/formatNumber";
 import { Plus, RefreshRight, Search, Upload } from "@element-plus/icons-vue";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { STAGES } from "../domain/electionStages";
@@ -204,10 +204,20 @@ onMounted(async () => {
   await loadData();
 });
 
+onUnmounted(() => {
+  void electionStore.leaveDashboardElections();
+});
+
 async function loadData() {
   try {
     await electionStore.fetchElections();
     await electionStore.initializeSignalR();
+    // Known tellers: multi-join MainHub so statusChanged updates all list cards
+    // (v3 JoinAll). Guest tellers skip; store enforces isFullTeller.
+    const guids = electionStore.elections
+      .map((e) => e.electionGuid)
+      .filter((g): g is string => !!g);
+    await electionStore.joinDashboardElections(guids);
   } catch (error) {
     handleApiError(error);
   }

--- a/frontend/src/pages/__tests__/DashboardPage.test.ts
+++ b/frontend/src/pages/__tests__/DashboardPage.test.ts
@@ -26,6 +26,8 @@ vi.mock("@/stores/electionStore", () => ({
     loading: false,
     fetchElections: vi.fn().mockResolvedValue(undefined),
     initializeSignalR: vi.fn().mockResolvedValue(undefined),
+    joinDashboardElections: vi.fn().mockResolvedValue(undefined),
+    leaveDashboardElections: vi.fn().mockResolvedValue(undefined),
   }),
 }));
 

--- a/frontend/src/services/__tests__/signalrService.dashboard.spec.ts
+++ b/frontend/src/services/__tests__/signalrService.dashboard.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HubConnectionState } from "@microsoft/signalr";
+
+const invoke = vi.fn();
+const start = vi.fn().mockResolvedValue(undefined);
+const stop = vi.fn().mockResolvedValue(undefined);
+const on = vi.fn();
+const onclose = vi.fn();
+const onreconnecting = vi.fn();
+const onreconnected = vi.fn();
+
+vi.mock("@microsoft/signalr", () => {
+  class HubConnectionBuilder {
+    withUrl() {
+      return this;
+    }
+    withAutomaticReconnect() {
+      return this;
+    }
+    configureLogging() {
+      return this;
+    }
+    build() {
+      return {
+        state: HubConnectionState.Connected,
+        start,
+        stop,
+        invoke,
+        on,
+        onclose,
+        onreconnecting,
+        onreconnected,
+      };
+    }
+  }
+  return {
+    HubConnectionBuilder,
+    HubConnectionState: {
+      Connected: "Connected",
+      Disconnected: "Disconnected",
+      Connecting: "Connecting",
+      Reconnecting: "Reconnecting",
+    },
+    LogLevel: { Warning: 2 },
+  };
+});
+
+vi.mock("@/config/appConfig", () => ({
+  getAppConfig: () => ({ apiUrl: "http://localhost:5016" }),
+}));
+
+vi.mock("@/utils/clientIdStorage", () => ({
+  getOrCreateClientId: () => "client-1",
+}));
+
+vi.mock("@/utils/computerCodeStorage", () => ({
+  setComputerCode: vi.fn(),
+}));
+
+describe("signalrService dashboard multi-join", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    invoke.mockReset().mockResolvedValue(undefined);
+    start.mockClear();
+    stop.mockClear();
+  });
+
+  it("invokes JoinElections and tracks guids for leave", async () => {
+    const { signalrService } = await import("../signalrService");
+    await signalrService.connectToMainHub();
+
+    await signalrService.joinDashboardElections([
+      "e1",
+      "e2",
+      "e1",
+      "  ",
+    ]);
+
+    expect(invoke).toHaveBeenCalledWith("JoinElections", ["e1", "e2"]);
+
+    await signalrService.leaveDashboardElections();
+    expect(invoke).toHaveBeenCalledWith("LeaveElections", ["e1", "e2"]);
+  });
+
+  it("preserves active main election when leaving dashboard set", async () => {
+    const { signalrService } = await import("../signalrService");
+    await signalrService.connectToMainHub();
+    invoke.mockResolvedValueOnce("A"); // JoinElection code
+    await signalrService.joinElection("e1");
+    invoke.mockClear();
+
+    await signalrService.joinDashboardElections(["e1", "e2"]);
+    expect(invoke).toHaveBeenCalledWith("JoinElections", ["e1", "e2"]);
+    invoke.mockClear();
+
+    await signalrService.leaveDashboardElections();
+    // e1 is the active workstation election — do not LeaveElections it
+    expect(invoke).toHaveBeenCalledWith("LeaveElections", ["e2"]);
+  });
+});

--- a/frontend/src/services/signalrService.ts
+++ b/frontend/src/services/signalrService.ts
@@ -9,6 +9,8 @@ class SignalRService {
   private readonly connectionStates: Map<string, ConnectionState> = new Map();
   private frontDeskElectionGuid: string | null = null;
   private mainElectionGuid: string | null = null;
+  /** Known-teller dashboard multi-election listen set (MainHub JoinElections). */
+  private dashboardElectionGuids: string[] = [];
   private publicGroupJoined = false;
 
   private get baseUrl(): string {
@@ -48,24 +50,43 @@ class SignalRService {
         `SignalR reconnected for ${hubPath}. Connection ID: ${connectionId}`,
       );
       this.connectionStates.set(hubPath, ConnectionState.Connected);
-      if (hubPath === "/hubs/main" && this.mainElectionGuid) {
-        try {
-          const assignedCode = (await connection.invoke(
-            "JoinElection",
-            this.mainElectionGuid,
-            getOrCreateClientId(),
-          )) as string;
-          if (assignedCode) {
-            setComputerCode(this.mainElectionGuid, assignedCode);
+      if (hubPath === "/hubs/main") {
+        if (this.mainElectionGuid) {
+          try {
+            const assignedCode = (await connection.invoke(
+              "JoinElection",
+              this.mainElectionGuid,
+              getOrCreateClientId(),
+            )) as string;
+            if (assignedCode) {
+              setComputerCode(this.mainElectionGuid, assignedCode);
+            }
+            console.log(
+              `Rejoined main election ${this.mainElectionGuid} after reconnect with code ${assignedCode}`,
+            );
+          } catch (error) {
+            console.error(
+              "Failed to rejoin main election after reconnect:",
+              error,
+            );
           }
-          console.log(
-            `Rejoined main election ${this.mainElectionGuid} after reconnect with code ${assignedCode}`,
-          );
-        } catch (error) {
-          console.error(
-            "Failed to rejoin main election after reconnect:",
-            error,
-          );
+        }
+
+        if (this.dashboardElectionGuids.length > 0) {
+          try {
+            await connection.invoke(
+              "JoinElections",
+              this.dashboardElectionGuids,
+            );
+            console.log(
+              `Rejoined ${this.dashboardElectionGuids.length} dashboard elections after reconnect`,
+            );
+          } catch (error) {
+            console.error(
+              "Failed to rejoin dashboard elections after reconnect:",
+              error,
+            );
+          }
         }
       }
 
@@ -216,6 +237,74 @@ class SignalRService {
     const frontDeskConnection = this.getConnection("/hubs/front-desk");
     if (frontDeskConnection) {
       await frontDeskConnection.invoke("LeaveElection", electionGuid);
+    }
+  }
+
+  /**
+   * Known-teller dashboard: join MainHub groups for many elections (listen-only).
+   * Replaces any previous dashboard multi-join set. Does not assign computer codes.
+   */
+  async joinDashboardElections(electionGuids: string[]): Promise<void> {
+    const unique = [
+      ...new Set(
+        electionGuids.map((g) => g.trim()).filter((g) => g.length > 0),
+      ),
+    ];
+
+    const previous = this.dashboardElectionGuids;
+    const toLeave = previous.filter((g) => !unique.includes(g));
+    // Keep active workstation membership if it is in the leave set — SignalR
+    // groups are not refcounted; leaving would drop the active JoinElection.
+    const leaveGuids = this.mainElectionGuid
+      ? toLeave.filter((g) => g !== this.mainElectionGuid)
+      : toLeave;
+
+    if (leaveGuids.length > 0) {
+      const mainConnection = this.getConnection("/hubs/main");
+      if (mainConnection) {
+        await mainConnection.invoke("LeaveElections", leaveGuids);
+      }
+    }
+
+    this.dashboardElectionGuids = unique;
+    if (unique.length === 0) {
+      return;
+    }
+
+    const mainConnection = this.getConnection("/hubs/main");
+    if (!mainConnection) {
+      throw new Error("Main hub is not connected");
+    }
+    if (mainConnection.state !== signalR.HubConnectionState.Connected) {
+      throw new Error(
+        `Main hub is not ready (state: ${mainConnection.state})`,
+      );
+    }
+
+    await mainConnection.invoke("JoinElections", unique);
+  }
+
+  /**
+   * Leave dashboard multi-election groups. Preserves active workstation
+   * MainHub membership when that election is still the main session election.
+   */
+  async leaveDashboardElections(): Promise<void> {
+    const guids = this.dashboardElectionGuids;
+    this.dashboardElectionGuids = [];
+    if (guids.length === 0) {
+      return;
+    }
+
+    const leaveGuids = this.mainElectionGuid
+      ? guids.filter((g) => g !== this.mainElectionGuid)
+      : guids;
+    if (leaveGuids.length === 0) {
+      return;
+    }
+
+    const mainConnection = this.getConnection("/hubs/main");
+    if (mainConnection) {
+      await mainConnection.invoke("LeaveElections", leaveGuids);
     }
   }
 

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -420,6 +420,12 @@ export const useAuthStore = defineStore("auth", () => {
 
     clearClientSessionSelections();
 
+    try {
+      await signalrService.leaveDashboardElections();
+    } catch {
+      // Best-effort hub cleanup before redirect.
+    }
+
     const activeElectionHubGuid = getActiveElectionHubGuid();
     if (activeElectionHubGuid) {
       try {

--- a/frontend/src/stores/electionStore.test.ts
+++ b/frontend/src/stores/electionStore.test.ts
@@ -28,8 +28,20 @@ vi.mock("../services/signalrService", () => ({
     connectToFrontDeskHub: vi.fn(),
     joinElection: vi.fn(),
     leaveElection: vi.fn(),
+    joinDashboardElections: vi.fn(),
+    leaveDashboardElections: vi.fn(),
   },
 }));
+
+vi.mock("@/domain/guestTellerAccess", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/domain/guestTellerAccess")>();
+  return {
+    ...actual,
+    isFullTeller: vi.fn(() => true),
+    isGuestTeller: vi.fn(() => false),
+  };
+});
 
 const elMessageMock = vi.fn();
 
@@ -560,6 +572,43 @@ describe("Election Store", () => {
       await electionStore.leaveElection("election-123");
 
       expect(signalrService.leaveElection).toHaveBeenCalledWith("election-123");
+    });
+  });
+
+  describe("joinDashboardElections and leaveDashboardElections", () => {
+    it("joins dashboard elections for known tellers after initializing SignalR", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const { isFullTeller } = await import("@/domain/guestTellerAccess");
+      vi.mocked(isFullTeller).mockReturnValue(true);
+      signalrService.connectToMainHub.mockResolvedValue({ on: vi.fn() });
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
+      signalrService.joinDashboardElections.mockResolvedValue(undefined);
+
+      await electionStore.joinDashboardElections(["e1", "e2"]);
+
+      expect(signalrService.connectToMainHub).toHaveBeenCalled();
+      expect(signalrService.joinDashboardElections).toHaveBeenCalledWith([
+        "e1",
+        "e2",
+      ]);
+    });
+
+    it("skips multi-join for guest tellers", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const { isFullTeller } = await import("@/domain/guestTellerAccess");
+      vi.mocked(isFullTeller).mockReturnValue(false);
+
+      await electionStore.joinDashboardElections(["e1"]);
+
+      expect(signalrService.joinDashboardElections).not.toHaveBeenCalled();
+    });
+
+    it("leaves dashboard election groups", async () => {
+      const { signalrService } = await import("../services/signalrService");
+
+      await electionStore.leaveDashboardElections();
+
+      expect(signalrService.leaveDashboardElections).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -1,4 +1,4 @@
-import { isGuestTeller } from "@/domain/guestTellerAccess";
+import { isFullTeller, isGuestTeller } from "@/domain/guestTellerAccess";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import { electionService } from "../services/electionService";
@@ -377,6 +377,31 @@ export const useElectionStore = defineStore("election", () => {
     }
   }
 
+  /**
+   * Known tellers on the elections dashboard: listen to statusChanged for all
+   * managed elections (v3 MainHub JoinAll). No-op for guest tellers.
+   */
+  async function joinDashboardElections(electionGuids: string[]) {
+    if (!isFullTeller()) {
+      return;
+    }
+
+    try {
+      await initializeSignalR();
+      await signalrService.joinDashboardElections(electionGuids);
+    } catch (e) {
+      console.error("Failed to join dashboard election groups:", e);
+    }
+  }
+
+  async function leaveDashboardElections() {
+    try {
+      await signalrService.leaveDashboardElections();
+    } catch (e) {
+      console.error("Failed to leave dashboard election groups:", e);
+    }
+  }
+
   async function setActiveElectionHub(electionGuid: string) {
     const previousGuid = getActiveElectionHubGuid();
     if (previousGuid && previousGuid !== electionGuid) {
@@ -488,6 +513,8 @@ export const useElectionStore = defineStore("election", () => {
     initializeSignalR,
     joinElection,
     leaveElection,
+    joinDashboardElections,
+    leaveDashboardElections,
     setActiveElectionHub,
     ensureActiveElectionHubConnection,
     clearActiveElectionHubConnection,


### PR DESCRIPTION
## Summary

- Restores v3 MainHub `JoinAll` parity: known tellers on the elections dashboard multi-join MainHub groups so `statusChanged` updates all list cards without opening each election.
- Backend adds `JoinElections` / `LeaveElections` (membership-checked, known-only, no computer codes); frontend wires dashboard load/unmount, reconnect, and logout cleanup while preserving active workstation membership.

## Test plan

- [ ] As a known teller with multiple elections, open the dashboard; change stage/status on one election from another session and confirm the list card updates live.
- [ ] Guest tellers are not multi-joined (no `JoinElections` call / hub rejects guests).
- [ ] Leaving the dashboard stops multi-listen; an already-open active election still receives MainHub updates.
- [ ] Reconnect while on the dashboard re-joins the multi-election set.
- [ ] Logout cleans up multi-join groups.
- [ ] `dotnet test --filter FullyQualifiedName~MainHubTests` and frontend dashboard/signalr/electionStore unit tests pass.

Closes #230