### PR TITLE
Add online voter SignalR hubs (AllVoters + VoterPersonal) (#233)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Do not assume every backend response uses the same wrapper.
 
 ### SignalR group naming and hubs
 
-There are 6 hubs under `backend/Hubs/`. **Do not assume a single `election-{guid}` convention** (the previous short recommendation is not present in code).
+There are 9 hubs under `backend/Hubs/`. **Do not assume a single `election-{guid}` convention** (the previous short recommendation is not present in code).
 
 Group name patterns (constructed via `GetGroupName` statics in each hub + used for broadcasts in `SignalRNotificationService.cs`):
 
@@ -114,8 +114,10 @@ Group name patterns (constructed via `GetGroupName` statics in each hub + used f
 - `PeopleImport{electionGuid}` — PeopleImportHub (same event names; progress payload `{ processed, total, status }`).
 - `ElectionPackageImport{userId}` — ElectionPackageImportHub (loaderStatus message + isTemporary; known teller; package load on dashboard).
 - `Public` (static group) — PublicHub for guest-teller joinable elections list updates.
+- `AllVoters` (global) — AllVotersHub (`/hubs/all-voters`): thin `updateVoters` for online window/process; OnlineVoter JWT.
+- `Voter{voterId}` — VoterPersonalHub (`/hubs/voter-personal`): thin `updateVoter` (registration / login-elsewhere); group from JWT only.
 
-**Frontend side**: `src/services/signalrService.ts` provides `connectToMainHub()`, `connectToAnalyzeHub()`, `connectToFrontDeskHub()`, etc. + `joinElection(guid)`, `joinDashboardElections(guids)` (known-teller multi-listen), `joinTallySession(guid)`, etc. Stores (electionStore, ballotStore, peopleStore, etc.) call these and wire `connection.on("eventName", handler)`.
+**Frontend side**: `src/services/signalrService.ts` provides `connectToMainHub()`, `connectToAnalyzeHub()`, `connectToFrontDeskHub()`, `connectVoterHubs()`, etc. + `joinElection(guid)`, `joinDashboardElections(guids)` (known-teller multi-listen), `joinTallySession(guid)`, etc. Stores (electionStore, ballotStore, peopleStore, onlineVotingStore, etc.) call these and wire `connection.on("eventName", handler)`.
 
 When adding or touching real-time features, update the matching hub + the corresponding method in `SignalRNotificationService.cs` (see examples at lines 55, 73, 92, 111, 135, 152, 170, 189) + the frontend service + any store subscriptions together.
 

--- a/Backend.Tests/UnitTests/Hubs/AllVotersHubTests.cs
+++ b/Backend.Tests/UnitTests/Hubs/AllVotersHubTests.cs
@@ -1,0 +1,62 @@
+using System.Security.Claims;
+using Backend.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Backend.Tests.UnitTests.Hubs;
+
+public class AllVotersHubTests
+{
+    private (AllVotersHub Hub, Mock<IGroupManager> Groups) CreateHub()
+    {
+        var hub = new AllVotersHub(NullLogger<AllVotersHub>.Instance);
+        var context = new Mock<HubCallerContext>();
+        context.Setup(c => c.ConnectionId).Returns("conn-all");
+        context.Setup(c => c.User).Returns(new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("voterId", "alice@example.com"),
+            new Claim("voterType", "online"),
+        ], "TestAuth")));
+
+        var groups = new Mock<IGroupManager>();
+        groups
+            .Setup(g => g.AddToGroupAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        groups
+            .Setup(g => g.RemoveFromGroupAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        hub.Context = context.Object;
+        hub.Groups = groups.Object;
+        return (hub, groups);
+    }
+
+    [Fact]
+    public async Task Join_adds_to_global_AllVoters_group()
+    {
+        var (hub, groups) = CreateHub();
+
+        await hub.Join();
+
+        groups.Verify(
+            g => g.AddToGroupAsync(
+                "conn-all",
+                AllVotersHub.GetGroupName(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetGroupName_is_global_AllVoters()
+    {
+        Assert.Equal("AllVoters", AllVotersHub.GetGroupName());
+    }
+}

--- a/Backend.Tests/UnitTests/Hubs/VoterPersonalHubTests.cs
+++ b/Backend.Tests/UnitTests/Hubs/VoterPersonalHubTests.cs
@@ -1,0 +1,91 @@
+using System.Security.Claims;
+using Backend.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Backend.Tests.UnitTests.Hubs;
+
+/// <summary>
+/// Ensures personal groups are server-derived from the JWT voterId claim
+/// (voter A cannot join voter B's group).
+/// </summary>
+public class VoterPersonalHubTests
+{
+    private (VoterPersonalHub Hub, Mock<IGroupManager> Groups) CreateHub(ClaimsPrincipal? user)
+    {
+        var hub = new VoterPersonalHub(NullLogger<VoterPersonalHub>.Instance);
+        var context = new Mock<HubCallerContext>();
+        context.Setup(c => c.ConnectionId).Returns("conn-voter");
+        context.Setup(c => c.User).Returns(user!);
+
+        var groups = new Mock<IGroupManager>();
+        groups
+            .Setup(g => g.AddToGroupAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        groups
+            .Setup(g => g.RemoveFromGroupAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        hub.Context = context.Object;
+        hub.Groups = groups.Object;
+        return (hub, groups);
+    }
+
+    private static ClaimsPrincipal OnlineVoterPrincipal(string voterId)
+    {
+        return new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("voterId", voterId),
+            new Claim("voterIdType", "E"),
+            new Claim("voterType", "online"),
+        ], "TestAuth"));
+    }
+
+    [Fact]
+    public async Task Join_uses_server_voterId_claim_for_group()
+    {
+        const string voterId = "alice@example.com";
+        var (hub, groups) = CreateHub(OnlineVoterPrincipal(voterId));
+
+        await hub.Join();
+
+        groups.Verify(
+            g => g.AddToGroupAsync(
+                "conn-voter",
+                VoterPersonalHub.GetGroupName(voterId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        groups.Verify(
+            g => g.AddToGroupAsync(
+                "conn-voter",
+                VoterPersonalHub.GetGroupName("bob@example.com"),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Join_without_voterId_throws()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("voterType", "online"),
+        ], "TestAuth"));
+        var (hub, _) = CreateHub(user);
+
+        await Assert.ThrowsAsync<HubException>(() => hub.Join());
+    }
+
+    [Fact]
+    public void GetGroupName_prefixes_voter_id()
+    {
+        Assert.Equal("Voteralice@example.com", VoterPersonalHub.GetGroupName("alice@example.com"));
+    }
+}

--- a/Backend.Tests/UnitTests/Hubs/VoterPersonalHubTests.cs
+++ b/Backend.Tests/UnitTests/Hubs/VoterPersonalHubTests.cs
@@ -88,4 +88,27 @@ public class VoterPersonalHubTests
     {
         Assert.Equal("Voteralice@example.com", VoterPersonalHub.GetGroupName("alice@example.com"));
     }
+
+    [Fact]
+    public void GetGroupName_trims_whitespace()
+    {
+        Assert.Equal(
+            "Voteralice@example.com",
+            VoterPersonalHub.GetGroupName("  alice@example.com  "));
+    }
+
+    [Fact]
+    public async Task Join_trims_voterId_claim_for_group()
+    {
+        var (hub, groups) = CreateHub(OnlineVoterPrincipal("  alice@example.com  "));
+
+        await hub.Join();
+
+        groups.Verify(
+            g => g.AddToGroupAsync(
+                "conn-voter",
+                "Voteralice@example.com",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
@@ -24,6 +24,8 @@ public class SignalRNotificationServiceTests
         Mock<IHubClients> BallotImportClients,
         Mock<IHubClients> PeopleImportClients,
         Mock<IHubClients> ElectionPackageImportClients,
+        Mock<IHubClients> AllVotersClients,
+        Mock<IHubClients> VoterPersonalClients,
         Dictionary<string, Mock<IClientProxy>> GroupProxies) CreateService()
     {
         var mainHub = new Mock<IHubContext<MainHub>>();
@@ -33,11 +35,15 @@ public class SignalRNotificationServiceTests
         var electionPackageImportHub = new Mock<IHubContext<ElectionPackageImportHub>>();
         var frontDeskHub = new Mock<IHubContext<FrontDeskHub>>();
         var publicHub = new Mock<IHubContext<PublicHub>>();
+        var allVotersHub = new Mock<IHubContext<AllVotersHub>>();
+        var voterPersonalHub = new Mock<IHubContext<VoterPersonalHub>>();
         var mainClients = new Mock<IHubClients>();
         var frontDeskClients = new Mock<IHubClients>();
         var ballotImportClients = new Mock<IHubClients>();
         var peopleImportClients = new Mock<IHubClients>();
         var electionPackageImportClients = new Mock<IHubClients>();
+        var allVotersClients = new Mock<IHubClients>();
+        var voterPersonalClients = new Mock<IHubClients>();
         var groupProxies = new Dictionary<string, Mock<IClientProxy>>();
 
         Mock<IClientProxy> GetOrCreateProxy(string groupName)
@@ -62,6 +68,8 @@ public class SignalRNotificationServiceTests
         ballotImportHub.Setup(h => h.Clients).Returns(ballotImportClients.Object);
         peopleImportHub.Setup(h => h.Clients).Returns(peopleImportClients.Object);
         electionPackageImportHub.Setup(h => h.Clients).Returns(electionPackageImportClients.Object);
+        allVotersHub.Setup(h => h.Clients).Returns(allVotersClients.Object);
+        voterPersonalHub.Setup(h => h.Clients).Returns(voterPersonalClients.Object);
         mainClients
             .Setup(c => c.Group(It.IsAny<string>()))
             .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
@@ -77,6 +85,12 @@ public class SignalRNotificationServiceTests
         electionPackageImportClients
             .Setup(c => c.Group(It.IsAny<string>()))
             .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
+        allVotersClients
+            .Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
+        voterPersonalClients
+            .Setup(c => c.Group(It.IsAny<string>()))
+            .Returns((string groupName) => GetOrCreateProxy(groupName).Object);
 
         var service = new SignalRNotificationService(
             mainHub.Object,
@@ -86,15 +100,26 @@ public class SignalRNotificationServiceTests
             electionPackageImportHub.Object,
             frontDeskHub.Object,
             publicHub.Object,
+            allVotersHub.Object,
+            voterPersonalHub.Object,
             NullLogger<SignalRNotificationService>.Instance);
 
-        return (service, mainClients, frontDeskClients, ballotImportClients, peopleImportClients, electionPackageImportClients, groupProxies);
+        return (
+            service,
+            mainClients,
+            frontDeskClients,
+            ballotImportClients,
+            peopleImportClients,
+            electionPackageImportClients,
+            allVotersClients,
+            voterPersonalClients,
+            groupProxies);
     }
 
     [Fact]
     public async Task SendElectionUpdateAsync_sends_statusChanged_to_base_Main_group()
     {
-        var (service, mainClients, _, _, _, _, groupProxies) = CreateService();
+        var (service, mainClients, _, _, _, _, _, _, groupProxies) = CreateService();
         var update = new ElectionUpdateDto
         {
             ElectionGuid = _electionGuid,
@@ -132,7 +157,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task CloseOutGuestTellersAsync_sends_electionClosed_to_Guest_group_only()
     {
-        var (service, mainClients, _, _, _, _, groupProxies) = CreateService();
+        var (service, mainClients, _, _, _, _, _, _, groupProxies) = CreateService();
         var baseGroup = MainHub.GetGroupName(_electionGuid);
         var guestGroup = baseGroup + "Guest";
 
@@ -160,7 +185,7 @@ public class SignalRNotificationServiceTests
         string action,
         string expectedEvent)
     {
-        var (service, _, frontDeskClients, _, _, _, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, _, _, _, groupProxies) = CreateService();
         var personGuid = Guid.Parse("33333333-3333-3333-3333-333333333333");
         var update = new PersonUpdateDto
         {
@@ -197,7 +222,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task NotifyVoterCountUpdatedAsync_sends_VoterCountUpdated_to_FrontDesk_group()
     {
-        var (service, _, frontDeskClients, _, _, _, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, _, _, _, groupProxies) = CreateService();
         var stats = new FrontDeskStatsDto
         {
             TotalEligible = 100,
@@ -229,9 +254,9 @@ public class SignalRNotificationServiceTests
     }
 
     [Fact]
-    public async Task SendOnlineElectionUpdateAsync_sends_updateOnlineElection_to_FrontDesk_group()
+    public async Task SendOnlineElectionUpdateAsync_sends_updateOnlineElection_to_FrontDesk_and_updateVoters_to_AllVoters()
     {
-        var (service, _, frontDeskClients, _, _, _, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, _, allVotersClients, _, groupProxies) = CreateService();
         var open = DateTimeOffset.Parse("2026-04-01T12:00:00Z");
         var close = DateTimeOffset.Parse("2026-04-02T12:00:00Z");
         var update = new OnlineElectionUpdateDto
@@ -242,20 +267,30 @@ public class SignalRNotificationServiceTests
             OnlineCloseIsEstimate = true,
             OnlineSelectionProcess = "A"
         };
-        var expectedGroup = FrontDeskHub.GetGroupName(_electionGuid);
+        var frontDeskGroup = FrontDeskHub.GetGroupName(_electionGuid);
+        var allVotersGroup = AllVotersHub.GetGroupName();
 
         await service.SendOnlineElectionUpdateAsync(update);
 
-        frontDeskClients.Verify(c => c.Group(expectedGroup), Times.Once);
-        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
-        proxy!.Verify(
+        frontDeskClients.Verify(c => c.Group(frontDeskGroup), Times.Once);
+        allVotersClients.Verify(c => c.Group(allVotersGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(frontDeskGroup, out var frontDeskProxy));
+        frontDeskProxy!.Verify(
             p => p.SendCoreAsync(
                 "updateOnlineElection",
                 It.IsAny<object?[]>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
 
-        var invocation = proxy.Invocations.Single(i =>
+        Assert.True(groupProxies.TryGetValue(allVotersGroup, out var allVotersProxy));
+        allVotersProxy!.Verify(
+            p => p.SendCoreAsync(
+                "updateVoters",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = frontDeskProxy.Invocations.Single(i =>
             i.Method.Name == nameof(IClientProxy.SendCoreAsync)
             && Equals(i.Arguments[0], "updateOnlineElection"));
         var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
@@ -269,9 +304,72 @@ public class SignalRNotificationServiceTests
     }
 
     [Fact]
+    public async Task NotifyVoterPersonalUpdateAsync_sends_updateVoter_only_to_person_identity_groups()
+    {
+        var (service, _, _, _, _, _, _, voterPersonalClients, groupProxies) = CreateService();
+        var update = new VoterPersonalUpdateDto
+        {
+            UpdateRegistration = true,
+            ElectionGuid = _electionGuid,
+            VotingMethod = "P",
+            RegistrationTime = DateTimeOffset.Parse("2026-04-01T12:00:00Z")
+        };
+
+        await service.NotifyVoterPersonalUpdateAsync(
+            "alice@example.com",
+            "+15551212",
+            null,
+            update);
+
+        var emailGroup = VoterPersonalHub.GetGroupName("alice@example.com");
+        var phoneGroup = VoterPersonalHub.GetGroupName("+15551212");
+        var otherGroup = VoterPersonalHub.GetGroupName("bob@example.com");
+
+        voterPersonalClients.Verify(c => c.Group(emailGroup), Times.Once);
+        voterPersonalClients.Verify(c => c.Group(phoneGroup), Times.Once);
+        voterPersonalClients.Verify(c => c.Group(otherGroup), Times.Never);
+
+        Assert.True(groupProxies.TryGetValue(emailGroup, out var emailProxy));
+        emailProxy!.Verify(
+            p => p.SendCoreAsync(
+                "updateVoter",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.False(groupProxies.ContainsKey(otherGroup));
+    }
+
+    [Fact]
+    public async Task NotifyVoterLoginElsewhereAsync_sends_login_updateVoter_to_voter_group()
+    {
+        var (service, _, _, _, _, _, _, voterPersonalClients, groupProxies) = CreateService();
+        const string voterId = "alice@example.com";
+        var expectedGroup = VoterPersonalHub.GetGroupName(voterId);
+
+        await service.NotifyVoterLoginElsewhereAsync(voterId);
+
+        voterPersonalClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "updateVoter",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "updateVoter"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        var dto = Assert.IsType<VoterPersonalUpdateDto>(capturedArgs[0]);
+        Assert.True(dto.Login);
+        Assert.False(dto.UpdateRegistration);
+    }
+
+    [Fact]
     public async Task RequestFrontDeskReloadAsync_sends_reloadPage_to_FrontDesk_group()
     {
-        var (service, _, frontDeskClients, _, _, _, groupProxies) = CreateService();
+        var (service, _, frontDeskClients, _, _, _, _, _, groupProxies) = CreateService();
         var expectedGroup = FrontDeskHub.GetGroupName(_electionGuid);
 
         await service.RequestFrontDeskReloadAsync(_electionGuid);
@@ -289,7 +387,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task SendImportProgressAsync_sends_camelCase_importProgress_to_BallotImport_group()
     {
-        var (service, _, _, ballotImportClients, _, _, groupProxies) = CreateService();
+        var (service, _, _, ballotImportClients, _, _, _, _, groupProxies) = CreateService();
         var progress = new ImportProgressDto
         {
             ElectionGuid = _electionGuid,
@@ -335,7 +433,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task SendImportCompleteAsync_sends_camelCase_importComplete_to_BallotImport_group()
     {
-        var (service, _, _, ballotImportClients, _, _, groupProxies) = CreateService();
+        var (service, _, _, ballotImportClients, _, _, _, _, groupProxies) = CreateService();
         var expectedGroup = BallotImportHub.GetGroupName(_electionGuid);
         var summary = new { ballotsCreated = 5 };
 
@@ -360,7 +458,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task SendImportErrorAsync_sends_importError_with_message_and_row()
     {
-        var (service, _, _, ballotImportClients, _, _, groupProxies) = CreateService();
+        var (service, _, _, ballotImportClients, _, _, _, _, groupProxies) = CreateService();
         var expectedGroup = BallotImportHub.GetGroupName(_electionGuid);
 
         await service.SendImportErrorAsync(_electionGuid, "bad row", 12);
@@ -379,7 +477,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task SendPeopleImportProgressAsync_sends_object_payload_to_PeopleImport_group()
     {
-        var (service, _, _, _, peopleImportClients, _, groupProxies) = CreateService();
+        var (service, _, _, _, peopleImportClients, _, _, _, groupProxies) = CreateService();
         var expectedGroup = PeopleImportHub.GetGroupName(_electionGuid);
 
         await service.SendPeopleImportProgressAsync(_electionGuid, 3, 10, "Processing row 3");
@@ -411,7 +509,7 @@ public class SignalRNotificationServiceTests
     [Fact]
     public async Task SendElectionPackageLoaderStatusAsync_sends_loaderStatus_to_user_group()
     {
-        var (service, _, _, _, _, packageClients, groupProxies) = CreateService();
+        var (service, _, _, _, _, packageClients, _, _, groupProxies) = CreateService();
         var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
         var expectedGroup = ElectionPackageImportHub.GetGroupName(userId);
 

--- a/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
@@ -367,6 +367,24 @@ public class SignalRNotificationServiceTests
     }
 
     [Fact]
+    public async Task NotifyVoterLoginElsewhereAsync_trims_voterId_for_group_name()
+    {
+        var (service, _, _, _, _, _, _, voterPersonalClients, groupProxies) = CreateService();
+        var expectedGroup = VoterPersonalHub.GetGroupName("alice@example.com");
+
+        await service.NotifyVoterLoginElsewhereAsync("  alice@example.com  ");
+
+        voterPersonalClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "updateVoter",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task RequestFrontDeskReloadAsync_sends_reloadPage_to_FrontDesk_group()
     {
         var (service, _, frontDeskClients, _, _, _, _, _, groupProxies) = CreateService();

--- a/backend/DTOs/SignalR/VoterPersonalUpdateDto.cs
+++ b/backend/DTOs/SignalR/VoterPersonalUpdateDto.cs
@@ -1,0 +1,35 @@
+namespace Backend.DTOs.SignalR;
+
+/// <summary>
+/// Thin SignalR payload for a connected online voter's personal channel
+/// (VoterPersonalHub <c>updateVoter</c>). Clients re-fetch status / election list;
+/// do not push tallies or rich private election detail.
+/// </summary>
+public class VoterPersonalUpdateDto
+{
+    /// <summary>
+    /// When true, front desk (or processing) changed this voter's registration / voting method.
+    /// Client should re-fetch available elections and vote status for the election.
+    /// </summary>
+    public bool UpdateRegistration { get; set; }
+
+    /// <summary>
+    /// Election whose registration changed (when <see cref="UpdateRegistration"/> is true).
+    /// </summary>
+    public Guid? ElectionGuid { get; set; }
+
+    /// <summary>
+    /// Current voting method code after the change (optional thin hint; client may ignore and re-fetch).
+    /// </summary>
+    public string? VotingMethod { get; set; }
+
+    /// <summary>
+    /// Registration timestamp after the change (null when unregistered).
+    /// </summary>
+    public DateTimeOffset? RegistrationTime { get; set; }
+
+    /// <summary>
+    /// When true, the same voter identity authenticated on another browser/device (v3 <c>login: true</c>).
+    /// </summary>
+    public bool Login { get; set; }
+}

--- a/backend/Hubs/AllVotersHub.cs
+++ b/backend/Hubs/AllVotersHub.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Backend.Hubs;
+
+/// <summary>
+/// SignalR hub for connected online voters (v3 AllVotersHub parity).
+/// Global group receives thin online-settings change signals so clients re-fetch
+/// <c>GET availableElections</c> (and related status APIs). Server push only via
+/// <see cref="Backend.Services.ISignalRNotificationService"/> / <c>IHubContext&lt;AllVotersHub&gt;</c>.
+/// </summary>
+[Authorize(Policy = "OnlineVoter")]
+public class AllVotersHub : Hub
+{
+    private readonly ILogger<AllVotersHub> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AllVotersHub"/> class.
+    /// </summary>
+    public AllVotersHub(ILogger<AllVotersHub> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Adds the authenticated online voter to the global all-voters group.
+    /// </summary>
+    public async Task Join()
+    {
+        var groupName = GetGroupName();
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+        _logger.LogInformation(
+            "Client {ConnectionId} joined AllVoters group",
+            Context.ConnectionId);
+    }
+
+    /// <summary>
+    /// Removes the client from the global all-voters group.
+    /// </summary>
+    public async Task Leave()
+    {
+        var groupName = GetGroupName();
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+        _logger.LogInformation(
+            "Client {ConnectionId} left AllVoters group",
+            Context.ConnectionId);
+    }
+
+    /// <inheritdoc />
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        _logger.LogInformation(
+            "Client {ConnectionId} disconnected from AllVotersHub",
+            Context.ConnectionId);
+        await base.OnDisconnectedAsync(exception);
+    }
+
+    /// <summary>
+    /// Global group for all connected online voters (v3 <c>AllVoters</c>).
+    /// Chosen over per-election groups so a single join covers list refresh when any
+    /// election's online window changes; clients re-fetch and filter server-side eligibility.
+    /// </summary>
+    public static string GetGroupName() => "AllVoters";
+}

--- a/backend/Hubs/VoterPersonalHub.cs
+++ b/backend/Hubs/VoterPersonalHub.cs
@@ -1,0 +1,80 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Backend.Hubs;
+
+/// <summary>
+/// SignalR hub for per-voter personal updates (v3 VoterPersonalHub parity).
+/// Group is derived from the JWT <c>voterId</c> claim — clients cannot join another voter's group.
+/// Server push only via <see cref="Backend.Services.ISignalRNotificationService"/> /
+/// <c>IHubContext&lt;VoterPersonalHub&gt;</c>.
+/// </summary>
+[Authorize(Policy = "OnlineVoter")]
+public class VoterPersonalHub : Hub
+{
+    private readonly ILogger<VoterPersonalHub> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VoterPersonalHub"/> class.
+    /// </summary>
+    public VoterPersonalHub(ILogger<VoterPersonalHub> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Joins the caller's personal voter group (server-derived from JWT voterId).
+    /// </summary>
+    public async Task Join()
+    {
+        var voterId = GetVoterId(Context.User);
+        if (string.IsNullOrWhiteSpace(voterId))
+        {
+            throw new HubException("Authenticated online voter id is required.");
+        }
+
+        var groupName = GetGroupName(voterId);
+        await Groups.AddToGroupAsync(Context.ConnectionId, groupName);
+        _logger.LogInformation(
+            "Client {ConnectionId} joined personal voter group",
+            Context.ConnectionId);
+    }
+
+    /// <summary>
+    /// Leaves the caller's personal voter group.
+    /// </summary>
+    public async Task Leave()
+    {
+        var voterId = GetVoterId(Context.User);
+        if (string.IsNullOrWhiteSpace(voterId))
+        {
+            return;
+        }
+
+        var groupName = GetGroupName(voterId);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, groupName);
+        _logger.LogInformation(
+            "Client {ConnectionId} left personal voter group",
+            Context.ConnectionId);
+    }
+
+    /// <inheritdoc />
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        _logger.LogInformation(
+            "Client {ConnectionId} disconnected from VoterPersonalHub",
+            Context.ConnectionId);
+        await base.OnDisconnectedAsync(exception);
+    }
+
+    /// <summary>
+    /// Personal group for one online voter identity (email, phone, or kiosk code).
+    /// </summary>
+    public static string GetGroupName(string voterId) => $"Voter{voterId}";
+
+    private static string? GetVoterId(ClaimsPrincipal? user)
+    {
+        return user?.FindFirst("voterId")?.Value;
+    }
+}

--- a/backend/Hubs/VoterPersonalHub.cs
+++ b/backend/Hubs/VoterPersonalHub.cs
@@ -70,11 +70,17 @@ public class VoterPersonalHub : Hub
 
     /// <summary>
     /// Personal group for one online voter identity (email, phone, or kiosk code).
+    /// Always trims so join paths and server fan-out use the same group key.
     /// </summary>
-    public static string GetGroupName(string voterId) => $"Voter{voterId}";
+    public static string GetGroupName(string voterId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(voterId);
+        return $"Voter{voterId.Trim()}";
+    }
 
-private static string? GetVoterId(ClaimsPrincipal? user)
-{
-    var voterId = user?.FindFirst("voterId")?.Value;
-    return string.IsNullOrWhiteSpace(voterId) ? null : voterId.Trim();
+    private static string? GetVoterId(ClaimsPrincipal? user)
+    {
+        var voterId = user?.FindFirst("voterId")?.Value;
+        return string.IsNullOrWhiteSpace(voterId) ? null : voterId.Trim();
+    }
 }

--- a/backend/Hubs/VoterPersonalHub.cs
+++ b/backend/Hubs/VoterPersonalHub.cs
@@ -73,8 +73,8 @@ public class VoterPersonalHub : Hub
     /// </summary>
     public static string GetGroupName(string voterId) => $"Voter{voterId}";
 
-    private static string? GetVoterId(ClaimsPrincipal? user)
-    {
-        return user?.FindFirst("voterId")?.Value;
-    }
+private static string? GetVoterId(ClaimsPrincipal? user)
+{
+    var voterId = user?.FindFirst("voterId")?.Value;
+    return string.IsNullOrWhiteSpace(voterId) ? null : voterId.Trim();
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -568,6 +568,8 @@ async Task ConfigureApp(WebApplication app, IConfiguration configuration)
     app.MapHub<Backend.Hubs.ElectionPackageImportHub>("/hubs/election-package-import");
     app.MapHub<Backend.Hubs.FrontDeskHub>("/hubs/front-desk");
     app.MapHub<Backend.Hubs.PublicHub>("/hubs/public");
+    app.MapHub<Backend.Hubs.AllVotersHub>("/hubs/all-voters");
+    app.MapHub<Backend.Hubs.VoterPersonalHub>("/hubs/voter-personal");
 
     app.MapGet("/protected", () => "This is protected!").RequireAuthorization();
 

--- a/backend/Services/FrontDeskService.cs
+++ b/backend/Services/FrontDeskService.cs
@@ -88,6 +88,7 @@ public class FrontDeskService : IFrontDeskService
         var voterDto = MapToFrontDeskVoterDto(person);
 
         await _signalRNotificationService.NotifyPersonCheckedInAsync(electionGuid, voterDto);
+        await NotifyVoterPersonalRegistrationAsync(person);
 
         var stats = await GetStatsAsync(electionGuid);
         await _signalRNotificationService.NotifyVoterCountUpdatedAsync(electionGuid, stats);
@@ -169,6 +170,7 @@ public class FrontDeskService : IFrontDeskService
         var voterDto = MapToFrontDeskVoterDto(person);
 
         await _signalRNotificationService.NotifyPersonCheckedInAsync(electionGuid, voterDto);
+        await NotifyVoterPersonalRegistrationAsync(person);
 
         var stats = await GetStatsAsync(electionGuid);
         await _signalRNotificationService.NotifyVoterCountUpdatedAsync(electionGuid, stats);
@@ -286,8 +288,28 @@ public class FrontDeskService : IFrontDeskService
 
         var voterDto = MapToFrontDeskVoterDto(person);
         await _signalRNotificationService.NotifyPersonCheckedInAsync(electionGuid, voterDto);
+        await NotifyVoterPersonalRegistrationAsync(person);
 
         return voterDto;
+    }
+
+    /// <summary>
+    /// Thin personal push so a connected online voter re-fetches status when front desk
+    /// changes their registration (v3 VoterPersonalHub parity).
+    /// </summary>
+    private Task NotifyVoterPersonalRegistrationAsync(Person person)
+    {
+        return _signalRNotificationService.NotifyVoterPersonalUpdateAsync(
+            person.Email,
+            person.Phone,
+            person.KioskCode,
+            new VoterPersonalUpdateDto
+            {
+                UpdateRegistration = true,
+                ElectionGuid = person.ElectionGuid,
+                VotingMethod = person.VotingMethod,
+                RegistrationTime = person.RegistrationTime
+            });
     }
 
     private static string? NormalizeTellerName(string? tellerName)

--- a/backend/Services/ISignalRNotificationService.cs
+++ b/backend/Services/ISignalRNotificationService.cs
@@ -122,10 +122,34 @@ public interface ISignalRNotificationService
     Task SendPersonFlagsUpdatedAsync(Guid electionGuid, FrontDeskVoterDto voter);
 
     /// <summary>
-    /// Notifies front desk / monitor clients that online open/close (or related) settings changed.
+    /// Notifies front desk / monitor clients and connected online voters that online open/close
+    /// (or related) settings changed. FrontDesk gets <c>updateOnlineElection</c>; AllVotersHub
+    /// gets <c>updateVoters</c> (same thin payload) so voters re-fetch available elections.
     /// </summary>
     /// <param name="update">Thin online-window payload for the election.</param>
     Task SendOnlineElectionUpdateAsync(OnlineElectionUpdateDto update);
+
+    /// <summary>
+    /// Notifies a voter's personal channel that their registration / voting method changed
+    /// (VoterPersonalHub <c>updateVoter</c>). Targets groups for the person's email, phone,
+    /// and kiosk code when present (server-derived; not client-supplied).
+    /// </summary>
+    /// <param name="email">Person email used as online voter id (if any).</param>
+    /// <param name="phone">Person phone used as online voter id (if any).</param>
+    /// <param name="kioskCode">Person kiosk code used as online voter id (if any).</param>
+    /// <param name="update">Thin personal update payload.</param>
+    Task NotifyVoterPersonalUpdateAsync(
+        string? email,
+        string? phone,
+        string? kioskCode,
+        VoterPersonalUpdateDto update);
+
+    /// <summary>
+    /// Notifies existing sessions for a voter identity that the same identity logged in elsewhere
+    /// (VoterPersonalHub <c>updateVoter</c> with <c>login: true</c>).
+    /// </summary>
+    /// <param name="voterId">Authenticated online voter id (email, phone, or kiosk code).</param>
+    Task NotifyVoterLoginElsewhereAsync(string voterId);
 
     /// <summary>
     /// Asks front desk (and other FrontDeskHub clients) to re-fetch state after bulk ballot import.

--- a/backend/Services/OnlineVotingService.cs
+++ b/backend/Services/OnlineVotingService.cs
@@ -31,6 +31,7 @@ public class OnlineVotingService : IOnlineVotingService
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IEmailSender _emailSender;
     private readonly IGoogleIdTokenValidator _googleIdTokenValidator;
+    private readonly ISignalRNotificationService _signalRNotificationService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OnlineVotingService"/> class.
@@ -42,6 +43,7 @@ public class OnlineVotingService : IOnlineVotingService
     /// <param name="httpClientFactory">The HTTP client factory.</param>
     /// <param name="emailSender">The email sender service.</param>
     /// <param name="googleIdTokenValidator">The Google ID token validator.</param>
+    /// <param name="signalRNotificationService">Realtime notifications for connected voter sessions.</param>
     public OnlineVotingService(
         MainDbContext context,
         IConfiguration configuration,
@@ -49,7 +51,8 @@ public class OnlineVotingService : IOnlineVotingService
         ILogger<OnlineVotingService> logger,
         IHttpClientFactory httpClientFactory,
         IEmailSender emailSender,
-        IGoogleIdTokenValidator googleIdTokenValidator)
+        IGoogleIdTokenValidator googleIdTokenValidator,
+        ISignalRNotificationService signalRNotificationService)
     {
         _context = context;
         _configuration = configuration;
@@ -58,6 +61,7 @@ public class OnlineVotingService : IOnlineVotingService
         _httpClientFactory = httpClientFactory;
         _emailSender = emailSender;
         _googleIdTokenValidator = googleIdTokenValidator;
+        _signalRNotificationService = signalRNotificationService;
     }
 
     /// <inheritdoc/>
@@ -202,6 +206,7 @@ public class OnlineVotingService : IOnlineVotingService
                 ExpiresAt = expiresAt
             };
 
+            await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
             _logger.LogInformation("Voter {VoterId} authenticated successfully", dto.VoterId);
 
             return (true, null, response);
@@ -590,6 +595,7 @@ public class OnlineVotingService : IOnlineVotingService
                 ExpiresAt = expiresAt
             };
 
+            await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
             _logger.LogInformation("Voter {Email} authenticated successfully via Google OAuth (registered in {Count} open election(s))",
                 email, openElections.Count);
 
@@ -752,6 +758,8 @@ public class OnlineVotingService : IOnlineVotingService
                 ExpiresAt = expiresAt
             };
 
+            await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
+
             _logger.LogInformation("Voter {Email} authenticated via Facebook OAuth (in {Count} open election(s))", email, openElections.Count);
             return (true, null, authResponse);
         }
@@ -860,6 +868,7 @@ public class OnlineVotingService : IOnlineVotingService
                 ExpiresAt = expiresAt
             };
 
+            await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
             _logger.LogInformation("Voter {VoterId} authenticated via Kakao OAuth (in {Count} open election(s))", matchedVoterId, openElections.Count);
             return (true, null, authResponse);
         }
@@ -928,6 +937,7 @@ public class OnlineVotingService : IOnlineVotingService
                 ExpiresAt = DateTimeOffset.UtcNow.AddHours(24)
             };
 
+            await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
             _logger.LogInformation("Voter {TelegramId} authenticated via Telegram Login Widget", dto.Id);
             return (true, null, authResponse);
         }
@@ -1296,9 +1306,19 @@ public class OnlineVotingService : IOnlineVotingService
             ExpiresAt = DateTimeOffset.UtcNow.AddHours(24)
         };
 
+        await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
         var safeVoterIdForLog = SanitizeForLog(normalizedCode);
         _logger.LogInformation("Voter {VoterId} authenticated via direct kiosk/personal code", safeVoterIdForLog);
         return (true, null, response);
+    }
+
+    /// <summary>
+    /// Notifies existing browser sessions for this voter id that another device just logged in
+    /// (v3 VoterPersonalHub Login parity). Failures are logged inside the notification service.
+    /// </summary>
+    private Task NotifyLoginElsewhereAsync(string voterId)
+    {
+        return _signalRNotificationService.NotifyVoterLoginElsewhereAsync(voterId);
     }
 
     private RequestCodeResponseDto BuildRequestCodeResponse(string messageKey, string? verifyCode = null)

--- a/backend/Services/SignalRNotificationService.cs
+++ b/backend/Services/SignalRNotificationService.cs
@@ -19,6 +19,8 @@ public class SignalRNotificationService : ISignalRNotificationService
     private readonly IHubContext<ElectionPackageImportHub> _electionPackageImportHubContext;
     private readonly IHubContext<FrontDeskHub> _frontDeskHubContext;
     private readonly IHubContext<PublicHub> _publicHubContext;
+    private readonly IHubContext<AllVotersHub> _allVotersHubContext;
+    private readonly IHubContext<VoterPersonalHub> _voterPersonalHubContext;
     private readonly ILogger<SignalRNotificationService> _logger;
 
     /// <summary>
@@ -31,6 +33,8 @@ public class SignalRNotificationService : ISignalRNotificationService
     /// <param name="electionPackageImportHubContext">Hub context for election package load progress.</param>
     /// <param name="frontDeskHubContext">Hub context for the front desk SignalR hub.</param>
     /// <param name="publicHubContext">Hub context for PublicHub (guest-teller join list).</param>
+    /// <param name="allVotersHubContext">Hub context for online voters (global list refresh).</param>
+    /// <param name="voterPersonalHubContext">Hub context for per-voter personal updates.</param>
     /// <param name="logger">Logger for recording notification service operations.</param>
     public SignalRNotificationService(
         IHubContext<MainHub> mainHubContext,
@@ -40,6 +44,8 @@ public class SignalRNotificationService : ISignalRNotificationService
         IHubContext<ElectionPackageImportHub> electionPackageImportHubContext,
         IHubContext<FrontDeskHub> frontDeskHubContext,
         IHubContext<PublicHub> publicHubContext,
+        IHubContext<AllVotersHub> allVotersHubContext,
+        IHubContext<VoterPersonalHub> voterPersonalHubContext,
         ILogger<SignalRNotificationService> logger)
     {
         _mainHubContext = mainHubContext;
@@ -49,6 +55,8 @@ public class SignalRNotificationService : ISignalRNotificationService
         _electionPackageImportHubContext = electionPackageImportHubContext;
         _frontDeskHubContext = frontDeskHubContext;
         _publicHubContext = publicHubContext;
+        _allVotersHubContext = allVotersHubContext;
+        _voterPersonalHubContext = voterPersonalHubContext;
         _logger = logger;
     }
 
@@ -398,20 +406,86 @@ public class SignalRNotificationService : ISignalRNotificationService
     }
 
     /// <summary>
-    /// Notifies front desk / monitor clients that online open/close settings changed.
-    /// Event name matches SPA: <c>updateOnlineElection</c> (v3 parity).
+    /// Notifies front desk / monitor clients and connected online voters that online open/close
+    /// settings changed. FrontDesk: <c>updateOnlineElection</c>; AllVoters: <c>updateVoters</c>.
     /// </summary>
     public async Task SendOnlineElectionUpdateAsync(OnlineElectionUpdateDto update)
     {
         try
         {
-            var groupName = FrontDeskHub.GetGroupName(update.ElectionGuid);
-            await _frontDeskHubContext.Clients.Group(groupName).SendAsync("updateOnlineElection", update);
-            _logger.LogInformation("Sent updateOnlineElection notification to group {GroupName}", groupName);
+            var frontDeskGroup = FrontDeskHub.GetGroupName(update.ElectionGuid);
+            await _frontDeskHubContext.Clients.Group(frontDeskGroup).SendAsync("updateOnlineElection", update);
+            _logger.LogInformation("Sent updateOnlineElection notification to group {GroupName}", frontDeskGroup);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error sending updateOnlineElection for election {ElectionGuid}", update.ElectionGuid);
+        }
+
+        try
+        {
+            // Thin same payload on global AllVoters — clients re-fetch availableElections.
+            var allVotersGroup = AllVotersHub.GetGroupName();
+            await _allVotersHubContext.Clients.Group(allVotersGroup).SendAsync("updateVoters", update);
+            _logger.LogInformation("Sent updateVoters notification to group {GroupName}", allVotersGroup);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending updateVoters for election {ElectionGuid}", update.ElectionGuid);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyVoterPersonalUpdateAsync(
+        string? email,
+        string? phone,
+        string? kioskCode,
+        VoterPersonalUpdateDto update)
+    {
+        var groupKeys = DistinctNonEmpty(email, phone, kioskCode);
+        if (groupKeys.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var voterId in groupKeys)
+        {
+            try
+            {
+                var groupName = VoterPersonalHub.GetGroupName(voterId);
+                await _voterPersonalHubContext.Clients.Group(groupName).SendAsync("updateVoter", update);
+                _logger.LogInformation(
+                    "Sent updateVoter (registration) to group for election {ElectionGuid}",
+                    update.ElectionGuid);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Error sending updateVoter registration for election {ElectionGuid}",
+                    update.ElectionGuid);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task NotifyVoterLoginElsewhereAsync(string voterId)
+    {
+        if (string.IsNullOrWhiteSpace(voterId))
+        {
+            return;
+        }
+
+        try
+        {
+            var groupName = VoterPersonalHub.GetGroupName(voterId);
+            var update = new VoterPersonalUpdateDto { Login = true };
+            await _voterPersonalHubContext.Clients.Group(groupName).SendAsync("updateVoter", update);
+            _logger.LogInformation("Sent updateVoter (login) to personal voter group");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error sending updateVoter login notification");
         }
     }
 
@@ -430,6 +504,27 @@ public class SignalRNotificationService : ISignalRNotificationService
         {
             _logger.LogError(ex, "Error sending reloadPage for election {ElectionGuid}", electionGuid);
         }
+    }
+
+    private static List<string> DistinctNonEmpty(params string?[] values)
+    {
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var trimmed = value.Trim();
+            if (seen.Add(trimmed))
+            {
+                result.Add(trimmed);
+            }
+        }
+
+        return result;
     }
 }
 

--- a/backend/Services/SignalRNotificationService.cs
+++ b/backend/Services/SignalRNotificationService.cs
@@ -448,11 +448,12 @@ public class SignalRNotificationService : ISignalRNotificationService
             return;
         }
 
-        foreach (var voterId in groupKeys)
+        foreach (var identityKey in groupKeys)
         {
             try
             {
-                var groupName = VoterPersonalHub.GetGroupName(voterId);
+                // GetGroupName trims; identityKey is already trimmed by DistinctNonEmpty.
+                var groupName = VoterPersonalHub.GetGroupName(identityKey);
                 await _voterPersonalHubContext.Clients.Group(groupName).SendAsync("updateVoter", update);
                 _logger.LogInformation(
                     "Sent updateVoter (registration) to group for election {ElectionGuid}",
@@ -478,6 +479,7 @@ public class SignalRNotificationService : ISignalRNotificationService
 
         try
         {
+            // Same normalization as Join / registration fan-out (trim via GetGroupName).
             var groupName = VoterPersonalHub.GetGroupName(voterId);
             var update = new VoterPersonalUpdateDto { Login = true };
             await _voterPersonalHubContext.Clients.Group(groupName).SendAsync("updateVoter", update);

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -17,8 +17,10 @@ Do **not** assume a single `election-{guid}` convention for all realtime traffic
 | `BallotImport{electionGuid}` / `PeopleImport{electionGuid}` | import hubs (election-scoped)                           |
 | `ElectionPackageImport{userId}`                             | ElectionPackageImportHub — dashboard package load log   |
 | `Public`                                                    | PublicHub — guest-teller joinable elections list        |
+| `AllVoters` (global)                                        | AllVotersHub — online voter list/window refresh         |
+| `Voter{voterId}`                                            | VoterPersonalHub — registration + multi-device login     |
 
-Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElection`, `joinDashboardElections`, etc.) and store subscriptions.
+Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElection`, `joinDashboardElections`, `connectVoterHubs`, etc.) and store subscriptions.
 
 ## MainHub status vs role groups
 
@@ -68,18 +70,44 @@ Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElect
 
 **Rejected alternative:** one shared election group for every event type. Rejected because Main, Front Desk, Analyze, and Public have different listeners and update cadences.
 
-## No OnlineVotingHub (election-scoped online voting SignalR)
+## No election-scoped OnlineVotingHub (ballot totals)
 
 **Status:** active  
 **Evidence:** confirmed  
-**Source:** maintainer review of unused scaffold vs v3 `AllVotersHub` / `VoterPersonalHub`  
-**Revisit when:** online voters need live list refresh or personal status push
+**Source:** maintainer review of unused scaffold vs v3 `AllVotersHub` / `VoterPersonalHub`; issue #233  
+**Revisit when:** product wants per-election voter groups or ballot-submit live counts
 
-There is no `/hubs/online-voting` hub and no `online-election-{guid}` group. Online voting remains HTTP (`/api/online-voting/*`). Operator-facing online window updates use FrontDeskHub (`updateOnlineElection`). Ballot submit confirmation is the HTTP response.
+There is still no `/hubs/online-voting` hub and no `online-election-{guid}` group that pushes vote totals. Ballot submit confirmation remains the HTTP response.
 
-**Rejected alternative:** keep scaffolded `OnlineVotingHub` with `online-election-{electionGuid}` and client-callable `BallotSubmitted` (payload including `totalVotes`). Rejected — unused (no server `IHubContext` producers, no frontend client), mismatched v3 voter model (global all-voters + personal `Voter{id}`, not per-election ballot events), and would push vote totals rather than a thin “refetch” signal.
+**Rejected alternative:** scaffolded `OnlineVotingHub` with `online-election-{electionGuid}` and client-callable `BallotSubmitted` (payload including `totalVotes`). Rejected — mismatched v3 voter model, would push vote totals rather than thin “refetch” signals.
 
-**Preferred shape if restored later:** authenticated voter channel; thin “changed” (or `electionGuid` only) event so clients re-call `GET availableElections` / vote status APIs — avoid disclosing election detail or tallies on the hub.
+## Online voter hubs (AllVoters + VoterPersonal) — issue #233
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #233; v3 `AllVotersHub` / `VoterPersonalHub`; preferred thin-signal shape above  
+**Revisit when:** global `AllVoters` becomes too chatty, or kiosk multi-login needs different UX
+
+Online voters use two authenticated hubs (policy `OnlineVoter` — JWT claims `voterType=online` + `voterId`). FE connects with the voter Bearer token (`accessTokenFactory` + existing query `access_token` support).
+
+| Hub | Path | Group | Join | Events |
+| --- | ---- | ----- | ---- | ------ |
+| AllVotersHub | `/hubs/all-voters` | `AllVoters` (global) | `Join` / `Leave` | `updateVoters` — thin `OnlineElectionUpdateDto` (same fields as FrontDesk `updateOnlineElection`) |
+| VoterPersonalHub | `/hubs/voter-personal` | `Voter{voterId}` | `Join` / `Leave` (group from JWT only) | `updateVoter` — thin `VoterPersonalUpdateDto` (`updateRegistration` / `login`) |
+
+**Producers** (via `ISignalRNotificationService` only — hubs are join/leave):
+
+- Online window/process change (`ElectionService` → `SendOnlineElectionUpdateAsync`) → FrontDesk **and** AllVoters.
+- Front desk check-in / unregister / envelope (`FrontDeskService`) → personal `updateVoter` with `updateRegistration` to email, phone, and kiosk groups when present.
+- Successful online voter auth (`OnlineVotingService`) → personal `updateVoter` with `login: true` (other browsers for that id).
+
+**Client behavior:** thin signal → re-call `GET availableElections` / vote status. Do not treat hub payloads as authoritative election detail or tallies. Login-elsewhere shows a dismissible notice.
+
+**Why global AllVoters (not per-election):** one join after auth covers list refresh for any election whose online window changes; eligibility filtering stays on `GET availableElections`. Per-election groups would miss elections the voter has not joined yet.
+
+**Rejected alternative:** per-election voter groups only. Rejected for MVP — discovery of newly opened elections for an already-connected voter would require a second discovery channel.
+
+**Security:** personal join never accepts a client-supplied voter id (server uses JWT `voterId`). Personal updates target only groups for that person's contact identifiers; voter A does not receive voter B events.
 
 ## No anonymous public results display
 

--- a/docs/Hubs-in-v3.md
+++ b/docs/Hubs-in-v3.md
@@ -392,8 +392,8 @@ Example payloads from `ElectionHelper`:
 
 ### Rewrite checklist
 
-- [ ] Push online open/close / process changes to connected voters  
-- [ ] Re-evaluate global vs per-election groups  
+- [x] Push online open/close / process changes to connected voters (v4 AllVotersHub + `updateVoters`, #233)
+- [x] Re-evaluate global vs per-election groups — kept global for list discovery; see `context/realtime.md`
 
 ---
 
@@ -445,9 +445,9 @@ Same as AllVotersHub: `Vote/JoinVoterHubs` under `[AllowVoter]`.
 
 ### Rewrite checklist
 
-- [ ] Per-voter registration push when tellers/process change their status  
-- [ ] Multi-device login notification  
-- [ ] Decide kiosk identity parity for personal updates  
+- [x] Per-voter registration push when tellers/process change their status (v4 FrontDesk → `updateVoter`, #233)
+- [x] Multi-device login notification (auth success → `login: true`)
+- [x] Kiosk identity: personal updates target email, phone, **and** kiosk code groups when present
 
 ---
 

--- a/docs/Hubs-v3-vs-v4.md
+++ b/docs/Hubs-v3-vs-v4.md
@@ -27,7 +27,7 @@ Companion to [Hubs-in-v3.md](./Hubs-in-v3.md). Summarizes how TallyJ 4’s realt
 | VoterCodeHub | — | Not implemented |
 | *(scaffold)* OnlineVotingHub | — | Removed on purpose; see `context/realtime.md` |
 
-Mapped in `backend/Program.cs` as `/hubs/main`, `/analyze`, `/ballot-import`, `/people-import`, `/election-package-import`, `/front-desk`, `/public`, `/all-voters`, `/voter-personal`.
+Mapped in `backend/Program.cs` as `/hubs/main`, `/hubs/analyze`, `/hubs/ballot-import`, `/hubs/people-import`, `/hubs/election-package-import`, `/hubs/front-desk`, `/hubs/public`, `/hubs/all-voters`, `/hubs/voter-personal`.
 
 ---
 

--- a/docs/Hubs-v3-vs-v4.md
+++ b/docs/Hubs-v3-vs-v4.md
@@ -22,12 +22,12 @@ Companion to [Hubs-in-v3.md](./Hubs-in-v3.md). Summarizes how TallyJ 4’s realt
 | ImportHub (election package load) | `ElectionPackageImportHub` (`/hubs/election-package-import`) | User-scoped `loaderStatus` (#231) |
 | BallotImportHub | `BallotImportHub` (`/hubs/ballot-import`) | Present; election-scoped groups |
 | RollCallHub | — | Deferred |
-| AllVotersHub | — | Not implemented (online voting HTTP-only for now) |
-| VoterPersonalHub | — | Not implemented |
+| AllVotersHub | `AllVotersHub` (`/hubs/all-voters`) | Global `AllVoters`; thin `updateVoters` (#233) |
+| VoterPersonalHub | `VoterPersonalHub` (`/hubs/voter-personal`) | `Voter{voterId}` from JWT; thin `updateVoter` (#233) |
 | VoterCodeHub | — | Not implemented |
 | *(scaffold)* OnlineVotingHub | — | Removed on purpose; see `context/realtime.md` |
 
-Mapped in `backend/Program.cs` as `/hubs/main`, `/analyze`, `/ballot-import`, `/people-import`, `/election-package-import`, `/front-desk`, `/public`.
+Mapped in `backend/Program.cs` as `/hubs/main`, `/analyze`, `/ballot-import`, `/people-import`, `/election-package-import`, `/front-desk`, `/public`, `/all-voters`, `/voter-personal`.
 
 ---
 
@@ -63,8 +63,8 @@ Mapped in `backend/Program.cs` as `/hubs/main`, `/analyze`, `/ballot-import`, `/
 | People import | `Import{loginId}` (shared name pattern with ballot import, different hub type) | `PeopleImport{electionGuid}` |
 | Ballot import | `Import{loginId}` | `BallotImport{electionGuid}` |
 | Roll call | `RollCall{electionGuid}` | — |
-| All voters | `AllVoters` (global) | — |
-| Voter personal | `Voter{voterId}` | — |
+| All voters | `AllVoters` (global) | Same |
+| Voter personal | `Voter{voterId}` | Same (server-derived from JWT) |
 | Voter code | Client opaque key | — |
 
 **Import scope change:** v3 scoped progress to the **login**; v4 scopes people/ballot import to the **election**. Concurrent tellers on the same election share the stream.
@@ -84,9 +84,9 @@ Mapped in `backend/Program.cs` as `/hubs/main`, `/analyze`, `/ballot-import`, `/
 
 Documented in `context/realtime.md`:
 
-- No election-scoped OnlineVotingHub; online voting is HTTP (`/api/online-voting/*`).
+- No election-scoped OnlineVotingHub that pushes ballot totals; submit remains HTTP.
+- Online voters: AllVotersHub + VoterPersonalHub with thin refetch signals (#233).
 - PublicHub is **only** for guest-teller joinable elections — not anonymous results display.
-- Preferred restore shape for voter realtime: thin “refetch” signals, not tallies or rich private data on the wire.
 
 ---
 
@@ -164,8 +164,8 @@ Catalog: `context/realtime.md` § Import hub event catalog.
 
 | Gap | v3 | v4 | Issue |
 |-----|----|----|-------|
-| All voters online window / process | AllVotersHub | HTTP only | [#233](https://github.com/glittle/TallyJ-4/issues/233) |
-| Personal registration / multi-login | VoterPersonalHub | — | [#233](https://github.com/glittle/TallyJ-4/issues/233) |
+| All voters online window / process | AllVotersHub | **Fixed** — `/hubs/all-voters` + `updateVoters` | [#233](https://github.com/glittle/TallyJ-4/issues/233) |
+| Personal registration / multi-login | VoterPersonalHub | **Fixed** — `/hubs/voter-personal` + `updateVoter` | [#233](https://github.com/glittle/TallyJ-4/issues/233) |
 | Code delivery live status | VoterCodeHub | `requestCode` / `verifyCode` only | [#229](https://github.com/glittle/TallyJ-4/issues/229) |
 
 If restored: prefer server-derived groups, high-entropy channel tokens for code status (not short client keys), and thin refetch signals — see `context/realtime.md`.
@@ -188,8 +188,8 @@ If restored: prefer server-derived groups, high-entropy channel tokens for code 
 | Front desk registration live | FrontDeskHub | **Mostly** — check-in/flags/counts; person CRUD event mismatch |
 | Roll call live | RollCallHub | **Deferred** |
 | Monitor online window | FrontDeskHub | **No** (no producer/listener) |
-| Voters online open/close | AllVotersHub | **No** |
-| Voter personal / multi-login | VoterPersonalHub | **No** |
+| Voters online open/close | AllVotersHub | **Yes** — thin `updateVoters` → refetch |
+| Voter personal / multi-login | VoterPersonalHub | **Yes** — thin `updateVoter` → refetch / notice |
 | Voter code delivery status | VoterCodeHub | **No** |
 | CSV import progress | ImportHub | **Yes** (PeopleImportHub) |
 | Election-load progress | ImportHub | **Yes** (ElectionPackageImportHub, user-scoped) |

--- a/frontend/src/locales/en/voting.json
+++ b/frontend/src/locales/en/voting.json
@@ -53,6 +53,7 @@
   "voting.elections.footerNote": "If something looks wrong, please stop using TallyJ and send details to your head teller and/or to global technical support.",
   "voting.elections.loadError": "Failed to load elections. Please try again.",
   "voting.elections.loading": "Loading your elections...",
+  "voting.elections.loginElsewhere": "You signed in on another browser or device. This session is still active; only one session may vote at a time depending on your election settings.",
   "voting.elections.logout": "Log Out",
   "voting.elections.method.online": "Online",
   "voting.elections.noElections": "No elections found for your account.",

--- a/frontend/src/pages/voting/VoterBallotPage.vue
+++ b/frontend/src/pages/voting/VoterBallotPage.vue
@@ -83,6 +83,7 @@ onMounted(async () => {
     return;
   }
 
+  await onlineVotingStore.ensureVoterHubsConnected();
   await loadElectionData();
 });
 
@@ -238,6 +239,16 @@ function backToElections() {
             </div>
           </div>
         </template>
+
+        <ElAlert
+          v-if="onlineVotingStore.loginElsewhereNotice"
+          type="warning"
+          :closable="true"
+          class="ballot-alert"
+          @close="onlineVotingStore.dismissLoginElsewhereNotice()"
+        >
+          {{ $t("voting.elections.loginElsewhere") }}
+        </ElAlert>
 
         <ElAlert
           v-if="isEditing"

--- a/frontend/src/pages/voting/VoterElectionsPage.vue
+++ b/frontend/src/pages/voting/VoterElectionsPage.vue
@@ -19,18 +19,11 @@ onMounted(async () => {
 
   try {
     await onlineVotingStore.loadAvailableElections();
+    await onlineVotingStore.ensureVoterHubsConnected();
   } catch {
     showErrorMessage(t("voting.elections.loadError"));
   }
 });
-
-// const  openElections = computed(() =>
-//   onlineVotingStore.availableElections.filter((e) => e.isOpen),
-// );
-
-// const otherElections = computed(() =>
-//   onlineVotingStore.availableElections.filter((e) => !e.isOpen),
-// );
 
 function selectElection(electionGuid: string) {
   router.push(`/vote/${electionGuid}`);
@@ -121,6 +114,16 @@ function handleLogout() {
 <template>
   <div class="voter-elections-page">
     <div class="elections-container">
+      <ElAlert
+        v-if="onlineVotingStore.loginElsewhereNotice"
+        type="warning"
+        :closable="true"
+        class="login-elsewhere-alert"
+        @close="onlineVotingStore.dismissLoginElsewhereNotice()"
+      >
+        {{ $t("voting.elections.loginElsewhere") }}
+      </ElAlert>
+
       <ElAlert
         v-if="onlineVotingStore.voterId"
         type="info"

--- a/frontend/src/services/__tests__/signalrService.voterHubs.spec.ts
+++ b/frontend/src/services/__tests__/signalrService.voterHubs.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HubConnectionState } from "@microsoft/signalr";
+
+const invoke = vi.fn();
+const start = vi.fn().mockResolvedValue(undefined);
+const stop = vi.fn().mockResolvedValue(undefined);
+const on = vi.fn();
+const onclose = vi.fn();
+const onreconnecting = vi.fn();
+const onreconnected = vi.fn();
+const withUrl = vi.fn().mockReturnThis();
+
+vi.mock("@microsoft/signalr", () => {
+  class HubConnectionBuilder {
+    withUrl(...args: unknown[]) {
+      withUrl(...args);
+      return this;
+    }
+    withAutomaticReconnect() {
+      return this;
+    }
+    configureLogging() {
+      return this;
+    }
+    build() {
+      return {
+        state: HubConnectionState.Connected,
+        start,
+        stop,
+        invoke,
+        on,
+        onclose,
+        onreconnecting,
+        onreconnected,
+      };
+    }
+  }
+  return {
+    HubConnectionBuilder,
+    HubConnectionState: {
+      Connected: "Connected",
+      Disconnected: "Disconnected",
+      Connecting: "Connecting",
+      Reconnecting: "Reconnecting",
+    },
+    LogLevel: { Warning: 2 },
+  };
+});
+
+vi.mock("@/config/appConfig", () => ({
+  getAppConfig: () => ({ apiUrl: "http://localhost:5016" }),
+}));
+
+vi.mock("@/utils/clientIdStorage", () => ({
+  getOrCreateClientId: () => "client-1",
+}));
+
+vi.mock("@/utils/computerCodeStorage", () => ({
+  setComputerCode: vi.fn(),
+}));
+
+describe("signalrService voter hubs", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    invoke.mockReset().mockResolvedValue(undefined);
+    start.mockClear();
+    stop.mockClear();
+    withUrl.mockClear();
+    onreconnected.mockClear();
+  });
+
+  it("connectVoterHubs joins AllVoters then VoterPersonal with token factory", async () => {
+    const { signalrService } = await import("../signalrService");
+    const tokenFactory = vi.fn(() => "voter-jwt");
+
+    await signalrService.connectVoterHubs(tokenFactory);
+
+    expect(withUrl).toHaveBeenCalledWith(
+      "http://localhost:5016/hubs/all-voters",
+      expect.objectContaining({
+        withCredentials: true,
+        accessTokenFactory: expect.any(Function),
+      }),
+    );
+    expect(withUrl).toHaveBeenCalledWith(
+      "http://localhost:5016/hubs/voter-personal",
+      expect.objectContaining({
+        withCredentials: true,
+        accessTokenFactory: expect.any(Function),
+      }),
+    );
+
+    // Join order: AllVoters then VoterPersonal
+    const joinCalls = invoke.mock.calls.filter((c) => c[0] === "Join");
+    expect(joinCalls).toHaveLength(2);
+
+    // accessTokenFactory from connect options should use the provided factory
+    const allVotersOpts = withUrl.mock.calls.find(
+      (c) => c[0] === "http://localhost:5016/hubs/all-voters",
+    )?.[1] as { accessTokenFactory: () => string };
+    expect(allVotersOpts.accessTokenFactory()).toBe("voter-jwt");
+    expect(tokenFactory).toHaveBeenCalled();
+  });
+
+  it("disconnectVoterHubs leaves then disconnects both hubs", async () => {
+    const { signalrService } = await import("../signalrService");
+    await signalrService.connectVoterHubs(() => "voter-jwt");
+    invoke.mockClear();
+    stop.mockClear();
+
+    await signalrService.disconnectVoterHubs();
+
+    expect(invoke).toHaveBeenCalledWith("Leave");
+    expect(invoke.mock.calls.filter((c) => c[0] === "Leave")).toHaveLength(2);
+    expect(stop).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-invokes Join after reconnect when voter groups were joined", async () => {
+    const { signalrService } = await import("../signalrService");
+    await signalrService.connectVoterHubs(() => "voter-jwt");
+    invoke.mockClear();
+
+    // Capture onreconnected handlers registered during connect
+    expect(onreconnected).toHaveBeenCalled();
+    const reconnectHandlers = onreconnected.mock.calls.map((c) => c[0]);
+    expect(reconnectHandlers.length).toBeGreaterThanOrEqual(2);
+
+    for (const handler of reconnectHandlers) {
+      await handler("new-connection-id");
+    }
+
+    const rejoinCalls = invoke.mock.calls.filter((c) => c[0] === "Join");
+    expect(rejoinCalls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/frontend/src/services/signalrService.ts
+++ b/frontend/src/services/signalrService.ts
@@ -12,12 +12,23 @@ class SignalRService {
   /** Known-teller dashboard multi-election listen set (MainHub JoinElections). */
   private dashboardElectionGuids: string[] = [];
   private publicGroupJoined = false;
+  /** Online voter hubs (Bearer voter JWT from localStorage). */
+  private allVotersJoined = false;
+  private voterPersonalJoined = false;
+  private voterAccessTokenFactory: (() => string | null) | null = null;
 
   private get baseUrl(): string {
     return getAppConfig().apiUrl;
   }
 
-  async connect(hubPath: string): Promise<signalR.HubConnection> {
+  /**
+   * Connect to a hub. Optional accessTokenFactory is used for online-voter hubs
+   * (Bearer JWT in localStorage); teller hubs rely on cookies / default auth.
+   */
+  async connect(
+    hubPath: string,
+    accessTokenFactory?: () => string | null,
+  ): Promise<signalR.HubConnection> {
     const existingConnection = this.connections.get(hubPath);
     if (existingConnection?.state === signalR.HubConnectionState.Connected) {
       return existingConnection;
@@ -27,9 +38,12 @@ class SignalRService {
 
     const connection = new signalR.HubConnectionBuilder()
       .withUrl(hubUrl, {
-        // Cookies are sent automatically by the browser with the initial HTTP request
-        // No need to provide accessTokenFactory when using httpOnly cookies
+        // Cookies are sent automatically by the browser with the initial HTTP request.
+        // Online-voter hubs also send the voter JWT via access_token / Authorization.
         withCredentials: true,
+        accessTokenFactory: accessTokenFactory
+          ? () => accessTokenFactory() ?? ""
+          : undefined,
       })
       .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
       .configureLogging(signalR.LogLevel.Warning)
@@ -111,6 +125,30 @@ class SignalRService {
         } catch (error) {
           console.error(
             "Failed to rejoin public group after reconnect:",
+            error,
+          );
+        }
+      }
+
+      if (hubPath === "/hubs/all-voters" && this.allVotersJoined) {
+        try {
+          await connection.invoke("Join");
+          console.log("Rejoined AllVoters group after reconnect");
+        } catch (error) {
+          console.error(
+            "Failed to rejoin AllVoters group after reconnect:",
+            error,
+          );
+        }
+      }
+
+      if (hubPath === "/hubs/voter-personal" && this.voterPersonalJoined) {
+        try {
+          await connection.invoke("Join");
+          console.log("Rejoined VoterPersonal group after reconnect");
+        } catch (error) {
+          console.error(
+            "Failed to rejoin VoterPersonal group after reconnect:",
             error,
           );
         }
@@ -411,6 +449,88 @@ class SignalRService {
     const publicConnection = this.getConnection("/hubs/public");
     if (publicConnection) {
       await publicConnection.invoke("LeavePublicGroup");
+    }
+  }
+
+  /**
+   * Connect + join online-voter hubs (AllVoters + VoterPersonal).
+   * Requires a factory that returns the current voter JWT (localStorage).
+   */
+  async connectVoterHubs(
+    accessTokenFactory: () => string | null,
+  ): Promise<void> {
+    this.voterAccessTokenFactory = accessTokenFactory;
+    await this.connectToAllVotersHub();
+    await this.joinAllVoters();
+    await this.connectToVoterPersonalHub();
+    await this.joinVoterPersonal();
+  }
+
+  async disconnectVoterHubs(): Promise<void> {
+    await this.leaveAllVoters();
+    await this.leaveVoterPersonal();
+    await this.disconnect("/hubs/all-voters");
+    await this.disconnect("/hubs/voter-personal");
+    this.voterAccessTokenFactory = null;
+  }
+
+  async connectToAllVotersHub(): Promise<signalR.HubConnection> {
+    const factory =
+      this.voterAccessTokenFactory ??
+      (() => localStorage.getItem("voter_token"));
+    return this.connect("/hubs/all-voters", factory);
+  }
+
+  async connectToVoterPersonalHub(): Promise<signalR.HubConnection> {
+    const factory =
+      this.voterAccessTokenFactory ??
+      (() => localStorage.getItem("voter_token"));
+    return this.connect("/hubs/voter-personal", factory);
+  }
+
+  async joinAllVoters(): Promise<void> {
+    this.allVotersJoined = true;
+    const connection = await this.connectToAllVotersHub();
+    if (connection.state !== signalR.HubConnectionState.Connected) {
+      throw new Error(
+        `AllVoters hub is not ready (state: ${connection.state})`,
+      );
+    }
+    await connection.invoke("Join");
+  }
+
+  async leaveAllVoters(): Promise<void> {
+    this.allVotersJoined = false;
+    const connection = this.getConnection("/hubs/all-voters");
+    if (connection?.state === signalR.HubConnectionState.Connected) {
+      try {
+        await connection.invoke("Leave");
+      } catch (error) {
+        console.warn("Failed to leave AllVoters group:", error);
+      }
+    }
+  }
+
+  async joinVoterPersonal(): Promise<void> {
+    this.voterPersonalJoined = true;
+    const connection = await this.connectToVoterPersonalHub();
+    if (connection.state !== signalR.HubConnectionState.Connected) {
+      throw new Error(
+        `VoterPersonal hub is not ready (state: ${connection.state})`,
+      );
+    }
+    await connection.invoke("Join");
+  }
+
+  async leaveVoterPersonal(): Promise<void> {
+    this.voterPersonalJoined = false;
+    const connection = this.getConnection("/hubs/voter-personal");
+    if (connection?.state === signalR.HubConnectionState.Connected) {
+      try {
+        await connection.invoke("Leave");
+      } catch (error) {
+        console.warn("Failed to leave VoterPersonal group:", error);
+      }
     }
   }
 }

--- a/frontend/src/stores/onlineVotingStore.ts
+++ b/frontend/src/stores/onlineVotingStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 import { onlineVotingService } from "../services/onlineVotingService";
+import { signalrService } from "../services/signalrService";
 import { useApiErrorHandler } from "../composables/useApiErrorHandler";
 import type {
   RequestCodeDto,
@@ -15,6 +16,10 @@ import type {
   TelegramAuthForVoterDto,
   AvailableElection,
 } from "../types";
+import type {
+  UpdateVoterEvent,
+  UpdateVotersEvent,
+} from "../types/SignalREvents";
 
 export const useOnlineVotingStore = defineStore("onlineVoting", () => {
   const { handleApiError } = useApiErrorHandler();
@@ -26,6 +31,19 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
   const voteStatus = ref<OnlineVoteStatus | null>(null);
   const availableElections = ref<AvailableElection[]>([]);
   const loading = ref(false);
+  /** True while AllVoters + VoterPersonal hubs are connected for this session. */
+  const voterHubsConnected = ref(false);
+  /** Multi-device login notice for the UI (cleared when dismissed or on logout). */
+  const loginElsewhereNotice = ref(false);
+
+  let voterHubHandlersBound = false;
+
+  function persistAuth(token: string, id: string) {
+    voterToken.value = token;
+    voterId.value = id;
+    localStorage.setItem("voter_token", token);
+    localStorage.setItem("voter_id", id);
+  }
 
   async function requestVerificationCode(data: RequestCodeDto) {
     try {
@@ -41,10 +59,9 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.verifyCode(data);
-      voterToken.value = response.token;
-      voterId.value = response.voterId;
-      localStorage.setItem("voter_token", response.token);
-      localStorage.setItem("voter_id", response.voterId);
+      if (response.token && response.voterId) {
+        persistAuth(response.token, response.voterId);
+      }
       return response;
     } finally {
       loading.value = false;
@@ -55,10 +72,9 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.googleAuth(data);
-      voterToken.value = response.token;
-      voterId.value = response.voterId;
-      localStorage.setItem("voter_token", response.token);
-      localStorage.setItem("voter_id", response.voterId);
+      if (response.token && response.voterId) {
+        persistAuth(response.token, response.voterId);
+      }
       return response;
     } finally {
       loading.value = false;
@@ -69,10 +85,9 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.facebookAuth(data);
-      voterToken.value = response.token;
-      voterId.value = response.voterId;
-      localStorage.setItem("voter_token", response.token);
-      localStorage.setItem("voter_id", response.voterId);
+      if (response.token && response.voterId) {
+        persistAuth(response.token, response.voterId);
+      }
       return response;
     } finally {
       loading.value = false;
@@ -83,10 +98,9 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.kakaoAuth(data);
-      voterToken.value = response.token;
-      voterId.value = response.voterId;
-      localStorage.setItem("voter_token", response.token);
-      localStorage.setItem("voter_id", response.voterId);
+      if (response.token && response.voterId) {
+        persistAuth(response.token, response.voterId);
+      }
       return response;
     } finally {
       loading.value = false;
@@ -97,10 +111,9 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.telegramAuth(data);
-      voterToken.value = response.token;
-      voterId.value = response.voterId;
-      localStorage.setItem("voter_token", response.token);
-      localStorage.setItem("voter_id", response.voterId);
+      if (response.token && response.voterId) {
+        persistAuth(response.token, response.voterId);
+      }
       return response;
     } finally {
       loading.value = false;
@@ -191,13 +204,98 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     }
   }
 
-  function logout() {
+  function dismissLoginElsewhereNotice() {
+    loginElsewhereNotice.value = false;
+  }
+
+  async function handleUpdateVoters(_payload: UpdateVotersEvent) {
+    // Thin signal: re-fetch authoritative list (eligibility is server-side).
+    if (!voterToken.value) {
+      return;
+    }
+    try {
+      await loadAvailableElections();
+    } catch {
+      // Errors already handled in loadAvailableElections; avoid tearing down hubs.
+    }
+  }
+
+  async function handleUpdateVoter(payload: UpdateVoterEvent) {
+    if (payload.login) {
+      loginElsewhereNotice.value = true;
+    }
+
+    if (payload.updateRegistration && voterToken.value) {
+      try {
+        await loadAvailableElections();
+        if (payload.electionGuid && voterId.value) {
+          await checkVoteStatus(payload.electionGuid, voterId.value);
+        }
+      } catch {
+        // Errors already handled; keep hub session alive.
+      }
+    }
+  }
+
+  /**
+   * Connect AllVoters + VoterPersonal hubs for the authenticated voter session.
+   * Safe to call multiple times (idempotent).
+   */
+  async function ensureVoterHubsConnected(): Promise<void> {
+    if (!voterToken.value) {
+      return;
+    }
+
+    if (voterHubsConnected.value && voterHubHandlersBound) {
+      return;
+    }
+
+    try {
+      await signalrService.connectVoterHubs(
+        () => voterToken.value ?? localStorage.getItem("voter_token"),
+      );
+
+      if (!voterHubHandlersBound) {
+        const allVoters = signalrService.getConnection("/hubs/all-voters");
+        const personal = signalrService.getConnection("/hubs/voter-personal");
+
+        allVoters?.on("updateVoters", (payload: UpdateVotersEvent) => {
+          void handleUpdateVoters(payload);
+        });
+
+        personal?.on("updateVoter", (payload: UpdateVoterEvent) => {
+          void handleUpdateVoter(payload);
+        });
+
+        voterHubHandlersBound = true;
+      }
+
+      voterHubsConnected.value = true;
+    } catch (error) {
+      console.warn("Failed to connect online voter SignalR hubs:", error);
+      voterHubsConnected.value = false;
+    }
+  }
+
+  async function disconnectVoterHubs(): Promise<void> {
+    voterHubHandlersBound = false;
+    voterHubsConnected.value = false;
+    try {
+      await signalrService.disconnectVoterHubs();
+    } catch (error) {
+      console.warn("Failed to disconnect online voter SignalR hubs:", error);
+    }
+  }
+
+  async function logout() {
+    await disconnectVoterHubs();
     voterToken.value = null;
     voterId.value = null;
     electionInfo.value = null;
     votablePeople.value = [];
     voteStatus.value = null;
     availableElections.value = [];
+    loginElsewhereNotice.value = false;
     localStorage.removeItem("voter_token");
     localStorage.removeItem("voter_id");
   }
@@ -210,6 +308,8 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     voteStatus,
     availableElections,
     loading,
+    voterHubsConnected,
+    loginElsewhereNotice,
     requestVerificationCode,
     verifyCode,
     googleAuth,
@@ -221,6 +321,9 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     loadVotablePeople,
     submitBallot,
     checkVoteStatus,
+    ensureVoterHubsConnected,
+    disconnectVoterHubs,
+    dismissLoginElsewhereNotice,
     logout,
   };
 });

--- a/frontend/src/types/SignalREvents.ts
+++ b/frontend/src/types/SignalREvents.ts
@@ -16,6 +16,24 @@ export interface OnlineElectionUpdateEvent {
   onlineSelectionProcess?: string | null;
 }
 
+/**
+ * AllVotersHub updateVoters — same thin online-window fields as FrontDesk.
+ * Clients re-fetch GET availableElections (do not trust as full election detail).
+ */
+export type UpdateVotersEvent = OnlineElectionUpdateEvent;
+
+/**
+ * VoterPersonalHub updateVoter — registration change and/or multi-device login.
+ * Clients re-fetch status / election list; login:true shows a notice.
+ */
+export interface UpdateVoterEvent {
+  updateRegistration?: boolean;
+  electionGuid?: string | null;
+  votingMethod?: string | null;
+  registrationTime?: string | null;
+  login?: boolean;
+}
+
 export interface TallyProgressEvent {
   electionGuid: string;
   totalBallots: number;


### PR DESCRIPTION
## Summary
- Restores v3 AllVoters + VoterPersonal realtime for online voters via `/hubs/all-voters` and `/hubs/voter-personal` (OnlineVoter JWT, thin refetch signals only).
- Producers: online window/process changes fan out to AllVoters; front desk registration changes and multi-device login hit personal groups (server-derived voter id).
- Frontend connects voter hubs after auth, refetches available elections / vote status, and shows a login-elsewhere notice.

## Test plan
- [ ] Unit tests: SignalRNotificationService + AllVotersHub + VoterPersonalHub (fan-out + group isolation)
- [ ] Online voter auth → elections page: browser joins both hubs (Network / SignalR)
- [ ] Change election online open/close while voter list is open → list refreshes without full reload
- [ ] Front desk check-in/unregister person matching connected voter → voter list/status refreshes
- [ ] Log in as same voter in second browser → first session shows login-elsewhere warning
- [ ] Confirm voter A personal group never receives voter B updates
- [ ] Logout disconnects voter hubs cleanly

Closes #233