### PR TITLE
Add remaining #198 tests for extras and tie-break coverage

### DIFF
--- a/Backend.Tests/UnitTests/ElectionAnalyzerNormalTests.cs
+++ b/Backend.Tests/UnitTests/ElectionAnalyzerNormalTests.cs
@@ -1080,6 +1080,156 @@ public class ElectionAnalyzerNormalTests : IDisposable
     }
 
     [Fact]
+    public async Task NumberExtraZero_DoesNotCreateXSection()
+    {
+        var election = CreateElection(numberToElect: 2, numberExtra: 0);
+        var people = new[]
+        {
+            MakePerson("rank01"),
+            MakePerson("rank02"),
+            MakePerson("rank03"),
+            MakePerson("rank04"),
+            MakePerson("rank05"),
+        };
+        _context.SaveChanges();
+
+        CreateDescendingVotesWithSpoiledPadding(people, [5, 4, 3, 2, 1], votesNeededOnBallot: 2);
+
+        await RunAnalysis(election);
+
+        var results = _context.Results
+            .Where(r => r.ElectionGuid == _electionGuid)
+            .OrderBy(r => r.Rank)
+            .ToList();
+
+        Assert.Equal(5, results.Count);
+        Assert.DoesNotContain(results, r => r.Section == "X");
+        Assert.All(results, r => Assert.Null(r.RankInExtra));
+
+        Assert.Equal(people[0].PersonGuid, results[0].PersonGuid);
+        Assert.Equal("E", results[0].Section);
+        Assert.Equal("E", results[1].Section);
+        Assert.Equal("O", results[2].Section);
+        Assert.Equal("O", results[3].Section);
+        Assert.Equal("O", results[4].Section);
+    }
+
+    [Fact]
+    public async Task TieWithinExtraSectionOnly_RequiresTieBreak()
+    {
+        var election = CreateElection(numberToElect: 1, numberExtra: 3);
+        var people = new[]
+        {
+            MakePerson("elected"),
+            MakePerson("extraA"),
+            MakePerson("extraB"),
+        };
+        _context.SaveChanges();
+
+        for (var i = 0; i < 4; i++)
+        {
+            MakeVote(MakeBallot(), people[0]);
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            MakeVote(MakeBallot(), people[1]);
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            MakeVote(MakeBallot(), people[2]);
+        }
+
+        await RunAnalysis(election);
+
+        var results = _context.Results
+            .Where(r => r.ElectionGuid == _electionGuid)
+            .OrderBy(r => r.Rank)
+            .ToList();
+
+        Assert.Equal(3, results.Count);
+
+        Assert.Equal(people[0].PersonGuid, results[0].PersonGuid);
+        Assert.Equal(1, results[0].Rank);
+        Assert.Equal("E", results[0].Section);
+        Assert.Equal(false, results[0].IsTied);
+
+        var tiedInExtra = results.Where(r => r.Section == "X" && r.IsTied == true).ToList();
+        Assert.Equal(2, tiedInExtra.Count);
+        Assert.All(tiedInExtra, r => Assert.Equal(true, r.TieBreakRequired));
+        Assert.All(tiedInExtra, r => Assert.Equal(tiedInExtra[0].TieBreakGroup, r.TieBreakGroup));
+        Assert.Contains(people[1].PersonGuid, tiedInExtra.Select(r => r.PersonGuid));
+        Assert.Contains(people[2].PersonGuid, tiedInExtra.Select(r => r.PersonGuid));
+        Assert.Equal(1, tiedInExtra[0].RankInExtra);
+        Assert.Equal(2, tiedInExtra[1].RankInExtra);
+
+        var resultTies = _context.ResultTies
+            .Where(rt => rt.ElectionGuid == _electionGuid)
+            .ToList();
+        Assert.Single(resultTies);
+        Assert.Equal(true, resultTies[0].TieBreakRequired);
+        Assert.Equal(2, resultTies[0].NumInTie);
+        Assert.Equal(1, resultTies[0].NumToElect);
+        Assert.Equal(false, resultTies[0].IsResolved);
+    }
+
+    [Fact]
+    public async Task LsaScale_TieWithinExtraSectionOnly_RequiresTieBreak()
+    {
+        var election = CreateElection(numberToElect: 9, numberExtra: 2);
+        var people = Enumerable.Range(0, 12)
+            .Select(i => MakePerson($"p{i:D2}"))
+            .ToArray();
+        _context.SaveChanges();
+
+        CreateDescendingVotesWithSpoiledPadding(
+            people,
+            [13, 12, 11, 10, 9, 8, 7, 6, 5, 2, 2, 1],
+            votesNeededOnBallot: 9);
+
+        await RunAnalysis(election);
+
+        var results = _context.Results
+            .Where(r => r.ElectionGuid == _electionGuid)
+            .OrderBy(r => r.Rank)
+            .ToList();
+
+        Assert.Equal(12, results.Count);
+
+        var elected = results.Where(r => r.Section == "E").ToList();
+        var extra = results.Where(r => r.Section == "X").ToList();
+        var other = results.Where(r => r.Section == "O").ToList();
+
+        Assert.Equal(9, elected.Count);
+        Assert.Equal(2, extra.Count);
+        Assert.Single(other);
+        Assert.All(elected, r => Assert.Equal(false, r.IsTied));
+        Assert.All(elected, r => Assert.Equal(false, r.TieBreakRequired));
+
+        Assert.All(extra, r => Assert.Equal(true, r.IsTied));
+        Assert.All(extra, r => Assert.Equal(true, r.TieBreakRequired));
+        Assert.All(extra, r => Assert.Equal(extra[0].TieBreakGroup, r.TieBreakGroup));
+        Assert.Equal(1, extra[0].RankInExtra);
+        Assert.Equal(2, extra[1].RankInExtra);
+        Assert.Contains(people[9].PersonGuid, extra.Select(r => r.PersonGuid));
+        Assert.Contains(people[10].PersonGuid, extra.Select(r => r.PersonGuid));
+
+        Assert.Equal(people[11].PersonGuid, other[0].PersonGuid);
+        Assert.Equal(false, other[0].IsTied);
+        Assert.Equal(false, other[0].TieBreakRequired);
+
+        var resultTies = _context.ResultTies
+            .Where(rt => rt.ElectionGuid == _electionGuid)
+            .ToList();
+        Assert.Single(resultTies);
+        Assert.Equal(true, resultTies[0].TieBreakRequired);
+        Assert.Equal(2, resultTies[0].NumInTie);
+        Assert.Equal(1, resultTies[0].NumToElect);
+        Assert.Equal(false, resultTies[0].IsResolved);
+    }
+
+    [Fact]
     public async Task NSA_Election_1()
     {
         var election = CreateElection(numberToElect: 2, electionType: "NSA");
@@ -1126,5 +1276,27 @@ public class ElectionAnalyzerNormalTests : IDisposable
         Assert.Equal(0, summaryFinal.OnlineBallots);
         Assert.Equal(6, summaryFinal.NumEligibleToVote);
         Assert.Equal(1, summaryFinal.NumVoters);
+    }
+
+    /// <summary>
+    /// One ballot per vote, padded with spoiled slots so the ballot stays Ok when NumberToElect &gt; 1.
+    /// </summary>
+    private void CreateDescendingVotesWithSpoiledPadding(
+        Person[] people,
+        int[] voteCounts,
+        int votesNeededOnBallot)
+    {
+        for (var p = 0; p < voteCounts.Length; p++)
+        {
+            for (var v = 0; v < voteCounts[p]; v++)
+            {
+                var ballot = MakeBallot();
+                MakeVote(ballot, people[p], 1);
+                for (var slot = 2; slot <= votesNeededOnBallot; slot++)
+                {
+                    MakeVoteForIneligible(ballot, IneligibleReasonEnum.U01_Unidentifiable.Code, slot);
+                }
+            }
+        }
     }
 }

--- a/Backend.Tests/UnitTests/ElectionAnalyzerNormalTests.cs
+++ b/Backend.Tests/UnitTests/ElectionAnalyzerNormalTests.cs
@@ -1093,7 +1093,7 @@ public class ElectionAnalyzerNormalTests : IDisposable
         };
         _context.SaveChanges();
 
-        CreateDescendingVotesWithSpoiledPadding(people, [5, 4, 3, 2, 1], votesNeededOnBallot: 2);
+        CreateDescendingVotesWithIneligiblePadding(people, [5, 4, 3, 2, 1], votesNeededOnBallot: 2);
 
         await RunAnalysis(election);
 
@@ -1183,7 +1183,7 @@ public class ElectionAnalyzerNormalTests : IDisposable
             .ToArray();
         _context.SaveChanges();
 
-        CreateDescendingVotesWithSpoiledPadding(
+        CreateDescendingVotesWithIneligiblePadding(
             people,
             [13, 12, 11, 10, 9, 8, 7, 6, 5, 2, 2, 1],
             votesNeededOnBallot: 9);
@@ -1279,9 +1279,10 @@ public class ElectionAnalyzerNormalTests : IDisposable
     }
 
     /// <summary>
-    /// One ballot per vote, padded with spoiled slots so the ballot stays Ok when NumberToElect &gt; 1.
+    /// One ballot per vote, padded with ineligible placeholder votes
+    /// (null PersonGuid + ineligible reason, VoteStatus.Ok) so the ballot stays Ok when NumberToElect &gt; 1.
     /// </summary>
-    private void CreateDescendingVotesWithSpoiledPadding(
+    private void CreateDescendingVotesWithIneligiblePadding(
         Person[] people,
         int[] voteCounts,
         int votesNeededOnBallot)

--- a/Backend.Tests/UnitTests/TallyServiceTests.cs
+++ b/Backend.Tests/UnitTests/TallyServiceTests.cs
@@ -182,6 +182,33 @@ public class TallyServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task CalculateNormalElectionAsync_WithNumberExtraZero_DoesNotCreateXSection()
+    {
+        var election = await CreateTestElectionAsync(numberToElect: 2, numberExtra: 0);
+        var location = await CreateTestLocationAsync(election.ElectionGuid);
+        var people = await CreateTestPeopleAsync(election.ElectionGuid, 5);
+        var ballots = await CreateTestBallotsAsync(location.LocationGuid, 15);
+        await CreateDescendingVoteDistributionAsync(
+            ballots,
+            people,
+            [5, 4, 3, 2, 1],
+            spoiledFillerCount: 1);
+
+        await _service.CalculateNormalElectionAsync(election.ElectionGuid);
+
+        var results = Context.Results
+            .Where(r => r.ElectionGuid == election.ElectionGuid)
+            .OrderBy(r => r.Rank)
+            .ToList();
+
+        Assert.Equal(5, results.Count);
+        Assert.DoesNotContain(results, r => r.Section == "X");
+        Assert.All(results, r => Assert.Null(r.RankInExtra));
+        Assert.Equal(2, results.Count(r => r.Section == "E"));
+        Assert.Equal(3, results.Count(r => r.Section == "O"));
+    }
+
+    [Fact]
     public async Task CalculateSingleNameElectionAsync_WithValidElection_CalculatesCorrectly()
     {
         var election = await CreateTestElectionAsync(electionType: "Oth");
@@ -545,6 +572,61 @@ public class TallyServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task CalculateNormalElectionAsync_LsaScale_TieWithinExtraSectionOnly_RequiresTieBreak()
+    {
+        var election = await CreateTestElectionAsync(numberToElect: 9, numberExtra: 2);
+        var location = await CreateTestLocationAsync(election.ElectionGuid);
+        var people = await CreateTestPeopleAsync(election.ElectionGuid, 12);
+        var voteCounts = new[] { 13, 12, 11, 10, 9, 8, 7, 6, 5, 2, 2, 1 };
+        var ballots = await CreateTestBallotsAsync(location.LocationGuid, voteCounts.Sum());
+        await CreateDescendingVoteDistributionAsync(
+            ballots,
+            people,
+            voteCounts,
+            spoiledFillerCount: 8);
+
+        await _service.CalculateNormalElectionAsync(election.ElectionGuid);
+
+        var results = Context.Results
+            .Where(r => r.ElectionGuid == election.ElectionGuid)
+            .OrderBy(r => r.Rank)
+            .ToList();
+
+        Assert.Equal(12, results.Count);
+
+        var elected = results.Where(r => r.Section == "E").ToList();
+        var extra = results.Where(r => r.Section == "X").ToList();
+        var other = results.Where(r => r.Section == "O").ToList();
+
+        Assert.Equal(9, elected.Count);
+        Assert.Equal(2, extra.Count);
+        Assert.Single(other);
+        Assert.All(elected, r => Assert.False(r.IsTied));
+        Assert.All(elected, r => Assert.False(r.TieBreakRequired));
+
+        Assert.All(extra, r => Assert.True(r.IsTied));
+        Assert.All(extra, r => Assert.True(r.TieBreakRequired));
+        Assert.All(extra, r => Assert.Equal(extra[0].TieBreakGroup, r.TieBreakGroup));
+        Assert.Equal(1, extra[0].RankInExtra);
+        Assert.Equal(2, extra[1].RankInExtra);
+        Assert.Contains(people[9].PersonGuid, extra.Select(r => r.PersonGuid));
+        Assert.Contains(people[10].PersonGuid, extra.Select(r => r.PersonGuid));
+
+        Assert.Equal(people[11].PersonGuid, other[0].PersonGuid);
+        Assert.False(other[0].IsTied);
+        Assert.False(other[0].TieBreakRequired);
+
+        var resultTies = Context.ResultTies
+            .Where(rt => rt.ElectionGuid == election.ElectionGuid)
+            .ToList();
+        Assert.Single(resultTies);
+        Assert.True(resultTies[0].TieBreakRequired);
+        Assert.Equal(2, resultTies[0].NumInTie);
+        Assert.Equal(1, resultTies[0].NumToElect);
+        Assert.Equal(false, resultTies[0].IsResolved);
+    }
+
+    [Fact]
     public async Task CalculateNormalElectionAsync_TieWithinSection_DoesNotRequireTieBreak()
     {
         var election = await CreateTestElectionAsync(numberToElect: 9, numberExtra: 2);
@@ -705,13 +787,132 @@ public class TallyServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task SaveTieCountsAsync_ResolvedTie_SetsUseOnReportsAfterReanalysis()
+    {
+        var election = await CreateTestElectionAsync(numberToElect: 1, numberExtra: 1);
+        var location = await CreateTestLocationAsync(election.ElectionGuid);
+        var people = await CreateTestPeopleAsync(election.ElectionGuid, 3);
+        foreach (var person in people)
+        {
+            person.VotingMethod = "P";
+        }
+
+        await Context.SaveChangesAsync();
+
+        var ballots = await CreateTestBallotsAsync(location.LocationGuid, 3);
+        await CreateThreeWayEqualVoteAsync(ballots, people);
+
+        await _service.CalculateNormalElectionAsync(election.ElectionGuid);
+
+        var summaryBefore = Context.ResultSummaries
+            .First(rs => rs.ElectionGuid == election.ElectionGuid && rs.ResultType == "F");
+        var resultTieBefore = Context.ResultTies.Single(rt => rt.ElectionGuid == election.ElectionGuid);
+        Assert.Equal(false, resultTieBefore.IsResolved);
+        Assert.Equal(false, summaryBefore.UseOnReports);
+
+        var response = await _service.SaveTieCountsAsync(election.ElectionGuid, new SaveTieCountsRequestDto
+        {
+            Counts =
+            [
+                new TieCountDto { PersonGuid = people[2].PersonGuid, TieBreakCount = 5 },
+                new TieCountDto { PersonGuid = people[0].PersonGuid, TieBreakCount = 2 },
+                new TieCountDto { PersonGuid = people[1].PersonGuid, TieBreakCount = 1 },
+            ]
+        });
+
+        Assert.True(response.Success);
+        Assert.True(response.ReAnalysisTriggered);
+
+        var summaryAfter = Context.ResultSummaries
+            .First(rs => rs.ElectionGuid == election.ElectionGuid && rs.ResultType == "F");
+        var resultTieAfter = Context.ResultTies.Single(rt => rt.ElectionGuid == election.ElectionGuid);
+        Assert.Equal(true, resultTieAfter.IsResolved);
+        Assert.Equal(true, summaryAfter.UseOnReports);
+    }
+
+    [Fact]
+    public async Task SaveTieCountsAsync_SingleNameElection_TriggersReanalysisAndReordersPeople()
+    {
+        var election = await CreateTestElectionAsync(electionType: "Oth", numberToElect: 1, numberExtra: 1);
+        var location = await CreateTestLocationAsync(election.ElectionGuid);
+        var people = await CreateTestPeopleAsync(election.ElectionGuid, 3);
+        var ballots = await CreateTestBallotsAsync(location.LocationGuid, 1);
+
+        for (var i = 0; i < 3; i++)
+        {
+            Context.Votes.Add(new Vote
+            {
+                BallotGuid = ballots[0].BallotGuid,
+                PersonGuid = people[i].PersonGuid,
+                PositionOnBallot = i + 1,
+                VoteStatus = VoteStatus.Ok,
+                SingleNameElectionCount = 10,
+                PersonCombinedInfo = people[i].CombinedInfo,
+                RowVersion = new byte[8]
+            });
+        }
+
+        await Context.SaveChangesAsync();
+        await _service.CalculateSingleNameElectionAsync(election.ElectionGuid);
+
+        var before = (await _service.GetTallyResultsAsync(election.ElectionGuid)).Results
+            .OrderBy(r => r.Rank)
+            .ToList();
+
+        Assert.Equal(3, before.Count);
+        Assert.Equal(people[0].PersonGuid, before[0].PersonGuid);
+        Assert.Equal("E", before[0].Section);
+        Assert.Equal(people[1].PersonGuid, before[1].PersonGuid);
+        Assert.Equal("X", before[1].Section);
+        Assert.Equal(people[2].PersonGuid, before[2].PersonGuid);
+        Assert.Equal("O", before[2].Section);
+
+        var response = await _service.SaveTieCountsAsync(election.ElectionGuid, new SaveTieCountsRequestDto
+        {
+            Counts =
+            [
+                new TieCountDto { PersonGuid = people[2].PersonGuid, TieBreakCount = 5 },
+                new TieCountDto { PersonGuid = people[0].PersonGuid, TieBreakCount = 2 },
+                new TieCountDto { PersonGuid = people[1].PersonGuid, TieBreakCount = 1 },
+            ]
+        });
+
+        Assert.True(response.Success);
+        Assert.True(response.ReAnalysisTriggered);
+
+        var after = (await _service.GetTallyResultsAsync(election.ElectionGuid)).Results
+            .OrderBy(r => r.Rank)
+            .ToList();
+
+        Assert.Equal(people[2].PersonGuid, after[0].PersonGuid);
+        Assert.Equal(1, after[0].Rank);
+        Assert.Equal("E", after[0].Section);
+
+        Assert.Equal(people[0].PersonGuid, after[1].PersonGuid);
+        Assert.Equal(2, after[1].Rank);
+        Assert.Equal("X", after[1].Section);
+
+        Assert.Equal(people[1].PersonGuid, after[2].PersonGuid);
+        Assert.Equal(3, after[2].Rank);
+        Assert.Equal("O", after[2].Section);
+
+        var dbResults = Context.Results
+            .Where(r => r.ElectionGuid == election.ElectionGuid)
+            .OrderBy(r => r.Rank)
+            .ToList();
+        Assert.Equal(5, dbResults[0].TieBreakCount);
+        Assert.Equal(2, dbResults[1].TieBreakCount);
+        Assert.Equal(1, dbResults[2].TieBreakCount);
+    }
+
+    [Fact]
     public async Task CalculateNormalElectionAsync_ExtrasAssignRankInExtraSequentially()
     {
         var election = await CreateTestElectionAsync(numberToElect: 2, numberExtra: 3);
         var location = await CreateTestLocationAsync(election.ElectionGuid);
         var people = await CreateTestPeopleAsync(election.ElectionGuid, 5);
         var ballots = await CreateTestBallotsAsync(location.LocationGuid, 15);
-        await CreateDescendingVoteDistributionAsync(ballots, people, new[] { 5, 4, 3, 2, 1 }, useSpoiledSecondSlot: true);
+        await CreateDescendingVoteDistributionAsync(ballots, people, new[] { 5, 4, 3, 2, 1 }, spoiledFillerCount: 1);
 
         await _service.CalculateNormalElectionAsync(election.ElectionGuid);
 
@@ -1171,7 +1372,7 @@ public class TallyServiceTests : ServiceTestBase
         List<Ballot> ballots,
         List<Person> people,
         int[] voteCounts,
-        bool useSpoiledSecondSlot = false)
+        int spoiledFillerCount = 0)
     {
         var ballotIndex = 0;
         for (var p = 0; p < voteCounts.Length; p++)
@@ -1188,14 +1389,14 @@ public class TallyServiceTests : ServiceTestBase
                     RowVersion = new byte[8]
                 });
 
-                if (useSpoiledSecondSlot)
+                for (var slot = 0; slot < spoiledFillerCount; slot++)
                 {
                     Context.Votes.Add(new Vote
                     {
                         BallotGuid = ballots[ballotIndex].BallotGuid,
                         PersonGuid = null,
                         IneligibleReasonCode = IneligibleReasonEnum.U01_Unidentifiable.Code,
-                        PositionOnBallot = 2,
+                        PositionOnBallot = slot + 2,
                         VoteStatus = VoteStatus.Ok,
                         RowVersion = new byte[8]
                     });

--- a/Backend.Tests/UnitTests/TallyServiceTests.cs
+++ b/Backend.Tests/UnitTests/TallyServiceTests.cs
@@ -192,7 +192,7 @@ public class TallyServiceTests : ServiceTestBase
             ballots,
             people,
             [5, 4, 3, 2, 1],
-            spoiledFillerCount: 1);
+            ineligiblePaddingCount: 1);
 
         await _service.CalculateNormalElectionAsync(election.ElectionGuid);
 
@@ -583,7 +583,7 @@ public class TallyServiceTests : ServiceTestBase
             ballots,
             people,
             voteCounts,
-            spoiledFillerCount: 8);
+            ineligiblePaddingCount: 8);
 
         await _service.CalculateNormalElectionAsync(election.ElectionGuid);
 
@@ -912,7 +912,7 @@ public class TallyServiceTests : ServiceTestBase
         var location = await CreateTestLocationAsync(election.ElectionGuid);
         var people = await CreateTestPeopleAsync(election.ElectionGuid, 5);
         var ballots = await CreateTestBallotsAsync(location.LocationGuid, 15);
-        await CreateDescendingVoteDistributionAsync(ballots, people, new[] { 5, 4, 3, 2, 1 }, spoiledFillerCount: 1);
+        await CreateDescendingVoteDistributionAsync(ballots, people, new[] { 5, 4, 3, 2, 1 }, ineligiblePaddingCount: 1);
 
         await _service.CalculateNormalElectionAsync(election.ElectionGuid);
 
@@ -1368,11 +1368,16 @@ public class TallyServiceTests : ServiceTestBase
         await Context.SaveChangesAsync();
     }
 
+    /// <summary>
+    /// <paramref name="ineligiblePaddingCount"/> extra ineligible placeholder votes per ballot
+    /// (null PersonGuid + ineligible reason, VoteStatus.Ok) so the ballot stays Ok.
+    /// Default 0 adds no fillers.
+    /// </summary>
     private async Task CreateDescendingVoteDistributionAsync(
         List<Ballot> ballots,
         List<Person> people,
         int[] voteCounts,
-        int spoiledFillerCount = 0)
+        int ineligiblePaddingCount = 0)
     {
         var ballotIndex = 0;
         for (var p = 0; p < voteCounts.Length; p++)
@@ -1389,7 +1394,7 @@ public class TallyServiceTests : ServiceTestBase
                     RowVersion = new byte[8]
                 });
 
-                for (var slot = 0; slot < spoiledFillerCount; slot++)
+                for (var slot = 0; slot < ineligiblePaddingCount; slot++)
                 {
                     Context.Votes.Add(new Vote
                     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the remaining **test** coverage called out on #198 after PR 197. Product behavior of `SaveTieCountsAsync` is unchanged.

## Covers from #198

- [x] `NumberExtra = 0` — no `"X"` section when extras are not configured (analyzer + `TallyService`)
- [x] Analyzer-level X-only tie (mirrors the existing service-level test)
- [x] LSA-scale X-only tie (`numberToElect: 9`, `numberExtra: 2`) at analyzer and service layers
- [x] `UseOnReports` via `TallyService` after `SaveTieCountsAsync` + auto re-analysis
- [x] Single-name `SaveTieCountsAsync` end-to-end (optional parity)

## Leaves on #198

These behavior / frontend items are **not** in this PR:

- Re-analysis in `SaveTieCountsAsync` when any member has a count (not only when all members have counts)
- Clarify all-`0` tie-break counts vs valid input
- Distinguish default `TieBreakCount = 0` from an explicitly entered `0`
- Frontend: send explicit `0` when clearing tie-break values and refresh results after save
- v3 golden-file regression tests for extras and tie-break scenarios

## Review follow-up

Copilot comments on the test helpers are addressed: names and XML/comments now describe ineligible placeholder votes (`null` PersonGuid + ineligible reason, `VoteStatus.Ok`), not spoiled slots. Padding behavior is unchanged (default 0; former `true` is still 1).

## Verification

`dotnet test Backend.Tests --filter "FullyQualifiedName~ElectionAnalyzerNormalTests|FullyQualifiedName~TallyServiceTests"` — 51 passed, 0 failed.

Related: #198
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea7c71d6-a581-44e7-bd1a-5199876d1ca5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea7c71d6-a581-44e7-bd1a-5199876d1ca5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

