### PR TITLE
Add OnlineVoter.SmsStatus and honor it on paid send (#254)

### DIFF
--- a/Backend.Tests/UnitTests/Helpers/OnlineVoterSmsStatusTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/OnlineVoterSmsStatusTests.cs
@@ -1,0 +1,28 @@
+using Backend.Helpers;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class OnlineVoterSmsStatusTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("OK")]
+    public void AllowsPaidSend_NullOrOk(string? smsStatus)
+    {
+        Assert.True(OnlineVoterSmsStatus.AllowsPaidSend(smsStatus));
+    }
+
+    [Theory]
+    [InlineData("undeliverable")]
+    [InlineData("555-range")]
+    [InlineData("landline")]
+    [InlineData("premium")]
+    [InlineData("admin")]
+    [InlineData("twilio-30003")]
+    [InlineData("ok")]
+    [InlineData("")]
+    public void AllowsPaidSend_AnyOtherValue_Blocks(string smsStatus)
+    {
+        Assert.False(OnlineVoterSmsStatus.AllowsPaidSend(smsStatus));
+    }
+}

--- a/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
+++ b/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
@@ -1,6 +1,7 @@
 using Backend.DTOs.OnlineVoting;
 using Backend.Entities;
 using Backend.Enumerations;
+using Backend.Helpers;
 using Backend.Services;
 using Backend.Services.Auth;
 using Microsoft.EntityFrameworkCore;
@@ -12,8 +13,8 @@ using Moq;
 namespace Backend.Tests.UnitTests.Services;
 
 /// <summary>
-/// Paid-channel requestCode gate: reserved/malformed phones never reach the provider;
-/// a normal E.164 still hits the existing open-election registration check.
+/// Paid-channel requestCode gate: reserved/malformed phones and blocked SmsStatus
+/// never reach the provider; null/"OK" still hits send or the registration check.
 /// </summary>
 public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
 {
@@ -113,6 +114,87 @@ public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
         _paidSender.Verify(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()), Times.Once);
     }
 
+    [Theory]
+    [InlineData("undeliverable")]
+    [InlineData("555-range")]
+    public async Task RequestCode_SmsStatusBlocked_DoesNotCallProvider(string smsStatus)
+    {
+        await SeedOpenElectionWithPerson(phone: ValidPhone);
+        await SeedOnlineVoter(ValidPhone, smsStatus);
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        Assert.Equal("voting.auth.requestCode.invalidPhone", result.MessageKey);
+        Assert.Null(result.DevVerificationCode);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendVoiceAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendWhatsAppAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("voice")]
+    [InlineData("whatsapp")]
+    public async Task RequestCode_SmsStatusBlocked_BlocksVoiceAndWhatsApp(string deliveryMethod)
+    {
+        await SeedOpenElectionWithPerson(phone: ValidPhone);
+        await SeedOnlineVoter(ValidPhone, "undeliverable");
+
+        var result = await _service.RequestVerificationCodeAsync(new RequestCodeDto
+        {
+            VoterId = ValidPhone,
+            VoterIdType = "P",
+            DeliveryMethod = deliveryMethod
+        });
+
+        Assert.Equal("voting.auth.requestCode.invalidPhone", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendVoiceAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendWhatsAppAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RequestCode_SmsStatusOk_Registered_CallsMockedProvider()
+    {
+        await SeedOpenElectionWithPerson(phone: ValidPhone);
+        await SeedOnlineVoter(ValidPhone, OnlineVoterSmsStatus.Ok);
+        _paidSender
+            .Setup(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        Assert.Equal("voting.auth.requestCode.sent", result.MessageKey);
+        Assert.False(string.IsNullOrWhiteSpace(result.DevVerificationCode));
+        _paidSender.Verify(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestCode_SmsStatusNull_Registered_CallsMockedProvider()
+    {
+        await SeedOpenElectionWithPerson(phone: ValidPhone);
+        await SeedOnlineVoter(ValidPhone, smsStatus: null);
+        _paidSender
+            .Setup(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        Assert.Equal("voting.auth.requestCode.sent", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestCode_SmsStatusOk_NotRegistered_ReachesRegistrationCheck()
+    {
+        await SeedOpenElectionWithPerson(email: "other@example.com");
+        await SeedOnlineVoter(ValidPhone, OnlineVoterSmsStatus.Ok);
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        Assert.Equal("voting.auth.requestCode.notRegistered", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
     [Fact]
     public async Task RequestCode_Email_DoesNotUsePaidSender()
     {
@@ -128,6 +210,8 @@ public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
 
         Assert.Equal("voting.auth.requestCode.sent", result.MessageKey);
         _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendVoiceAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendWhatsAppAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     private static RequestCodeDto PaidSmsRequest(string phone) => new()
@@ -164,6 +248,17 @@ public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
             RowVersion = new byte[8]
         });
 
+        await Context.SaveChangesAsync();
+    }
+
+    private async Task SeedOnlineVoter(string voterId, string? smsStatus, string voterIdType = "P")
+    {
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = voterId,
+            VoterIdType = voterIdType,
+            SmsStatus = smsStatus
+        });
         await Context.SaveChangesAsync();
     }
 }

--- a/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
+++ b/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
@@ -14,7 +14,8 @@ namespace Backend.Tests.UnitTests.Services;
 
 /// <summary>
 /// Paid-channel requestCode gate: reserved/malformed phones and blocked SmsStatus
-/// never reach the provider; null/"OK" still hits send or the registration check.
+/// never reach the provider (SmsStatus is checked before registration);
+/// null/"OK" still hits send or the registration check.
 /// </summary>
 public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
 {
@@ -193,6 +194,22 @@ public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
 
         Assert.Equal("voting.auth.requestCode.notRegistered", result.MessageKey);
         _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RequestCode_SmsStatusBlocked_NotRegistered_ReturnsInvalidPhone()
+    {
+        await SeedOpenElectionWithPerson(email: "other@example.com");
+        await SeedOnlineVoter(ValidPhone, "undeliverable");
+
+        var result = await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        Assert.Equal("voting.auth.requestCode.invalidPhone", result.MessageKey);
+        Assert.NotEqual("voting.auth.requestCode.notRegistered", result.MessageKey);
+        Assert.Null(result.DevVerificationCode);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendVoiceAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _paidSender.Verify(s => s.SendWhatsAppAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [Fact]

--- a/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
+++ b/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
@@ -231,6 +231,47 @@ public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
         _paidSender.Verify(s => s.SendWhatsAppAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
+    [Fact]
+    public async Task RequestCode_Email_BlockedSmsStatus_DoesNotTakeInvalidPhonePath()
+    {
+        const string email = "voter@example.com";
+        await SeedOpenElectionWithPerson(email: email);
+        await SeedOnlineVoter(email, "undeliverable", voterIdType: "E");
+
+        var result = await _service.RequestVerificationCodeAsync(new RequestCodeDto
+        {
+            VoterId = email,
+            VoterIdType = "E",
+            DeliveryMethod = "email"
+        });
+
+        Assert.Equal("voting.auth.requestCode.sent", result.MessageKey);
+        Assert.NotEqual("voting.auth.requestCode.invalidPhone", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RequestCode_EmailType_SmsDelivery_BlockedEmailRow_DoesNotUseSmsStatusGate()
+    {
+        const string email = "voter@example.com";
+        await SeedOpenElectionWithPerson(email: email);
+        await SeedOnlineVoter(email, "undeliverable", voterIdType: "E");
+        _paidSender
+            .Setup(s => s.SendSmsAsync(email, It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.RequestVerificationCodeAsync(new RequestCodeDto
+        {
+            VoterId = email,
+            VoterIdType = "E",
+            DeliveryMethod = "sms"
+        });
+
+        Assert.NotEqual("voting.auth.requestCode.invalidPhone", result.MessageKey);
+        Assert.Equal("voting.auth.requestCode.sent", result.MessageKey);
+        _paidSender.Verify(s => s.SendSmsAsync(email, It.IsAny<string>()), Times.Once);
+    }
+
     private static RequestCodeDto PaidSmsRequest(string phone) => new()
     {
         VoterId = phone,

--- a/backend/Entities/OnlineVoter.cs
+++ b/backend/Entities/OnlineVoter.cs
@@ -36,6 +36,17 @@ public partial class OnlineVoter
     [StringLength(200)]
     public string? OtherInfo { get; set; }
 
+    /// <summary>
+    /// SMS/voice/WhatsApp eligibility when <see cref="VoterIdType"/> is phone.
+    /// null = not yet checked (paid send still allowed);
+    /// "OK" = checked and valid;
+    /// any other short value = blocked (reason code).
+    /// Email / kiosk / Telegram rows leave this null.
+    /// </summary>
+    [StringLength(50)]
+    [Unicode(false)]
+    public string? SmsStatus { get; set; }
+
     [StringLength(15)]
     [Unicode(false)]
     public string? VerifyCode { get; set; }

--- a/backend/Helpers/OnlineVoterSmsStatus.cs
+++ b/backend/Helpers/OnlineVoterSmsStatus.cs
@@ -1,0 +1,18 @@
+namespace Backend.Helpers;
+
+/// <summary>
+/// Durable paid-channel eligibility stored on <see cref="Entities.OnlineVoter.SmsStatus"/>.
+/// </summary>
+public static class OnlineVoterSmsStatus
+{
+    /// <summary>
+    /// Checked and valid for SMS / voice / WhatsApp.
+    /// </summary>
+    public const string Ok = "OK";
+
+    /// <summary>
+    /// Paid send is allowed when status is unset (not yet checked) or explicitly OK.
+    /// </summary>
+    public static bool AllowsPaidSend(string? smsStatus) =>
+        smsStatus is null || smsStatus == Ok;
+}

--- a/backend/Migrations/20260830030718_AddOnlineVoterSmsStatus.Designer.cs
+++ b/backend/Migrations/20260830030718_AddOnlineVoterSmsStatus.Designer.cs
@@ -4,6 +4,7 @@ using Backend.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Backend.Migrations
 {
     [DbContext(typeof(MainDbContext))]
-    partial class MainDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260830030718_AddOnlineVoterSmsStatus")]
+    partial class AddOnlineVoterSmsStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260830030718_AddOnlineVoterSmsStatus.cs
+++ b/backend/Migrations/20260830030718_AddOnlineVoterSmsStatus.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Backend.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOnlineVoterSmsStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SmsStatus",
+                table: "OnlineVoters",
+                type: "varchar(50)",
+                unicode: false,
+                maxLength: 50,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SmsStatus",
+                table: "OnlineVoters");
+        }
+    }
+}

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -28,13 +28,14 @@ public partial class OnlineVotingService
                 }
             }
 
-            // 2. Paid channels: durable SmsStatus on an existing row blocks send (null = not yet checked).
+            // 2. Phone + paid: durable SmsStatus on an existing phone row blocks send (null = not yet checked).
             //    Load once here and reuse below — do not create a row just to store status.
+            var phonePaid = dto.VoterIdType == "P" && paidChannel;
             OnlineVoter? onlineVoter = null;
-            if (paidChannel)
+            if (phonePaid)
             {
                 onlineVoter = await _context.OnlineVoters
-                    .FirstOrDefaultAsync(ov => ov.VoterId == dto.VoterId);
+                    .FirstOrDefaultAsync(ov => ov.VoterId == dto.VoterId && ov.VoterIdType == "P");
 
                 if (onlineVoter != null && !OnlineVoterSmsStatus.AllowsPaidSend(onlineVoter.SmsStatus))
                 {
@@ -80,10 +81,11 @@ public partial class OnlineVotingService
                 return BuildRequestCodeResponse("voting.auth.requestCode.notRegistered");
             }
 
-            // 5. Create or update OnlineVoter record for tracking (reuse the paid-channel load when present)
+            // 5. Create or update OnlineVoter record for tracking (reuse the phone+paid load when present)
             if (onlineVoter == null)
             {
-                if (!paidChannel)
+                var alreadyLookedUp = phonePaid;
+                if (!alreadyLookedUp)
                 {
                     onlineVoter = await _context.OnlineVoters
                         .FirstOrDefaultAsync(ov => ov.VoterId == dto.VoterId);

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -64,6 +64,18 @@ public partial class OnlineVotingService
             var onlineVoter = await _context.OnlineVoters
                 .FirstOrDefaultAsync(ov => ov.VoterId == dto.VoterId);
 
+            // Paid channels: durable SmsStatus on an existing row blocks send (null = not yet checked).
+            if (PaidDestinationPhone.IsPaidChannel(dto.DeliveryMethod)
+                && onlineVoter != null
+                && !OnlineVoterSmsStatus.AllowsPaidSend(onlineVoter.SmsStatus))
+            {
+                _logger.LogWarning(
+                    "Login code request skipped: SmsStatus blocks paid send ({Method}, {SmsStatus})",
+                    KnownDeliveryMethod(dto.DeliveryMethod),
+                    SanitizeForLog(onlineVoter.SmsStatus));
+                return BuildRequestCodeResponse("voting.auth.requestCode.invalidPhone");
+            }
+
             if (onlineVoter == null)
             {
                 onlineVoter = new OnlineVoter

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -14,8 +14,10 @@ public partial class OnlineVotingService
     {
         try
         {
-            // Paid channels: reject reserved/fictional/malformed destinations before any DB or provider work.
-            if (dto.VoterIdType == "P" && PaidDestinationPhone.IsPaidChannel(dto.DeliveryMethod))
+            var paidChannel = PaidDestinationPhone.IsPaidChannel(dto.DeliveryMethod);
+
+            // 1. Paid channels: reject reserved/fictional/malformed destinations before any DB or provider work.
+            if (dto.VoterIdType == "P" && paidChannel)
             {
                 if (!PaidDestinationPhone.TryExplain(dto.VoterId, out var reason))
                 {
@@ -26,7 +28,25 @@ public partial class OnlineVotingService
                 }
             }
 
-            // 1. Find all open elections where this voter is registered (SMS pumping prevention)
+            // 2. Paid channels: durable SmsStatus on an existing row blocks send (null = not yet checked).
+            //    Load once here and reuse below — do not create a row just to store status.
+            OnlineVoter? onlineVoter = null;
+            if (paidChannel)
+            {
+                onlineVoter = await _context.OnlineVoters
+                    .FirstOrDefaultAsync(ov => ov.VoterId == dto.VoterId);
+
+                if (onlineVoter != null && !OnlineVoterSmsStatus.AllowsPaidSend(onlineVoter.SmsStatus))
+                {
+                    _logger.LogWarning(
+                        "Login code request skipped: SmsStatus blocks paid send ({Method}, {SmsStatus})",
+                        KnownDeliveryMethod(dto.DeliveryMethod),
+                        SanitizeForLog(onlineVoter.SmsStatus));
+                    return BuildRequestCodeResponse("voting.auth.requestCode.invalidPhone");
+                }
+            }
+
+            // 3. Find all open elections where this voter is registered (SMS pumping prevention)
             var now = DateTimeOffset.UtcNow;
             var openElections = await _context.Elections
                 .Where(e => e.UseOnlineVoting &&
@@ -41,7 +61,7 @@ public partial class OnlineVotingService
                 return BuildRequestCodeResponse("voting.auth.requestCode.noOpenElections");
             }
 
-            // 2. Check if voter is registered in ANY of the open elections
+            // 4. Check if voter is registered in ANY of the open elections
             var isVoterRegistered = dto.VoterIdType switch
             {
                 "E" => await _context.People.AnyAsync(p =>
@@ -60,31 +80,25 @@ public partial class OnlineVotingService
                 return BuildRequestCodeResponse("voting.auth.requestCode.notRegistered");
             }
 
-            // 3. Create or update OnlineVoter record for tracking
-            var onlineVoter = await _context.OnlineVoters
-                .FirstOrDefaultAsync(ov => ov.VoterId == dto.VoterId);
-
-            // Paid channels: durable SmsStatus on an existing row blocks send (null = not yet checked).
-            if (PaidDestinationPhone.IsPaidChannel(dto.DeliveryMethod)
-                && onlineVoter != null
-                && !OnlineVoterSmsStatus.AllowsPaidSend(onlineVoter.SmsStatus))
-            {
-                _logger.LogWarning(
-                    "Login code request skipped: SmsStatus blocks paid send ({Method}, {SmsStatus})",
-                    KnownDeliveryMethod(dto.DeliveryMethod),
-                    SanitizeForLog(onlineVoter.SmsStatus));
-                return BuildRequestCodeResponse("voting.auth.requestCode.invalidPhone");
-            }
-
+            // 5. Create or update OnlineVoter record for tracking (reuse the paid-channel load when present)
             if (onlineVoter == null)
             {
-                onlineVoter = new OnlineVoter
+                if (!paidChannel)
                 {
-                    VoterId = dto.VoterId,
-                    VoterIdType = dto.VoterIdType,
-                    WhenRegistered = DateTimeOffset.UtcNow
-                };
-                _context.OnlineVoters.Add(onlineVoter);
+                    onlineVoter = await _context.OnlineVoters
+                        .FirstOrDefaultAsync(ov => ov.VoterId == dto.VoterId);
+                }
+
+                if (onlineVoter == null)
+                {
+                    onlineVoter = new OnlineVoter
+                    {
+                        VoterId = dto.VoterId,
+                        VoterIdType = dto.VoterIdType,
+                        WhenRegistered = DateTimeOffset.UtcNow
+                    };
+                    _context.OnlineVoters.Add(onlineVoter);
+                }
             }
 
             var verifyCode = GenerateVerificationCode();

--- a/context/sms-eligibility.md
+++ b/context/sms-eligibility.md
@@ -45,7 +45,14 @@ if SmsStatus is not null AND SmsStatus != "OK" → do not send
 
 Initial reason vocabulary (not a closed enum — short phrases/codes): `555-range`, `undeliverable`, `landline`, `premium`, `admin`, `twilio-30003`, plus in-code `malformed-e164`.
 
-The durable gate runs in `RequestVerificationCodeAsync` after the voter is registered in an open election and an `OnlineVoter` row is loaded, beside the existing `PaidDestinationPhone` check. Skip logs method + status only (no raw phone or email). Voter-facing message reuses `voting.auth.requestCode.invalidPhone`. Email / OAuth / kiosk unchanged. `WhenRegistered` semantics unchanged.
+Pre-Twilio gate order in `RequestVerificationCodeAsync` (issue #254):
+
+1. `PaidDestinationPhone` (in-code; no DB)
+2. `OnlineVoter.SmsStatus` when a row already exists and status is not null / not `"OK"` (paid channels only; do not create a row just to store status)
+3. Existing open-election registration check (unchanged)
+4. Then the provider
+
+Skip logs method + status only (no raw phone or email). Voter-facing message reuses `voting.auth.requestCode.invalidPhone`. Email / OAuth / kiosk unchanged. `WhenRegistered` semantics unchanged.
 
 **Rejected alternative (this slice):** rename the column to `Status` so email/kiosk rows could share it later. The issue field spec and this slice’s contract are `SmsStatus`; a generic rename can be a later migration if other identifier types need a status.
 

--- a/context/sms-eligibility.md
+++ b/context/sms-eligibility.md
@@ -5,13 +5,13 @@
 ## Evidence: confirmed
 
 **Source:** issue #254 (maintainer); July 555-range send incident described there  
-**Revisit when:** later #254 slices land (`OnlineVoter.SmsStatus`, Person UI, Twilio callback auto-learn), or NANP reserved-range rules change
+**Revisit when:** later #254 slices land (Person UI, EnsureOnlineVoterForPhoneAsync, Twilio callback auto-learn), or NANP reserved-range rules change
 
 ## In-code gate before any paid provider
 
 Paid verification (SMS / voice / WhatsApp) must not call Twilio or GreenAPI for reserved, fictional, or malformed destinations. The July incident was ~80 attempts to 555-style numbers that still incurred tiny Twilio charges — the existing “registered in an open election” check does not stop an election owner from loading those numbers and opening the window.
 
-**This slice (issue #254, first cut):** a pure in-code helper (`PaidDestinationPhone`) rejects:
+**First slice (issue #254):** a pure in-code helper (`PaidDestinationPhone`) rejects:
 
 - malformed E.164 (and the same digit string without a leading `+`)
 - NANP area code `555`
@@ -21,11 +21,37 @@ The check runs at the start of `RequestVerificationCodeAsync` for phone + paid d
 
 **Rejected alternative:** rely only on the open-election registration check. That stops outsiders requesting codes for arbitrary numbers; it does not stop fictional numbers that are already on a Person row.
 
-**Rejected alternative:** wait for `OnlineVoter.SmsStatus` (later on the same issue). Status needs a row and a reason vocabulary. 555 / malformed must be blocked with no database work.
+**Rejected alternative:** wait for `OnlineVoter.SmsStatus` (this file’s next section). Status needs a row and a reason vocabulary. 555 / malformed must be blocked with no database work.
 
 **Rejected alternative:** reject only `555-01xx` and allow other 555 NPA/NXX. The incident and the issue call out area code 555 and exchange 555, with `555-01xx` as the most important subset.
 
-**Not in this slice:** `OnlineVoter.SmsStatus`, migrations, Person UI, Twilio status-callback learning, country allow-lists, spend caps.
+## Durable `OnlineVoter.SmsStatus` (second slice)
+
+`OnlineVoter` is the global phone-status store (key remains `VoterId`, E.164 when `VoterIdType` is `"P"`). Person is per-election; the same phone can appear in many elections, so eligibility cannot live only on Person.
+
+Field: `string? SmsStatus`, max 50, non-unicode (`varchar(50)`).
+
+**Send rule (paid channels only):**
+
+```text
+if SmsStatus is not null AND SmsStatus != "OK" → do not send
+```
+
+| `SmsStatus` | Meaning | Send SMS/voice/WhatsApp? |
+|-------------|---------|---------------------------|
+| `null` | Not yet checked | Yes (current behaviour) |
+| `"OK"` | Checked, valid | Yes |
+| anything else | Blocked; value is the reason | **No** |
+
+Initial reason vocabulary (not a closed enum — short phrases/codes): `555-range`, `undeliverable`, `landline`, `premium`, `admin`, `twilio-30003`, plus in-code `malformed-e164`.
+
+The durable gate runs in `RequestVerificationCodeAsync` after the voter is registered in an open election and an `OnlineVoter` row is loaded, beside the existing `PaidDestinationPhone` check. Skip logs method + status only (no raw phone or email). Voter-facing message reuses `voting.auth.requestCode.invalidPhone`. Email / OAuth / kiosk unchanged. `WhenRegistered` semantics unchanged.
+
+**Rejected alternative (this slice):** rename the column to `Status` so email/kiosk rows could share it later. The issue field spec and this slice’s contract are `SmsStatus`; a generic rename can be a later migration if other identifier types need a status.
+
+**Rejected alternative:** persist the in-code `PaidDestinationPhone` reason onto an existing `OnlineVoter` row when the format gate rejects. Useful only when a row already exists; creating a row here would pull in `EnsureOnlineVoterForPhoneAsync` (later slice). Not done.
+
+**Not in this slice:** Person UI / Front Desk display, `EnsureOnlineVoterForPhoneAsync` on Person create/import/update, Twilio status-callback auto-learn, WhatsAppStatus / GreenAPI `checkWhatsapp` (#255).
 
 ## Related
 

--- a/context/sms-eligibility.md
+++ b/context/sms-eligibility.md
@@ -13,7 +13,7 @@ Paid verification (SMS / voice / WhatsApp) must not call Twilio or GreenAPI for 
 
 **First slice (issue #254):** a pure in-code helper (`PaidDestinationPhone`) rejects:
 
-- malformed E.164 (and the same digit string without a leading `+`)
+- malformed numbers that are neither true E.164 (`+` then 8–15 digits) nor the same digit string without a leading `+`
 - NANP area code `555`
 - NANP exchange `555` (including the `555-01xx` fictional block)
 
@@ -31,7 +31,7 @@ The check runs at the start of `RequestVerificationCodeAsync` for phone + paid d
 
 Field: `string? SmsStatus`, max 50, non-unicode (`varchar(50)`).
 
-**Send rule (paid channels only):**
+**Send rule (phone `VoterIdType` `"P"` + paid channel only):**
 
 ```text
 if SmsStatus is not null AND SmsStatus != "OK" → do not send
@@ -48,7 +48,7 @@ Initial reason vocabulary (not a closed enum — short phrases/codes): `555-rang
 Pre-Twilio gate order in `RequestVerificationCodeAsync` (issue #254):
 
 1. `PaidDestinationPhone` (in-code; no DB)
-2. `OnlineVoter.SmsStatus` when a row already exists and status is not null / not `"OK"` (paid channels only; do not create a row just to store status)
+2. `OnlineVoter.SmsStatus` when `VoterIdType` is `"P"` and the channel is paid, a phone row already exists (`VoterId` + `VoterIdType == "P"`), and status is not null / not `"OK"` (do not create a row just to store status). Email / kiosk identifiers skip this gate.
 3. Existing open-election registration check (unchanged)
 4. Then the provider
 

--- a/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
+++ b/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
@@ -33,7 +33,7 @@ This implementation provides a **security-first voter authentication system** fo
 
 2. **SMS Pumping Prevention**
    - Paid SMS / voice / WhatsApp: reserved/fictional/malformed destinations (NANP 555, bad E.164) are rejected in code before any provider call — see `context/sms-eligibility.md`
-   - `OnlineVoter` also stores global phone SMS eligibility (`SmsStatus`: null / `"OK"` / block reason). A non-null status other than `"OK"` skips Twilio and GreenAPI.
+   - `OnlineVoter` also stores global phone SMS eligibility (`SmsStatus`: null / `"OK"` / block reason). For `VoterIdType` `"P"` + paid channel, a non-null status other than `"OK"` skips Twilio and GreenAPI. The lookup is the phone row (`VoterId` + `VoterIdType == "P"`).
    - Verification codes only sent to voters registered in open elections
    - Validates voter registration BEFORE sending SMS/email
    - Prevents abuse of communication channels

--- a/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
+++ b/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
@@ -33,6 +33,7 @@ This implementation provides a **security-first voter authentication system** fo
 
 2. **SMS Pumping Prevention**
    - Paid SMS / voice / WhatsApp: reserved/fictional/malformed destinations (NANP 555, bad E.164) are rejected in code before any provider call — see `context/sms-eligibility.md`
+   - `OnlineVoter` also stores global phone SMS eligibility (`SmsStatus`: null / `"OK"` / block reason). A non-null status other than `"OK"` skips Twilio and GreenAPI.
    - Verification codes only sent to voters registered in open elections
    - Validates voter registration BEFORE sending SMS/email
    - Prevents abuse of communication channels
@@ -194,7 +195,7 @@ POST /api/online-voting/{electionGuid}/submitBallot
    - Election discovery endpoint
 
 4. **Database**
-   - `OnlineVoter` - Tracks verification codes and attempts
+   - `OnlineVoter` - Tracks verification codes and attempts; for phone rows, `SmsStatus` is the global paid-channel eligibility (null = unchecked, `"OK"` = allowed, any other short value = blocked)
    - `Person` - Voter registration in elections
    - `Election` - Election configuration and open/close times
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Second slice of #254. First slice already shipped in #276 (in-code `PaidDestinationPhone` NANP 555 / malformed E.164 gate). This PR does **not** finish or close #254.

## In this slice

- Add `OnlineVoter.SmsStatus` (`string?`, max 50, non-unicode / `varchar(50)`).
- EF code-first migration `AddOnlineVoterSmsStatus`.
- Paid send rule on request-code: if `SmsStatus` is not null **and** not `"OK"`, do not send SMS / voice / WhatsApp (no Twilio, no GreenAPI). `null` still sends (unchecked). `"OK"` still sends.
- Pre-Twilio gate order (issue #254): (1) `PaidDestinationPhone`, (2) existing `OnlineVoter.SmsStatus` when `VoterIdType` is `"P"` **and** the channel is paid, a phone row exists (`VoterId` + `VoterIdType == "P"`), and status is not null / not `"OK"`, (3) open-election registration check, (4) provider. The phone row loaded for the status gate is reused later. Email / kiosk identifiers skip this gate. No row is created just to store status.
- Skip logs **method + status only** (no raw phone or email).
- Voter-facing message reuses `voting.auth.requestCode.invalidPhone` (no new i18n key).
- Email / OAuth / kiosk unchanged. `WhenRegistered` semantics unchanged.

## Out of scope (still on #254 or elsewhere)

- Person UI / Front Desk display of SMS status
- `EnsureOnlineVoterForPhoneAsync` on Person create / import / update
- Twilio status-callback auto-learn
- WhatsAppStatus / GreenAPI `checkWhatsapp` (#255)
- Renaming the column to a generic `Status` (noted in `context/sms-eligibility.md`; this slice follows the issue field spec)

## Tests

- Registered open-election phone with a normal E.164 and `SmsStatus` set to a block reason never calls `IPaidVerificationSender`.
- Blocked `SmsStatus` on a phone that is **not** in an open election returns `invalidPhone` (not `notRegistered`) and never calls the paid sender.
- Same setup with `SmsStatus` null or `"OK"` still reaches send / existing `notRegistered` behaviour.
- Email request-code path still does not use the paid sender, including when that email’s `OnlineVoter.SmsStatus` is blocked.
- `VoterIdType` `"E"` + `sms` + blocked email row does not take the SmsStatus `invalidPhone` path.
- Unit tests: `OnlineVotingServiceRequestCodePaidPhoneTests`, `OnlineVoterSmsStatusTests`, `PaidDestinationPhoneTests` — 59 passed.

## Local SQL (this agent VM only)

- Docker SQL Server 2022 (local, not Azure).
- `dotnet ef database update` applied through `AddOnlineVoterSmsStatus` (`varchar(50)` nullable); re-checked, already up to date.
- `SeedOnStartup` completed on `TallyJ4Dev`.

## Verify before merge

Glen must verify this on UAT (UAT deploys from `main`). Do not merge until then. Do not close #254.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae060ae4-34ad-4df3-a19e-1cc871b54c7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae060ae4-34ad-4df3-a19e-1cc871b54c7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

