### PR TITLE
Reject reserved/malformed phones before Twilio (#254 first slice)

### DIFF
--- a/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
@@ -225,7 +225,7 @@ public class OnlineVotingBallotFlowTests : IntegrationTestBase
     [Fact]
     public async Task RequestCode_WithPhoneNumber_SucceedsForRegisteredVoter()
     {
-        var phone = "+15559876543";
+        var phone = "+16478971234";
         await SetupOpenElectionWithVoter(phone: phone);
 
         var response = await Client.PostAsJsonAsync("/api/online-voting/requestCode", new RequestCodeDto

--- a/Backend.Tests/IntegrationTests/VoterAuthenticationFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/VoterAuthenticationFlowTests.cs
@@ -93,7 +93,7 @@ public class VoterAuthenticationFlowTests : IntegrationTestBase
     public async Task RequestCode_WithPhoneNumber_ValidVoter_ShouldSucceed()
     {
         // Arrange
-        var phoneNumber = "+15551234567";
+        var phoneNumber = "+14168972671";
         await SetupOpenElectionWithVoter(null, phoneNumber);
 
         var request = new RequestCodeDto

--- a/Backend.Tests/IntegrationTests/VoterOtpAuthFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/VoterOtpAuthFlowTests.cs
@@ -55,7 +55,7 @@ public class VoterOtpAuthFlowTests : IntegrationTestBase
     [Fact]
     public async Task PhoneRequestCode_ThenVerifyCode_ReturnsVoterSession()
     {
-        var phone = "+15559870123";
+        var phone = "+14168972672";
         await SetupOpenElectionWithVoter(phone: phone);
 
         var requestResponse = await Client.PostAsJsonAsync("/api/online-voting/requestCode", new RequestCodeDto

--- a/Backend.Tests/UnitTests/Helpers/PaidDestinationPhoneTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/PaidDestinationPhoneTests.cs
@@ -1,0 +1,78 @@
+using Backend.Helpers;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class PaidDestinationPhoneTests
+{
+    [Theory]
+    [InlineData("+14168972671")]
+    [InlineData("14168972671")]
+    [InlineData("+447911123456")]
+    [InlineData("+16043871234")]
+    public void IsAllowed_AcceptsNormalE164(string phone)
+    {
+        Assert.True(PaidDestinationPhone.IsAllowed(phone));
+        Assert.True(PaidDestinationPhone.TryExplain(phone, out var reason));
+        Assert.Null(reason);
+    }
+
+    [Theory]
+    [InlineData("+15551234567")]
+    [InlineData("15551234567")]
+    [InlineData("5551234567")]
+    [InlineData("+15550123456")]
+    public void IsAllowed_RejectsNanpAreaCode555(string phone)
+    {
+        Assert.False(PaidDestinationPhone.IsAllowed(phone));
+        Assert.False(PaidDestinationPhone.TryExplain(phone, out var reason));
+        Assert.Equal(PaidDestinationPhone.ReasonNanp555, reason);
+    }
+
+    [Theory]
+    [InlineData("+14155550100")]
+    [InlineData("+14155551212")]
+    [InlineData("14155550199")]
+    [InlineData("4155550100")]
+    public void IsAllowed_RejectsNanpExchange555(string phone)
+    {
+        Assert.False(PaidDestinationPhone.IsAllowed(phone));
+        Assert.False(PaidDestinationPhone.TryExplain(phone, out var reason));
+        Assert.Equal(PaidDestinationPhone.ReasonNanp555, reason);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-phone")]
+    [InlineData("555-0100")]
+    [InlineData("+0123456789")]
+    [InlineData("+123")]
+    [InlineData("+1")]
+    [InlineData("1234567")]
+    [InlineData("+1234567890123456")]
+    public void IsAllowed_RejectsMalformedE164(string? phone)
+    {
+        Assert.False(PaidDestinationPhone.IsAllowed(phone));
+        Assert.False(PaidDestinationPhone.TryExplain(phone, out var reason));
+        Assert.Equal(PaidDestinationPhone.ReasonMalformedE164, reason);
+    }
+
+    [Theory]
+    [InlineData("sms")]
+    [InlineData("voice")]
+    [InlineData("whatsapp")]
+    public void IsPaidChannel_RecognizesPaidMethods(string method)
+    {
+        Assert.True(PaidDestinationPhone.IsPaidChannel(method));
+    }
+
+    [Theory]
+    [InlineData("email")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsPaidChannel_IgnoresUnpaidMethods(string? method)
+    {
+        Assert.False(PaidDestinationPhone.IsPaidChannel(method));
+    }
+}

--- a/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
+++ b/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
@@ -1,0 +1,169 @@
+using Backend.DTOs.OnlineVoting;
+using Backend.Entities;
+using Backend.Enumerations;
+using Backend.Services;
+using Backend.Services.Auth;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Backend.Tests.UnitTests.Services;
+
+/// <summary>
+/// Paid-channel requestCode gate: reserved/malformed phones never reach the provider;
+/// a normal E.164 still hits the existing open-election registration check.
+/// </summary>
+public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
+{
+    private const string ValidPhone = "+14168972671";
+
+    private readonly Mock<IPaidVerificationSender> _paidSender = new();
+    private readonly OnlineVotingService _service;
+
+    public OnlineVotingServiceRequestCodePaidPhoneTests()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        var hostEnvironment = new Mock<IHostEnvironment>();
+        hostEnvironment.Setup(e => e.EnvironmentName).Returns("Testing");
+        var emailSender = new Mock<IEmailSender>();
+        emailSender
+            .Setup(s => s.SendAsync(It.IsAny<MimeKit.MimeMessage>()))
+            .Returns(Task.CompletedTask);
+
+        _service = new OnlineVotingService(
+            Context,
+            configuration,
+            hostEnvironment.Object,
+            Mock.Of<ILogger<OnlineVotingService>>(),
+            Mock.Of<IHttpClientFactory>(),
+            emailSender.Object,
+            _paidSender.Object,
+            Mock.Of<IGoogleIdTokenValidator>(),
+            Mock.Of<ISignalRNotificationService>());
+    }
+
+    [Theory]
+    [InlineData("+15551234567")]
+    [InlineData("+14155550100")]
+    [InlineData("+14155551212")]
+    [InlineData("not-a-phone")]
+    [InlineData("+123")]
+    [InlineData("+0123456789")]
+    public async Task RequestCode_ReservedOrMalformedPhone_DoesNotCallProvider(string phone)
+    {
+        await SeedOpenElectionWithPerson(phone: phone);
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(phone));
+
+        Assert.Equal("voting.auth.requestCode.invalidPhone", result.MessageKey);
+        Assert.Null(result.DevVerificationCode);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendVoiceAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendWhatsAppAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        Assert.False(await Context.OnlineVoters.AnyAsync(ov => ov.VoterId == phone));
+    }
+
+    [Theory]
+    [InlineData("voice")]
+    [InlineData("whatsapp")]
+    public async Task RequestCode_ReservedPhone_BlocksVoiceAndWhatsApp(string deliveryMethod)
+    {
+        const string phone = "+15550123456";
+        await SeedOpenElectionWithPerson(phone: phone);
+
+        var result = await _service.RequestVerificationCodeAsync(new RequestCodeDto
+        {
+            VoterId = phone,
+            VoterIdType = "P",
+            DeliveryMethod = deliveryMethod
+        });
+
+        Assert.Equal("voting.auth.requestCode.invalidPhone", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendVoiceAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendWhatsAppAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RequestCode_ValidE164_NotRegistered_ReachesRegistrationCheck()
+    {
+        await SeedOpenElectionWithPerson(email: "other@example.com");
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        Assert.Equal("voting.auth.requestCode.notRegistered", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        Assert.False(await Context.OnlineVoters.AnyAsync(ov => ov.VoterId == ValidPhone));
+    }
+
+    [Fact]
+    public async Task RequestCode_ValidE164_Registered_CallsMockedProvider()
+    {
+        await SeedOpenElectionWithPerson(phone: ValidPhone);
+        _paidSender
+            .Setup(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        Assert.Equal("voting.auth.requestCode.sent", result.MessageKey);
+        Assert.False(string.IsNullOrWhiteSpace(result.DevVerificationCode));
+        _paidSender.Verify(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestCode_Email_DoesNotUsePaidSender()
+    {
+        const string email = "voter@example.com";
+        await SeedOpenElectionWithPerson(email: email);
+
+        var result = await _service.RequestVerificationCodeAsync(new RequestCodeDto
+        {
+            VoterId = email,
+            VoterIdType = "E",
+            DeliveryMethod = "email"
+        });
+
+        Assert.Equal("voting.auth.requestCode.sent", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    private static RequestCodeDto PaidSmsRequest(string phone) => new()
+    {
+        VoterId = phone,
+        VoterIdType = "P",
+        DeliveryMethod = "sms"
+    };
+
+    private async Task SeedOpenElectionWithPerson(string? email = null, string? phone = null)
+    {
+        var electionGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Paid phone gate election",
+            UseOnlineVoting = true,
+            OnlineWhenOpen = DateTimeOffset.UtcNow.AddHours(-1),
+            OnlineWhenClose = DateTimeOffset.UtcNow.AddHours(1),
+            ElectionStage = ElectionStage.GatheringBallots,
+            NumberToElect = 9,
+            RowVersion = new byte[8]
+        });
+
+        Context.People.Add(new Person
+        {
+            ElectionGuid = electionGuid,
+            PersonGuid = Guid.NewGuid(),
+            FirstName = "Test",
+            LastName = "Voter",
+            Email = email,
+            Phone = phone,
+            CanVote = true,
+            RowVersion = new byte[8]
+        });
+
+        await Context.SaveChangesAsync();
+    }
+}

--- a/Backend.Tests/UnitTests/Services/PaidVerificationSenderTests.cs
+++ b/Backend.Tests/UnitTests/Services/PaidVerificationSenderTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using Backend.Services.Auth;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Backend.Tests.UnitTests.Services;
+
+/// <summary>
+/// Defense-in-depth: the sender itself must not call Twilio/GreenAPI for rejected destinations.
+/// </summary>
+public class PaidVerificationSenderTests
+{
+    [Theory]
+    [InlineData("+15551234567")]
+    [InlineData("+14155550100")]
+    [InlineData("not-a-phone")]
+    public async Task SendSms_RejectedDestination_DoesNotCreateHttpClient(string phone)
+    {
+        var httpFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+        var sender = CreateSender(httpFactory.Object);
+
+        var sent = await sender.SendSmsAsync(phone, "ABC123");
+
+        Assert.False(sent);
+        httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendVoice_ReservedPhone_DoesNotCreateHttpClient()
+    {
+        var httpFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+        var sender = CreateSender(httpFactory.Object);
+
+        var sent = await sender.SendVoiceAsync("+15550123456", "ABC123");
+
+        Assert.False(sent);
+        httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendWhatsApp_ReservedPhone_DoesNotCreateHttpClient()
+    {
+        var httpFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+        var sender = CreateSender(httpFactory.Object);
+
+        var sent = await sender.SendWhatsAppAsync("+14155550100", "ABC123");
+
+        Assert.False(sent);
+        httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendSms_ValidPhone_WithoutTwilioConfig_SkipsWithoutHttp()
+    {
+        var httpFactory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+        var sender = CreateSender(httpFactory.Object);
+
+        var sent = await sender.SendSmsAsync("+14168972671", "ABC123");
+
+        Assert.True(sent);
+        httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendSms_ValidPhone_WithTwilioConfig_PostsToTwilio()
+    {
+        var handler = new RecordingHandler(HttpStatusCode.Created);
+        var httpFactory = new Mock<IHttpClientFactory>();
+        httpFactory
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient(handler));
+
+        var sender = CreateSender(httpFactory.Object, new Dictionary<string, string?>
+        {
+            ["Twilio:AccountSid"] = "ACtest",
+            ["Twilio:AuthToken"] = "token",
+            ["Twilio:FromNumber"] = "+14165550000"
+        });
+
+        var sent = await sender.SendSmsAsync("+14168972671", "ABC123");
+
+        Assert.True(sent);
+        Assert.NotNull(handler.LastRequest);
+        Assert.Contains("api.twilio.com", handler.LastRequest!.RequestUri!.Host, StringComparison.Ordinal);
+        Assert.Contains("/Messages.json", handler.LastRequest.RequestUri!.AbsolutePath, StringComparison.Ordinal);
+    }
+
+    private static PaidVerificationSender CreateSender(
+        IHttpClientFactory httpFactory,
+        Dictionary<string, string?>? values = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values ?? new Dictionary<string, string?>())
+            .Build();
+
+        return new PaidVerificationSender(
+            configuration,
+            httpFactory,
+            Mock.Of<ILogger<PaidVerificationSender>>());
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+
+        public RecordingHandler(HttpStatusCode statusCode)
+        {
+            _statusCode = statusCode;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent("{}")
+            });
+        }
+    }
+}

--- a/Backend.Tests/UnitTests/Validators/RequestCodeDtoValidatorTests.cs
+++ b/Backend.Tests/UnitTests/Validators/RequestCodeDtoValidatorTests.cs
@@ -7,10 +7,13 @@ public class RequestCodeDtoValidatorTests
 {
     private readonly RequestCodeDtoValidator _validator = new();
 
-    [Fact]
-    public void Phone_NormalE164_IsValid()
+    [Theory]
+    [InlineData("sms")]
+    [InlineData("voice")]
+    [InlineData("whatsapp")]
+    public void Phone_NormalE164_IsValid(string deliveryMethod)
     {
-        var result = _validator.Validate(PaidRequest("+14168972671"));
+        var result = _validator.Validate(PaidRequest("+14168972671", deliveryMethod));
 
         Assert.True(result.IsValid);
     }
@@ -22,7 +25,7 @@ public class RequestCodeDtoValidatorTests
     [InlineData("+123")]
     public void Phone_ReservedOrMalformed_IsInvalid(string phone)
     {
-        var result = _validator.Validate(PaidRequest(phone));
+        var result = _validator.Validate(PaidRequest(phone, "whatsapp"));
 
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, e => e.PropertyName == nameof(RequestCodeDto.VoterId));
@@ -41,10 +44,10 @@ public class RequestCodeDtoValidatorTests
         Assert.True(result.IsValid);
     }
 
-    private static RequestCodeDto PaidRequest(string phone) => new()
+    private static RequestCodeDto PaidRequest(string phone, string deliveryMethod = "sms") => new()
     {
         VoterId = phone,
         VoterIdType = "P",
-        DeliveryMethod = "sms"
+        DeliveryMethod = deliveryMethod
     };
 }

--- a/Backend.Tests/UnitTests/Validators/RequestCodeDtoValidatorTests.cs
+++ b/Backend.Tests/UnitTests/Validators/RequestCodeDtoValidatorTests.cs
@@ -1,0 +1,50 @@
+using Backend.DTOs.OnlineVoting;
+using Backend.Validators;
+
+namespace Backend.Tests.UnitTests.Validators;
+
+public class RequestCodeDtoValidatorTests
+{
+    private readonly RequestCodeDtoValidator _validator = new();
+
+    [Fact]
+    public void Phone_NormalE164_IsValid()
+    {
+        var result = _validator.Validate(PaidRequest("+14168972671"));
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData("+15551234567")]
+    [InlineData("+14155550100")]
+    [InlineData("not-a-phone")]
+    [InlineData("+123")]
+    public void Phone_ReservedOrMalformed_IsInvalid(string phone)
+    {
+        var result = _validator.Validate(PaidRequest(phone));
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.PropertyName == nameof(RequestCodeDto.VoterId));
+    }
+
+    [Fact]
+    public void Email_IsUnchangedByPhoneRules()
+    {
+        var result = _validator.Validate(new RequestCodeDto
+        {
+            VoterId = "voter@example.com",
+            VoterIdType = "E",
+            DeliveryMethod = "email"
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    private static RequestCodeDto PaidRequest(string phone) => new()
+    {
+        VoterId = phone,
+        VoterIdType = "P",
+        DeliveryMethod = "sms"
+    };
+}

--- a/backend/DTOs/OnlineVoting/RequestCodeDto.cs
+++ b/backend/DTOs/OnlineVoting/RequestCodeDto.cs
@@ -16,7 +16,7 @@ public class RequestCodeDto
     public string VoterIdType { get; set; } = null!;
 
     /// <summary>
-    /// The delivery method for the verification code: 'email', 'sms', or 'voice'.
+    /// The delivery method for the verification code: 'email', 'sms', 'voice', or 'whatsapp'.
     /// </summary>
     public string DeliveryMethod { get; set; } = null!;
 }

--- a/backend/Helpers/PaidDestinationPhone.cs
+++ b/backend/Helpers/PaidDestinationPhone.cs
@@ -1,0 +1,102 @@
+using System.Text.RegularExpressions;
+
+namespace Backend.Helpers;
+
+/// <summary>
+/// In-code checks for destinations that must never reach a paid SMS / voice / WhatsApp provider.
+/// No database lookup — reserved NANP ranges and E.164 shape only.
+/// </summary>
+public static class PaidDestinationPhone
+{
+    /// <summary>
+    /// Reason code when the value is not a usable E.164 (or E.164-shaped) number.
+    /// </summary>
+    public const string ReasonMalformedE164 = "malformed-e164";
+
+    /// <summary>
+    /// Reason code when the number is a reserved/fictional NANP 555 range.
+    /// </summary>
+    public const string ReasonNanp555 = "555-range";
+
+    // Standard NANP national number: NXX-NXX-XXXX (area code 555, or exchange 555).
+    private static readonly Regex NanpAreaCode555 = new(@"^1?555\d{7}$", RegexOptions.Compiled);
+    private static readonly Regex NanpExchange555 = new(@"^1?[2-9]\d{2}555\d{4}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Paid verification channels that incur provider charges.
+    /// </summary>
+    public static bool IsPaidChannel(string? deliveryMethod) =>
+        deliveryMethod is "sms" or "voice" or "whatsapp";
+
+    /// <summary>
+    /// Whether <paramref name="phone"/> may be passed to a paid provider.
+    /// </summary>
+    public static bool IsAllowed(string? phone) => TryExplain(phone, out _);
+
+    /// <summary>
+    /// Validates <paramref name="phone"/> and returns a short reason code when it is not allowed.
+    /// </summary>
+    public static bool TryExplain(string? phone, out string? reason)
+    {
+        reason = null;
+
+        if (!TryGetInternationalDigits(phone, out var digits))
+        {
+            reason = ReasonMalformedE164;
+            return false;
+        }
+
+        if (IsReservedNanp555(digits))
+        {
+            reason = ReasonNanp555;
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True for NANP area code 555 or exchange 555 (including the 555-01xx fictional block).
+    /// </summary>
+    public static bool IsReservedNanp555(string digits) =>
+        NanpAreaCode555.IsMatch(digits) || NanpExchange555.IsMatch(digits);
+
+    /// <summary>
+    /// Accepts true E.164 (<c>+</c> then 8–15 digits) or the same digit string without <c>+</c>.
+    /// </summary>
+    private static bool TryGetInternationalDigits(string? phone, out string digits)
+    {
+        digits = string.Empty;
+        if (string.IsNullOrWhiteSpace(phone))
+        {
+            return false;
+        }
+
+        var trimmed = phone.Trim();
+        if (trimmed[0] == '+')
+        {
+            trimmed = trimmed[1..];
+        }
+
+        if (trimmed.Length is < 8 or > 15)
+        {
+            return false;
+        }
+
+        if (trimmed[0] is < '1' or > '9')
+        {
+            return false;
+        }
+
+        for (var i = 1; i < trimmed.Length; i++)
+        {
+            if (trimmed[i] is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+
+        digits = trimmed;
+        return true;
+    }
+}

--- a/backend/Program.ServiceRegistration.cs
+++ b/backend/Program.ServiceRegistration.cs
@@ -51,6 +51,7 @@ public static class ProgramServiceRegistration
         });
 
         services.AddScoped<IEmailSender, SmtpEmailSender>();
+        services.AddScoped<IPaidVerificationSender, PaidVerificationSender>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
         services.AddScoped<EmailService>();
         services.AddScoped<ILocalAuthService, LocalAuthService>();

--- a/backend/Services/Auth/IPaidVerificationSender.cs
+++ b/backend/Services/Auth/IPaidVerificationSender.cs
@@ -2,7 +2,7 @@ namespace Backend.Services.Auth;
 
 /// <summary>
 /// Sends a verification code over a paid channel (SMS / voice / WhatsApp).
-/// Implementations must not call a provider when <see cref="Helpers.PaidDestinationPhone"/> rejects the destination.
+/// Implementations must not call a provider when <see cref="Backend.Helpers.PaidDestinationPhone"/> rejects the destination.
 /// </summary>
 public interface IPaidVerificationSender
 {

--- a/backend/Services/Auth/IPaidVerificationSender.cs
+++ b/backend/Services/Auth/IPaidVerificationSender.cs
@@ -1,0 +1,23 @@
+namespace Backend.Services.Auth;
+
+/// <summary>
+/// Sends a verification code over a paid channel (SMS / voice / WhatsApp).
+/// Implementations must not call a provider when <see cref="Helpers.PaidDestinationPhone"/> rejects the destination.
+/// </summary>
+public interface IPaidVerificationSender
+{
+    /// <summary>
+    /// Sends the code via SMS.
+    /// </summary>
+    Task<bool> SendSmsAsync(string phone, string code);
+
+    /// <summary>
+    /// Sends the code via a voice call.
+    /// </summary>
+    Task<bool> SendVoiceAsync(string phone, string code);
+
+    /// <summary>
+    /// Sends the code via WhatsApp.
+    /// </summary>
+    Task<bool> SendWhatsAppAsync(string phone, string code);
+}

--- a/backend/Services/Auth/PaidVerificationSender.cs
+++ b/backend/Services/Auth/PaidVerificationSender.cs
@@ -41,8 +41,8 @@ public class PaidVerificationSender : IPaidVerificationSender
         if (!PaidDestinationPhone.TryExplain(phone, out var reason))
         {
             _logger.LogWarning(
-                "Skipping {Channel} send; destination rejected ({Reason}): {Phone}",
-                channel, reason, phone);
+                "Skipping {Channel} send; destination rejected ({Reason})",
+                channel, reason);
             return false;
         }
 
@@ -54,7 +54,7 @@ public class PaidVerificationSender : IPaidVerificationSender
         var accountSid = _configuration["Twilio:AccountSid"];
         if (string.IsNullOrWhiteSpace(accountSid) || accountSid.StartsWith('<'))
         {
-            _logger.LogWarning("Twilio not configured; skipping SMS for {Phone}", phone);
+            _logger.LogWarning("Twilio not configured; skipping SMS");
             return true;
         }
 
@@ -78,12 +78,11 @@ public class PaidVerificationSender : IPaidVerificationSender
 
         if (!response.IsSuccessStatusCode)
         {
-            var body = await response.Content.ReadAsStringAsync();
-            _logger.LogError("Twilio SMS failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
+            _logger.LogError("Twilio SMS failed: {Status}", response.StatusCode);
             return false;
         }
 
-        _logger.LogInformation("SMS verification code sent to {Phone}", phone);
+        _logger.LogInformation("SMS verification code sent");
         return true;
     }
 
@@ -92,7 +91,7 @@ public class PaidVerificationSender : IPaidVerificationSender
         var accountSid = _configuration["Twilio:AccountSid"];
         if (string.IsNullOrWhiteSpace(accountSid) || accountSid.StartsWith('<'))
         {
-            _logger.LogWarning("Twilio not configured; skipping voice call for {Phone}", phone);
+            _logger.LogWarning("Twilio not configured; skipping voice call");
             return true;
         }
 
@@ -122,12 +121,11 @@ public class PaidVerificationSender : IPaidVerificationSender
 
         if (!response.IsSuccessStatusCode)
         {
-            var body = await response.Content.ReadAsStringAsync();
-            _logger.LogError("Twilio voice call failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
+            _logger.LogError("Twilio voice call failed: {Status}", response.StatusCode);
             return false;
         }
 
-        _logger.LogInformation("Voice verification code sent to {Phone}", phone);
+        _logger.LogInformation("Voice verification code sent");
         return true;
     }
 
@@ -139,7 +137,7 @@ public class PaidVerificationSender : IPaidVerificationSender
 
         if (string.IsNullOrWhiteSpace(idInstance) || idInstance.StartsWith('<'))
         {
-            _logger.LogWarning("GreenAPI not configured; skipping WhatsApp for {Phone}", phone);
+            _logger.LogWarning("GreenAPI not configured; skipping WhatsApp");
             return true;
         }
 
@@ -162,12 +160,11 @@ public class PaidVerificationSender : IPaidVerificationSender
 
         if (!response.IsSuccessStatusCode)
         {
-            var body = await response.Content.ReadAsStringAsync();
-            _logger.LogError("GreenAPI WhatsApp failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
+            _logger.LogError("GreenAPI WhatsApp failed: {Status}", response.StatusCode);
             return false;
         }
 
-        _logger.LogInformation("WhatsApp verification code sent to {Phone}", phone);
+        _logger.LogInformation("WhatsApp verification code sent");
         return true;
     }
 

--- a/backend/Services/Auth/PaidVerificationSender.cs
+++ b/backend/Services/Auth/PaidVerificationSender.cs
@@ -1,0 +1,178 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Backend.Helpers;
+
+namespace Backend.Services.Auth;
+
+/// <summary>
+/// Twilio (SMS / voice) and GreenAPI (WhatsApp) delivery for verification codes.
+/// </summary>
+public class PaidVerificationSender : IPaidVerificationSender
+{
+    private readonly IConfiguration _configuration;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<PaidVerificationSender> _logger;
+
+    public PaidVerificationSender(
+        IConfiguration configuration,
+        IHttpClientFactory httpClientFactory,
+        ILogger<PaidVerificationSender> logger)
+    {
+        _configuration = configuration;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> SendSmsAsync(string phone, string code) =>
+        SendIfAllowedAsync(phone, "SMS", () => SendSmsCoreAsync(phone, code));
+
+    /// <inheritdoc/>
+    public Task<bool> SendVoiceAsync(string phone, string code) =>
+        SendIfAllowedAsync(phone, "voice", () => SendVoiceCoreAsync(phone, code));
+
+    /// <inheritdoc/>
+    public Task<bool> SendWhatsAppAsync(string phone, string code) =>
+        SendIfAllowedAsync(phone, "WhatsApp", () => SendWhatsAppCoreAsync(phone, code));
+
+    private async Task<bool> SendIfAllowedAsync(string phone, string channel, Func<Task<bool>> send)
+    {
+        if (!PaidDestinationPhone.TryExplain(phone, out var reason))
+        {
+            _logger.LogWarning(
+                "Skipping {Channel} send; destination rejected ({Reason}): {Phone}",
+                channel, reason, phone);
+            return false;
+        }
+
+        return await send();
+    }
+
+    private async Task<bool> SendSmsCoreAsync(string phone, string code)
+    {
+        var accountSid = _configuration["Twilio:AccountSid"];
+        if (string.IsNullOrWhiteSpace(accountSid) || accountSid.StartsWith('<'))
+        {
+            _logger.LogWarning("Twilio not configured; skipping SMS for {Phone}", phone);
+            return true;
+        }
+
+        var authToken = _configuration["Twilio:AuthToken"];
+        var fromNumber = _configuration["Twilio:FromNumber"];
+
+        var client = _httpClientFactory.CreateClient();
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{accountSid}:{authToken}"));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+        var formData = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("To", phone),
+            new KeyValuePair<string, string>("From", fromNumber ?? ""),
+            new KeyValuePair<string, string>("Body", $"Your TallyJ voting code is: {code}\n\nThis code expires in 15 minutes.")
+        });
+
+        var response = await client.PostAsync(
+            $"https://api.twilio.com/2010-04-01/Accounts/{accountSid}/Messages.json",
+            formData);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            _logger.LogError("Twilio SMS failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
+            return false;
+        }
+
+        _logger.LogInformation("SMS verification code sent to {Phone}", phone);
+        return true;
+    }
+
+    private async Task<bool> SendVoiceCoreAsync(string phone, string code)
+    {
+        var accountSid = _configuration["Twilio:AccountSid"];
+        if (string.IsNullOrWhiteSpace(accountSid) || accountSid.StartsWith('<'))
+        {
+            _logger.LogWarning("Twilio not configured; skipping voice call for {Phone}", phone);
+            return true;
+        }
+
+        var authToken = _configuration["Twilio:AuthToken"];
+        var fromNumber = _configuration["Twilio:FromNumber"];
+
+        var spokenCode = string.Join(". ", code.ToCharArray());
+        var twiml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<Response>
+  <Say language=""en-US"">Your TallyJ voting code is: {spokenCode}. I repeat: {spokenCode}. This code expires in 15 minutes.</Say>
+</Response>";
+
+        var client = _httpClientFactory.CreateClient();
+        var credentials = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{accountSid}:{authToken}"));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+        var formData = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("To", phone),
+            new KeyValuePair<string, string>("From", fromNumber ?? ""),
+            new KeyValuePair<string, string>("Twiml", twiml)
+        });
+
+        var response = await client.PostAsync(
+            $"https://api.twilio.com/2010-04-01/Accounts/{accountSid}/Calls.json",
+            formData);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            _logger.LogError("Twilio voice call failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
+            return false;
+        }
+
+        _logger.LogInformation("Voice verification code sent to {Phone}", phone);
+        return true;
+    }
+
+    private async Task<bool> SendWhatsAppCoreAsync(string phone, string code)
+    {
+        var idInstance = _configuration["GreenApi:IdInstance"];
+        var apiToken = _configuration["GreenApi:ApiToken"];
+        var baseUrl = _configuration["GreenApi:BaseUrl"] ?? "https://api.green-api.com";
+
+        if (string.IsNullOrWhiteSpace(idInstance) || idInstance.StartsWith('<'))
+        {
+            _logger.LogWarning("GreenAPI not configured; skipping WhatsApp for {Phone}", phone);
+            return true;
+        }
+
+        var normalizedPhone = NormalizePhoneForWhatsApp(phone);
+        var chatId = $"{normalizedPhone}@c.us";
+
+        var client = _httpClientFactory.CreateClient("GreenApi");
+        var url = $"{baseUrl}/waInstance{idInstance}/sendMessage/{apiToken}";
+
+        var payload = new
+        {
+            chatId,
+            message = $"Your TallyJ voting code is: {code}\n\nThis code expires in 15 minutes."
+        };
+
+        var json = JsonSerializer.Serialize(payload);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(url, content);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            _logger.LogError("GreenAPI WhatsApp failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
+            return false;
+        }
+
+        _logger.LogInformation("WhatsApp verification code sent to {Phone}", phone);
+        return true;
+    }
+
+    private static string NormalizePhoneForWhatsApp(string phone)
+    {
+        return new string(phone.Where(char.IsDigit).ToArray());
+    }
+}

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -1,9 +1,6 @@
-using System.Collections.Generic;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
 using Backend.Entities;
 using Backend.DTOs.OnlineVoting;
+using Backend.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using MimeKit;
@@ -17,6 +14,18 @@ public partial class OnlineVotingService
     {
         try
         {
+            // Paid channels: reject reserved/fictional/malformed destinations before any DB or provider work.
+            if (dto.VoterIdType == "P" && PaidDestinationPhone.IsPaidChannel(dto.DeliveryMethod))
+            {
+                if (!PaidDestinationPhone.TryExplain(dto.VoterId, out var reason))
+                {
+                    _logger.LogWarning(
+                        "Login code request rejected: paid destination {VoterId} blocked ({Reason})",
+                        dto.VoterId, reason);
+                    return BuildRequestCodeResponse("voting.auth.requestCode.invalidPhone");
+                }
+            }
+
             // 1. Find all open elections where this voter is registered (SMS pumping prevention)
             var now = DateTimeOffset.UtcNow;
             var openElections = await _context.Elections
@@ -195,9 +204,9 @@ public partial class OnlineVotingService
             return method switch
             {
                 "email" => await SendEmailCodeAsync(recipient, code),
-                "sms" => await SendSmsCodeAsync(recipient, code),
-                "voice" => await SendVoiceCodeAsync(recipient, code),
-                "whatsapp" => await SendWhatsAppCodeAsync(recipient, code),
+                "sms" => await _paidVerificationSender.SendSmsAsync(recipient, code),
+                "voice" => await _paidVerificationSender.SendVoiceAsync(recipient, code),
+                "whatsapp" => await _paidVerificationSender.SendWhatsAppAsync(recipient, code),
                 _ => throw new ArgumentException($"Unknown delivery method: {method}")
             };
         }
@@ -236,157 +245,6 @@ public partial class OnlineVotingService
         await _emailSender.SendAsync(message);
         _logger.LogInformation("Email verification code sent to {Email}", email);
         return true;
-    }
-
-    /// <summary>
-    /// Sends a verification code via SMS using Twilio API.
-    /// </summary>
-    /// <param name="phone">The recipient's phone number.</param>
-    /// <param name="code">The verification code to send.</param>
-    /// <returns>True if the SMS was sent successfully, false otherwise.</returns>
-    private async Task<bool> SendSmsCodeAsync(string phone, string code)
-    {
-        var accountSid = _configuration["Twilio:AccountSid"];
-        if (string.IsNullOrWhiteSpace(accountSid) || accountSid.StartsWith("<"))
-        {
-            _logger.LogWarning("Twilio not configured; skipping SMS for {Phone}", phone);
-            return true;
-        }
-
-        var authToken = _configuration["Twilio:AuthToken"];
-        var fromNumber = _configuration["Twilio:FromNumber"];
-
-        var client = _httpClientFactory.CreateClient();
-        var credentials = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($"{accountSid}:{authToken}"));
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-
-        var formData = new FormUrlEncodedContent(new[]
-        {
-            new KeyValuePair<string, string>("To", phone),
-            new KeyValuePair<string, string>("From", fromNumber ?? ""),
-            new KeyValuePair<string, string>("Body", $"Your TallyJ voting code is: {code}\n\nThis code expires in 15 minutes.")
-        });
-
-        var response = await client.PostAsync(
-            $"https://api.twilio.com/2010-04-01/Accounts/{accountSid}/Messages.json",
-            formData);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var body = await response.Content.ReadAsStringAsync();
-            _logger.LogError("Twilio SMS failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
-            return false;
-        }
-
-        _logger.LogInformation("SMS verification code sent to {Phone}", phone);
-        return true;
-    }
-
-    /// <summary>
-    /// Sends a verification code via voice call using Twilio API.
-    /// </summary>
-    /// <param name="phone">The recipient's phone number.</param>
-    /// <param name="code">The verification code to send.</param>
-    /// <returns>True if the voice call was initiated successfully, false otherwise.</returns>
-    private async Task<bool> SendVoiceCodeAsync(string phone, string code)
-    {
-        var accountSid = _configuration["Twilio:AccountSid"];
-        if (string.IsNullOrWhiteSpace(accountSid) || accountSid.StartsWith("<"))
-        {
-            _logger.LogWarning("Twilio not configured; skipping voice call for {Phone}", phone);
-            return true;
-        }
-
-        var authToken = _configuration["Twilio:AuthToken"];
-        var fromNumber = _configuration["Twilio:FromNumber"];
-
-        var spokenCode = string.Join(". ", code.ToCharArray());
-        var twiml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
-<Response>
-  <Say language=""en-US"">Your TallyJ voting code is: {spokenCode}. I repeat: {spokenCode}. This code expires in 15 minutes.</Say>
-</Response>";
-
-        var client = _httpClientFactory.CreateClient();
-        var credentials = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($"{accountSid}:{authToken}"));
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
-
-        var formData = new FormUrlEncodedContent(new[]
-        {
-            new KeyValuePair<string, string>("To", phone),
-            new KeyValuePair<string, string>("From", fromNumber ?? ""),
-            new KeyValuePair<string, string>("Twiml", twiml)
-        });
-
-        var response = await client.PostAsync(
-            $"https://api.twilio.com/2010-04-01/Accounts/{accountSid}/Calls.json",
-            formData);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var body = await response.Content.ReadAsStringAsync();
-            _logger.LogError("Twilio voice call failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
-            return false;
-        }
-
-        _logger.LogInformation("Voice verification code sent to {Phone}", phone);
-        return true;
-    }
-
-    /// <summary>
-    /// Sends a verification code via WhatsApp using GreenAPI.
-    /// </summary>
-    /// <param name="phone">The recipient's phone number.</param>
-    /// <param name="code">The verification code to send.</param>
-    /// <returns>True if the WhatsApp message was sent successfully, false otherwise.</returns>
-    private async Task<bool> SendWhatsAppCodeAsync(string phone, string code)
-    {
-        var idInstance = _configuration["GreenApi:IdInstance"];
-        var apiToken = _configuration["GreenApi:ApiToken"];
-        var baseUrl = _configuration["GreenApi:BaseUrl"] ?? "https://api.green-api.com";
-
-        if (string.IsNullOrWhiteSpace(idInstance) || idInstance.StartsWith("<"))
-        {
-            _logger.LogWarning("GreenAPI not configured; skipping WhatsApp for {Phone}", phone);
-            return true;
-        }
-
-        var normalizedPhone = NormalizePhoneForWhatsApp(phone);
-        var chatId = $"{normalizedPhone}@c.us";
-
-        var client = _httpClientFactory.CreateClient("GreenApi");
-        var url = $"{baseUrl}/waInstance{idInstance}/sendMessage/{apiToken}";
-
-        var payload = new
-        {
-            chatId,
-            message = $"Your TallyJ voting code is: {code}\n\nThis code expires in 15 minutes."
-        };
-
-        var json = JsonSerializer.Serialize(payload);
-        var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
-
-        var response = await client.PostAsync(url, content);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var body = await response.Content.ReadAsStringAsync();
-            _logger.LogError("GreenAPI WhatsApp failed for {Phone}: {Status} - {Body}", phone, response.StatusCode, body);
-            return false;
-        }
-
-        _logger.LogInformation("WhatsApp verification code sent to {Phone}", phone);
-        return true;
-    }
-
-    /// <summary>
-    /// Normalizes a phone number for WhatsApp by extracting only the digits.
-    /// </summary>
-    /// <param name="phone">The phone number to normalize.</param>
-    /// <returns>The normalized phone number containing only digits.</returns>
-    private static string NormalizePhoneForWhatsApp(string phone)
-    {
-        var digits = new string(phone.Where(char.IsDigit).ToArray());
-        return digits;
     }
 
     private async Task<(bool Success, string? Error, OnlineVoterAuthResponse? Response)> TryAuthenticateWithDirectCodeAsync(string code)

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -56,7 +56,7 @@ public partial class OnlineVotingService
             if (!isVoterRegistered)
             {
                 _logger.LogWarning("Login code request rejected: voter not found in any open election (type: {VoterIdType})",
-                    dto.VoterIdType);
+                    KnownVoterIdType(dto.VoterIdType));
                 return BuildRequestCodeResponse("voting.auth.requestCode.notRegistered");
             }
 
@@ -91,7 +91,7 @@ public partial class OnlineVotingService
                 : "voting.auth.requestCode.sendFailed";
 
             _logger.LogInformation("Verification code sent via {Method} (registered in {Count} open election(s))",
-                dto.DeliveryMethod, openElections.Count);
+                KnownDeliveryMethod(dto.DeliveryMethod), openElections.Count);
 
             return BuildRequestCodeResponse(messageKey, verifyCode);
         }
@@ -197,7 +197,7 @@ public partial class OnlineVotingService
     /// <returns>True if the code was sent successfully, false otherwise.</returns>
     private async Task<bool> SendVerificationCodeAsync(string recipient, string method, string code)
     {
-        _logger.LogInformation("Sending verification code via {Method}", method);
+        _logger.LogInformation("Sending verification code via {Method}", KnownDeliveryMethod(method));
 
         try
         {
@@ -212,7 +212,7 @@ public partial class OnlineVotingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send verification code via {Method}", method);
+            _logger.LogError(ex, "Failed to send verification code via {Method}", KnownDeliveryMethod(method));
             return false;
         }
     }

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -20,8 +20,8 @@ public partial class OnlineVotingService
                 if (!PaidDestinationPhone.TryExplain(dto.VoterId, out var reason))
                 {
                     _logger.LogWarning(
-                        "Login code request rejected: paid destination {VoterId} blocked ({Reason})",
-                        dto.VoterId, reason);
+                        "Login code request rejected: paid destination blocked ({Reason})",
+                        reason);
                     return BuildRequestCodeResponse("voting.auth.requestCode.invalidPhone");
                 }
             }
@@ -56,7 +56,7 @@ public partial class OnlineVotingService
             if (!isVoterRegistered)
             {
                 _logger.LogWarning("Login code request rejected: VoterId {VoterId} (type: {VoterIdType}) not found in any open election",
-                    dto.VoterId, dto.VoterIdType);
+                    SanitizeForLog(dto.VoterId), dto.VoterIdType);
                 return BuildRequestCodeResponse("voting.auth.requestCode.notRegistered");
             }
 
@@ -91,13 +91,13 @@ public partial class OnlineVotingService
                 : "voting.auth.requestCode.sendFailed";
 
             _logger.LogInformation("Verification code sent to {VoterId} via {Method} (registered in {Count} open election(s))",
-                dto.VoterId, dto.DeliveryMethod, openElections.Count);
+                SanitizeForLog(dto.VoterId), dto.DeliveryMethod, openElections.Count);
 
             return BuildRequestCodeResponse(messageKey, verifyCode);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error requesting verification code for {VoterId}", dto.VoterId);
+            _logger.LogError(ex, "Error requesting verification code for {VoterId}", SanitizeForLog(dto.VoterId));
             return BuildRequestCodeResponse("voting.auth.requestCode.error");
         }
     }
@@ -197,7 +197,7 @@ public partial class OnlineVotingService
     /// <returns>True if the code was sent successfully, false otherwise.</returns>
     private async Task<bool> SendVerificationCodeAsync(string recipient, string method, string code)
     {
-        _logger.LogInformation("Sending verification code to {Recipient} via {Method}", recipient, method);
+        _logger.LogInformation("Sending verification code to {Recipient} via {Method}", SanitizeForLog(recipient), method);
 
         try
         {
@@ -212,7 +212,7 @@ public partial class OnlineVotingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send verification code to {Recipient} via {Method}", recipient, method);
+            _logger.LogError(ex, "Failed to send verification code to {Recipient} via {Method}", SanitizeForLog(recipient), method);
             return false;
         }
     }
@@ -243,7 +243,7 @@ public partial class OnlineVotingService
         message.Body = bodyBuilder.ToMessageBody();
 
         await _emailSender.SendAsync(message);
-        _logger.LogInformation("Email verification code sent to {Email}", email);
+        _logger.LogInformation("Email verification code sent to {Email}", SanitizeForLog(email));
         return true;
     }
 

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -55,8 +55,8 @@ public partial class OnlineVotingService
 
             if (!isVoterRegistered)
             {
-                _logger.LogWarning("Login code request rejected: VoterId {VoterId} (type: {VoterIdType}) not found in any open election",
-                    SanitizeForLog(dto.VoterId), dto.VoterIdType);
+                _logger.LogWarning("Login code request rejected: voter not found in any open election (type: {VoterIdType})",
+                    dto.VoterIdType);
                 return BuildRequestCodeResponse("voting.auth.requestCode.notRegistered");
             }
 
@@ -90,14 +90,14 @@ public partial class OnlineVotingService
                 ? "voting.auth.requestCode.sent"
                 : "voting.auth.requestCode.sendFailed";
 
-            _logger.LogInformation("Verification code sent to {VoterId} via {Method} (registered in {Count} open election(s))",
-                SanitizeForLog(dto.VoterId), dto.DeliveryMethod, openElections.Count);
+            _logger.LogInformation("Verification code sent via {Method} (registered in {Count} open election(s))",
+                dto.DeliveryMethod, openElections.Count);
 
             return BuildRequestCodeResponse(messageKey, verifyCode);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error requesting verification code for {VoterId}", SanitizeForLog(dto.VoterId));
+            _logger.LogError(ex, "Error requesting verification code");
             return BuildRequestCodeResponse("voting.auth.requestCode.error");
         }
     }
@@ -165,13 +165,13 @@ public partial class OnlineVotingService
             };
 
             await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
-            _logger.LogInformation("Voter {VoterId} authenticated successfully", dto.VoterId);
+            _logger.LogInformation("Voter authenticated successfully");
 
             return (true, null, response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error verifying code for {VoterId}", dto.VoterId);
+            _logger.LogError(ex, "Error verifying code");
             return (false, "voting.auth.verify.error", null);
         }
     }
@@ -197,7 +197,7 @@ public partial class OnlineVotingService
     /// <returns>True if the code was sent successfully, false otherwise.</returns>
     private async Task<bool> SendVerificationCodeAsync(string recipient, string method, string code)
     {
-        _logger.LogInformation("Sending verification code to {Recipient} via {Method}", SanitizeForLog(recipient), method);
+        _logger.LogInformation("Sending verification code via {Method}", method);
 
         try
         {
@@ -212,7 +212,7 @@ public partial class OnlineVotingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send verification code to {Recipient} via {Method}", SanitizeForLog(recipient), method);
+            _logger.LogError(ex, "Failed to send verification code via {Method}", method);
             return false;
         }
     }
@@ -243,7 +243,7 @@ public partial class OnlineVotingService
         message.Body = bodyBuilder.ToMessageBody();
 
         await _emailSender.SendAsync(message);
-        _logger.LogInformation("Email verification code sent to {Email}", SanitizeForLog(email));
+        _logger.LogInformation("Email verification code sent");
         return true;
     }
 
@@ -307,8 +307,7 @@ public partial class OnlineVotingService
         };
 
         await NotifyLoginElsewhereAsync(onlineVoter.VoterId);
-        var safeVoterIdForLog = SanitizeForLog(normalizedCode);
-        _logger.LogInformation("Voter {VoterId} authenticated via direct kiosk/personal code", safeVoterIdForLog);
+        _logger.LogInformation("Voter authenticated via direct kiosk/personal code");
         return (true, null, response);
     }
 

--- a/backend/Services/OnlineVotingService.Auth.Helpers.cs
+++ b/backend/Services/OnlineVotingService.Auth.Helpers.cs
@@ -55,4 +55,27 @@ public partial class OnlineVotingService
 
         return input.Replace("\r", "").Replace("\n", "");
     }
+
+    /// <summary>
+    /// Maps a request voter-id type to a closed set so logs are not user-controlled.
+    /// </summary>
+    private static string KnownVoterIdType(string? type) => type switch
+    {
+        "E" => "E",
+        "P" => "P",
+        "C" => "C",
+        _ => "unknown"
+    };
+
+    /// <summary>
+    /// Maps a request delivery method to a closed set so logs are not user-controlled.
+    /// </summary>
+    private static string KnownDeliveryMethod(string? method) => method switch
+    {
+        "email" => "email",
+        "sms" => "sms",
+        "voice" => "voice",
+        "whatsapp" => "whatsapp",
+        _ => "unknown"
+    };
 }

--- a/backend/Services/OnlineVotingService.cs
+++ b/backend/Services/OnlineVotingService.cs
@@ -17,6 +17,7 @@ public partial class OnlineVotingService : IOnlineVotingService
     private readonly ILogger<OnlineVotingService> _logger;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IEmailSender _emailSender;
+    private readonly IPaidVerificationSender _paidVerificationSender;
     private readonly IGoogleIdTokenValidator _googleIdTokenValidator;
     private readonly ISignalRNotificationService _signalRNotificationService;
 
@@ -29,6 +30,7 @@ public partial class OnlineVotingService : IOnlineVotingService
     /// <param name="logger">The logger instance.</param>
     /// <param name="httpClientFactory">The HTTP client factory.</param>
     /// <param name="emailSender">The email sender service.</param>
+    /// <param name="paidVerificationSender">Paid SMS / voice / WhatsApp delivery.</param>
     /// <param name="googleIdTokenValidator">The Google ID token validator.</param>
     /// <param name="signalRNotificationService">Realtime notifications for connected voter sessions.</param>
     public OnlineVotingService(
@@ -38,6 +40,7 @@ public partial class OnlineVotingService : IOnlineVotingService
         ILogger<OnlineVotingService> logger,
         IHttpClientFactory httpClientFactory,
         IEmailSender emailSender,
+        IPaidVerificationSender paidVerificationSender,
         IGoogleIdTokenValidator googleIdTokenValidator,
         ISignalRNotificationService signalRNotificationService)
     {
@@ -47,6 +50,7 @@ public partial class OnlineVotingService : IOnlineVotingService
         _logger = logger;
         _httpClientFactory = httpClientFactory;
         _emailSender = emailSender;
+        _paidVerificationSender = paidVerificationSender;
         _googleIdTokenValidator = googleIdTokenValidator;
         _signalRNotificationService = signalRNotificationService;
     }

--- a/backend/Validators/RequestCodeDtoValidator.cs
+++ b/backend/Validators/RequestCodeDtoValidator.cs
@@ -1,4 +1,5 @@
 ﻿using Backend.DTOs.OnlineVoting;
+using Backend.Helpers;
 using FluentValidation;
 
 namespace Backend.Validators;
@@ -37,9 +38,9 @@ public class RequestCodeDtoValidator : AbstractValidator<RequestCodeDto>
             .WithMessage("Invalid email address");
 
         RuleFor(x => x.VoterId)
-            .Matches(@"^\+?[1-9]\d{1,14}$")
+            .Must(PaidDestinationPhone.IsAllowed)
             .When(x => x.VoterIdType == "P")
-            .WithMessage("Invalid phone number format");
+            .WithMessage("Phone number is reserved, fictional, or not a valid E.164 number");
     }
 }
 

--- a/backend/Validators/RequestCodeDtoValidator.cs
+++ b/backend/Validators/RequestCodeDtoValidator.cs
@@ -29,8 +29,8 @@ public class RequestCodeDtoValidator : AbstractValidator<RequestCodeDto>
         RuleFor(x => x.DeliveryMethod)
             .NotEmpty()
             .WithMessage("Delivery method is required")
-            .Must(x => x == "email" || x == "sms" || x == "voice")
-            .WithMessage("Delivery method must be 'email', 'sms', or 'voice'");
+            .Must(x => x == "email" || PaidDestinationPhone.IsPaidChannel(x))
+            .WithMessage("Delivery method must be 'email', 'sms', 'voice', or 'whatsapp'");
 
         RuleFor(x => x.VoterId)
             .EmailAddress()

--- a/context/index.md
+++ b/context/index.md
@@ -12,3 +12,4 @@ Lean index of project *why* knowledge. Load a topic file only when the work touc
 - [online-ballots.md](online-ballots.md) — online acceptance and random name resolution
 - [people.md](people.md) — person fields; AgeGroup removed (eligibility is V01/X05)
 - [people-import.md](people-import.md) — three-action import pipeline (not a Next/Previous wizard)
+- [sms-eligibility.md](sms-eligibility.md) — reject reserved/fictional/malformed phones before paid SMS/voice/WhatsApp

--- a/context/sms-eligibility.md
+++ b/context/sms-eligibility.md
@@ -1,0 +1,34 @@
+# Paid SMS / voice / WhatsApp destination eligibility
+
+## Status: active
+
+## Evidence: confirmed
+
+**Source:** issue #254 (maintainer); July 555-range send incident described there  
+**Revisit when:** later #254 slices land (`OnlineVoter.SmsStatus`, Person UI, Twilio callback auto-learn), or NANP reserved-range rules change
+
+## In-code gate before any paid provider
+
+Paid verification (SMS / voice / WhatsApp) must not call Twilio or GreenAPI for reserved, fictional, or malformed destinations. The July incident was ~80 attempts to 555-style numbers that still incurred tiny Twilio charges — the existing “registered in an open election” check does not stop an election owner from loading those numbers and opening the window.
+
+**This slice (issue #254, first cut):** a pure in-code helper (`PaidDestinationPhone`) rejects:
+
+- malformed E.164 (and the same digit string without a leading `+`)
+- NANP area code `555`
+- NANP exchange `555` (including the `555-01xx` fictional block)
+
+The check runs at the start of `RequestVerificationCodeAsync` for phone + paid delivery, and again inside `PaidVerificationSender` so a future caller cannot bypass it. Email, OAuth, and kiosk paths are unchanged. `WhenRegistered` is not written for a rejected number.
+
+**Rejected alternative:** rely only on the open-election registration check. That stops outsiders requesting codes for arbitrary numbers; it does not stop fictional numbers that are already on a Person row.
+
+**Rejected alternative:** wait for `OnlineVoter.SmsStatus` (later on the same issue). Status needs a row and a reason vocabulary. 555 / malformed must be blocked with no database work.
+
+**Rejected alternative:** reject only `555-01xx` and allow other 555 NPA/NXX. The incident and the issue call out area code 555 and exchange 555, with `555-01xx` as the most important subset.
+
+**Not in this slice:** `OnlineVoter.SmsStatus`, migrations, Person UI, Twilio status-callback learning, country allow-lists, spend caps.
+
+## Related
+
+- [auth.md](auth.md) — voter JWT claims (separate from paid-destination rules)
+- `docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md` — requestCode flow and SMS pumping
+- Issue #254 remaining work; #255 for WhatsApp / GreenAPI status parity

--- a/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
+++ b/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
@@ -32,6 +32,7 @@ This implementation provides a **security-first voter authentication system** fo
    - Prevents unauthorized election discovery
 
 2. **SMS Pumping Prevention**
+   - Paid SMS / voice / WhatsApp: reserved/fictional/malformed destinations (NANP 555, bad E.164) are rejected in code before any provider call — see `context/sms-eligibility.md`
    - Verification codes only sent to voters registered in open elections
    - Validates voter registration BEFORE sending SMS/email
    - Prevents abuse of communication channels

--- a/frontend/src/locales/en/voting-auth.json
+++ b/frontend/src/locales/en/voting-auth.json
@@ -69,6 +69,7 @@
   "voting.auth.phone.whatsappNote": "A WhatsApp message will be sent to this number",
   "voting.auth.requestCode.error": "An error occurred while processing your request.",
   "voting.auth.requestCode.noOpenElections": "There are no elections currently open for online voting.",
+  "voting.auth.requestCode.invalidPhone": "That phone number cannot be used to receive a verification code.",
   "voting.auth.requestCode.notRegistered": "You are not registered to vote in any currently open election.",
   "voting.auth.requestCode.sendFailed": "Failed to send verification code. Please try again.",
   "voting.auth.requestCode.sent": "If the provided contact information is valid, a verification code has been sent.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes nothing yet — this is the first slice of #254.

## Problem

The existing “registered in an open election” check stops outsiders from requesting codes for arbitrary numbers. It does **not** stop fictional/reserved destinations (classic NANP `555` ranges) that are already on a Person row. Those still hit Twilio and incur tiny charges (the July example in #254).

## This slice

- In-code validator (`PaidDestinationPhone`) rejects:
  - malformed E.164 (and the same digit string without `+`)
  - NANP area code `555`
  - NANP exchange `555` (including `555-01xx`)
- Gate runs in `RequestVerificationCodeAsync` **before** the open-election registration check and again inside `PaidVerificationSender`, so SMS / voice / WhatsApp never reach Twilio or GreenAPI for those numbers.
- Paid delivery is extracted behind `IPaidVerificationSender` so tests mock the provider and do not send SMS.
- FluentValidation on `RequestCodeDto` uses the same helper for phone voter IDs, and now accepts `whatsapp` as well as email/sms/voice (the service and voter UI already supported it).
- Existing request-code tests that used `+1555…` fixtures now use ordinary NANP numbers.
- Request-code / paid-send logs record method, type, reason, and outcome only — no raw phone or email — after CodeQL log-injection and PII annotations.

## Not in this slice (remaining #254)

- `OnlineVoter.SmsStatus` / migration
- `EnsureOnlineVoterForPhoneAsync` on Person create/import/update
- Person UI for SMS status
- Auto-learn from Twilio status callbacks
- Any change to `WhenRegistered` semantics
- Country allow-lists, spend caps, #255 WhatsApp status parity

## Tests

- Helper: 555 / `555-01xx` / malformed rejected; normal E.164 allowed
- Service: reserved/malformed never call the mocked sender (even if the number is on a Person in an open election); a normal E.164 still reaches `notRegistered` / send
- Sender: rejected destinations never create an HTTP client
- Validator: `whatsapp` is a valid delivery method; reserved phones still fail

Email / OAuth / kiosk paths are unchanged.

Fixes part of #254. Do not merge until the rest of the issue is intentionally split or this slice is accepted as-is.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3a6e493-60e1-4305-aeef-e05a4c8a9add?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3a6e493-60e1-4305-aeef-e05a4c8a9add&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

