### PR TITLE
Online voters: httpOnly session cookies (align with teller auth)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Group name patterns (constructed via `GetGroupName` statics in each hub + used f
 - `AllVoters` (global) — AllVotersHub (`/hubs/all-voters`): thin `updateVoters` for online window/process; OnlineVoter JWT.
 - `Voter{voterId}` — VoterPersonalHub (`/hubs/voter-personal`): thin `updateVoter` (registration / login-elsewhere); group from JWT only.
 
-**Frontend side**: `src/services/signalrService.ts` provides `connectToMainHub()`, `connectToAnalyzeHub()`, `connectToFrontDeskHub()`, `connectVoterHubs()`, etc. + `joinElection(guid)`, `joinDashboardElections(guids)` (known-teller multi-listen), `joinTallySession(guid)`, etc. Stores (electionStore, ballotStore, peopleStore, onlineVotingStore, etc.) call these and wire `connection.on("eventName", handler)`.
+**Frontend side**: `src/services/signalrService.ts` provides `connectToMainHub()`, `connectToAnalyzeHub()`, `connectToFrontDeskHub()`, `connectVoterHubs()`, etc. + `joinElection(guid)`, `joinDashboardElections(guids)` (known-teller multi-listen), `joinTallySession(guid)`, etc. Stores (electionStore, ballotStore, peopleStore, onlineVotingStore, etc.) call these and wire `connection.on("eventName", handler)`. Voter hubs authenticate with the httpOnly `voter_token` cookie (`withCredentials`); do not add a client `accessTokenFactory` for voters.
 
 When adding or touching real-time features, update the matching hub + the corresponding method in `SignalRNotificationService.cs` (see examples at lines 55, 73, 92, 111, 135, 152, 170, 189) + the frontend service + any store subscriptions together.
 

--- a/Backend.Tests/Backend.Tests.csproj
+++ b/Backend.Tests/Backend.Tests.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />

--- a/Backend.Tests/IntegrationTests/IntegrationTestBase.cs
+++ b/Backend.Tests/IntegrationTests/IntegrationTestBase.cs
@@ -76,6 +76,53 @@ public abstract class IntegrationTestBase : IClassFixture<CustomWebApplicationFa
         return token;
     }
 
+    protected static string? GetSetCookieValue(HttpResponseMessage response, string cookieName)
+    {
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookies))
+        {
+            return null;
+        }
+
+        var prefix = cookieName + "=";
+        foreach (var cookie in setCookies)
+        {
+            if (cookie.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return cookie.Split(';')[0].Substring(prefix.Length);
+            }
+        }
+
+        return null;
+    }
+
+    protected static string? GetSetCookieHeader(HttpResponseMessage response, string cookieName)
+    {
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookies))
+        {
+            return null;
+        }
+
+        return setCookies.FirstOrDefault(c =>
+            c.StartsWith(cookieName + "=", StringComparison.OrdinalIgnoreCase));
+    }
+
+    protected void SetVoterCookie(string token)
+    {
+        Client.DefaultRequestHeaders.Authorization = null;
+        Client.DefaultRequestHeaders.Remove("Cookie");
+        Client.DefaultRequestHeaders.Add(
+            "Cookie",
+            $"{SecureCookieMiddleware.VoterTokenCookieName}={token}");
+    }
+
+    protected void SetCookies(params (string Name, string Value)[] cookies)
+    {
+        Client.DefaultRequestHeaders.Authorization = null;
+        Client.DefaultRequestHeaders.Remove("Cookie");
+        var header = string.Join("; ", cookies.Select(c => $"{c.Name}={c.Value}"));
+        Client.DefaultRequestHeaders.Add("Cookie", header);
+    }
+
     public async Task InitializeAsync()
     {
         await SeedDatabaseAsync();

--- a/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
@@ -33,7 +33,8 @@ public class OnlineVotingBallotFlowTests : IntegrationTestBase
         Assert.NotNull(auth);
         Assert.Equal(kioskCode, auth.VoterId);
         Assert.Equal("C", auth.VoterIdType);
-        Assert.False(string.IsNullOrWhiteSpace(auth.Token));
+        Assert.True(string.IsNullOrEmpty(auth.Token));
+        Assert.False(string.IsNullOrWhiteSpace(GetSetCookieValue(response, "voter_token")));
     }
 
     [Fact]

--- a/Backend.Tests/IntegrationTests/VoterAuthenticationFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/VoterAuthenticationFlowTests.cs
@@ -255,8 +255,9 @@ public class VoterAuthenticationFlowTests : IntegrationTestBase
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var auth = await response.Content.ReadFromJsonAsync<OnlineVoterAuthResponse>();
         Assert.NotNull(auth);
-        Assert.False(string.IsNullOrWhiteSpace(auth.Token));
-        return auth.Token;
+        var token = GetSetCookieValue(response, "voter_token");
+        Assert.False(string.IsNullOrWhiteSpace(token));
+        return token!;
     }
 
     private async Task<Guid> SetupOpenElection()

--- a/Backend.Tests/IntegrationTests/VoterCookieAuthTests.cs
+++ b/Backend.Tests/IntegrationTests/VoterCookieAuthTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Json;
+using Backend.Context;
+using Backend.DTOs.OnlineVoting;
+using Backend.Entities;
+using Backend.Enumerations;
+using Backend.Middleware;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Backend.Tests.IntegrationTests;
+
+/// <summary>
+/// Cookie transport for online-voter JWT (issue #250): set on auth, used without Bearer,
+/// accepted on voter hubs, cleared on logout, distinct from teller auth_token.
+/// </summary>
+public class VoterCookieAuthTests : IntegrationTestBase
+{
+    public VoterCookieAuthTests(CustomWebApplicationFactory factory) : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task VerifyCode_SetsHttpOnlyVoterCookie_AndOmitsTokenFromBody()
+    {
+        var email = $"cookie_otp_{Guid.NewGuid():N}@example.com";
+        await SetupOpenElectionWithVoter(email);
+
+        var requestResponse = await Client.PostAsJsonAsync("/api/online-voting/requestCode", new RequestCodeDto
+        {
+            VoterId = email,
+            VoterIdType = "E",
+            DeliveryMethod = "email"
+        });
+        var requestBody = await requestResponse.Content.ReadFromJsonAsync<RequestCodeResponseDto>();
+        Assert.False(string.IsNullOrWhiteSpace(requestBody?.DevVerificationCode));
+
+        var verifyResponse = await Client.PostAsJsonAsync("/api/online-voting/verifyCode", new VerifyCodeDto
+        {
+            VoterId = email,
+            VerifyCode = requestBody!.DevVerificationCode!
+        });
+
+        Assert.Equal(HttpStatusCode.OK, verifyResponse.StatusCode);
+        var auth = await verifyResponse.Content.ReadFromJsonAsync<OnlineVoterAuthResponse>();
+        Assert.NotNull(auth);
+        Assert.Equal(email, auth.VoterId);
+        Assert.True(string.IsNullOrEmpty(auth.Token));
+
+        var tokenCookie = GetSetCookieHeader(verifyResponse, SecureCookieMiddleware.VoterTokenCookieName);
+        Assert.False(string.IsNullOrWhiteSpace(tokenCookie));
+        Assert.Contains("httponly", tokenCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(SecureCookieMiddleware.AccessTokenCookieName + "=", tokenCookie, StringComparison.OrdinalIgnoreCase);
+
+        var sessionCookie = GetSetCookieHeader(verifyResponse, SecureCookieMiddleware.VoterSessionCookieName);
+        Assert.False(string.IsNullOrWhiteSpace(sessionCookie));
+        Assert.DoesNotContain("httponly", sessionCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AvailableElections_WithVoterCookieOnly_Succeeds()
+    {
+        var email = $"cookie_elections_{Guid.NewGuid():N}@example.com";
+        await SetupOpenElectionWithVoter(email, electionName: "Cookie Election");
+        var token = await AuthenticateVoterAndGetCookieAsync(email);
+
+        SetVoterCookie(token);
+        var response = await Client.GetAsync("/api/online-voting/availableElections");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var elections = await response.Content.ReadFromJsonAsync<List<AvailableElectionDto>>();
+        Assert.NotNull(elections);
+        Assert.Contains(elections, e => e.Name == "Cookie Election");
+    }
+
+    [Fact]
+    public async Task Me_WithVoterCookieOnly_ReturnsVoterIdentity()
+    {
+        var email = $"cookie_me_{Guid.NewGuid():N}@example.com";
+        await SetupOpenElectionWithVoter(email);
+        var token = await AuthenticateVoterAndGetCookieAsync(email);
+
+        SetVoterCookie(token);
+        var response = await Client.GetAsync("/api/online-voting/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var session = await response.Content.ReadFromJsonAsync<OnlineVoterSessionDto>();
+        Assert.NotNull(session);
+        Assert.Equal(email, session.VoterId);
+        Assert.Equal("E", session.VoterIdType);
+    }
+
+    [Fact]
+    public async Task Logout_ClearsVoterCookies_ThenAvailableElectionsUnauthorized()
+    {
+        var email = $"cookie_logout_{Guid.NewGuid():N}@example.com";
+        await SetupOpenElectionWithVoter(email);
+        var token = await AuthenticateVoterAndGetCookieAsync(email);
+
+        SetVoterCookie(token);
+        var logout = await Client.PostAsync("/api/online-voting/logout", null);
+        Assert.Equal(HttpStatusCode.OK, logout.StatusCode);
+
+        var clearedToken = GetSetCookieHeader(logout, SecureCookieMiddleware.VoterTokenCookieName);
+        Assert.False(string.IsNullOrWhiteSpace(clearedToken));
+        Assert.Contains("max-age=0", clearedToken, StringComparison.OrdinalIgnoreCase);
+
+        var tellerCookie = GetSetCookieHeader(logout, SecureCookieMiddleware.AccessTokenCookieName);
+        Assert.Null(tellerCookie);
+
+        Client.DefaultRequestHeaders.Remove("Cookie");
+        var noCookie = await Client.GetAsync("/api/online-voting/availableElections");
+        Assert.Equal(HttpStatusCode.Unauthorized, noCookie.StatusCode);
+    }
+
+    [Fact]
+    public async Task VoterAndTellerCookies_DoNotMixUpByPath()
+    {
+        var email = $"cookie_both_{Guid.NewGuid():N}@example.com";
+        await SetupOpenElectionWithVoter(email);
+        var voterToken = await AuthenticateVoterAndGetCookieAsync(email);
+        var tellerToken = await GetAuthTokenAsync();
+
+        SetCookies(
+            (SecureCookieMiddleware.VoterTokenCookieName, voterToken),
+            (SecureCookieMiddleware.AccessTokenCookieName, tellerToken));
+
+        var voterResponse = await Client.GetAsync("/api/online-voting/availableElections");
+        Assert.Equal(HttpStatusCode.OK, voterResponse.StatusCode);
+
+        var tellerResponse = await Client.GetAsync("/api/auth/me");
+        Assert.Equal(HttpStatusCode.OK, tellerResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task AllVotersAndVoterPersonal_JoinWithCookieOnly()
+    {
+        var email = $"cookie_hubs_{Guid.NewGuid():N}@example.com";
+        await SetupOpenElectionWithVoter(email);
+        var token = await AuthenticateVoterAndGetCookieAsync(email);
+        var cookieHeader = $"{SecureCookieMiddleware.VoterTokenCookieName}={token}";
+
+        await using var allVoters = CreateVoterHubConnection("/hubs/all-voters", cookieHeader);
+        await allVoters.StartAsync();
+        await allVoters.InvokeAsync("Join");
+
+        await using var personal = CreateVoterHubConnection("/hubs/voter-personal", cookieHeader);
+        await personal.StartAsync();
+        await personal.InvokeAsync("Join");
+    }
+
+    private HubConnection CreateVoterHubConnection(string hubPath, string cookieHeader)
+    {
+        var handler = Factory.Server.CreateHandler();
+        return new HubConnectionBuilder()
+            .WithUrl(new Uri(Client.BaseAddress!, hubPath), options =>
+            {
+                options.HttpMessageHandlerFactory = _ => handler;
+                options.Headers.Add("Cookie", cookieHeader);
+            })
+            .Build();
+    }
+
+    private async Task<string> AuthenticateVoterAndGetCookieAsync(string email)
+    {
+        var response = await Client.PostAsJsonAsync("/api/online-voting/googleAuth", new GoogleAuthForVoterDto
+        {
+            Credential = $"dev-google:{email}"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var token = GetSetCookieValue(response, SecureCookieMiddleware.VoterTokenCookieName);
+        Assert.False(string.IsNullOrWhiteSpace(token));
+        return token!;
+    }
+
+    private async Task SetupOpenElectionWithVoter(string email, string? electionName = null)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+
+        var electionGuid = Guid.NewGuid();
+        context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = electionName ?? "Cookie Auth Election",
+            UseOnlineVoting = true,
+            OnlineWhenOpen = DateTime.UtcNow.AddHours(-1),
+            OnlineWhenClose = DateTime.UtcNow.AddHours(1),
+            ElectionStage = ElectionStage.GatheringBallots,
+            RowVersion = new byte[8]
+        });
+
+        context.People.Add(new Person
+        {
+            ElectionGuid = electionGuid,
+            PersonGuid = Guid.NewGuid(),
+            FirstName = "Cookie",
+            LastName = "Voter",
+            Email = email,
+            CanVote = true,
+            RowVersion = new byte[8]
+        });
+
+        await context.SaveChangesAsync();
+    }
+}

--- a/Backend.Tests/IntegrationTests/VoterCookieAuthTests.cs
+++ b/Backend.Tests/IntegrationTests/VoterCookieAuthTests.cs
@@ -51,11 +51,17 @@ public class VoterCookieAuthTests : IntegrationTestBase
         var tokenCookie = GetSetCookieHeader(verifyResponse, SecureCookieMiddleware.VoterTokenCookieName);
         Assert.False(string.IsNullOrWhiteSpace(tokenCookie));
         Assert.Contains("httponly", tokenCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("secure", tokenCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("samesite=strict", tokenCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("domain=", tokenCookie, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain(SecureCookieMiddleware.AccessTokenCookieName + "=", tokenCookie, StringComparison.OrdinalIgnoreCase);
 
         var sessionCookie = GetSetCookieHeader(verifyResponse, SecureCookieMiddleware.VoterSessionCookieName);
         Assert.False(string.IsNullOrWhiteSpace(sessionCookie));
         Assert.DoesNotContain("httponly", sessionCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("secure", sessionCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("samesite=strict", sessionCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("domain=", sessionCookie, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -105,6 +111,9 @@ public class VoterCookieAuthTests : IntegrationTestBase
         var clearedToken = GetSetCookieHeader(logout, SecureCookieMiddleware.VoterTokenCookieName);
         Assert.False(string.IsNullOrWhiteSpace(clearedToken));
         Assert.Contains("max-age=0", clearedToken, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("secure", clearedToken, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("samesite=strict", clearedToken, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("domain=", clearedToken, StringComparison.OrdinalIgnoreCase);
 
         var tellerCookie = GetSetCookieHeader(logout, SecureCookieMiddleware.AccessTokenCookieName);
         Assert.Null(tellerCookie);

--- a/Backend.Tests/IntegrationTests/VoterOtpAuthFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/VoterOtpAuthFlowTests.cs
@@ -49,7 +49,8 @@ public class VoterOtpAuthFlowTests : IntegrationTestBase
         Assert.NotNull(auth);
         Assert.Equal(email, auth.VoterId);
         Assert.Equal("E", auth.VoterIdType);
-        Assert.False(string.IsNullOrWhiteSpace(auth.Token));
+        Assert.True(string.IsNullOrEmpty(auth.Token));
+        Assert.False(string.IsNullOrWhiteSpace(GetSetCookieValue(verifyResponse, "voter_token")));
     }
 
     [Fact]
@@ -81,7 +82,8 @@ public class VoterOtpAuthFlowTests : IntegrationTestBase
         Assert.NotNull(auth);
         Assert.Equal(phone, auth.VoterId);
         Assert.Equal("P", auth.VoterIdType);
-        Assert.False(string.IsNullOrWhiteSpace(auth.Token));
+        Assert.True(string.IsNullOrEmpty(auth.Token));
+        Assert.False(string.IsNullOrWhiteSpace(GetSetCookieValue(verifyResponse, "voter_token")));
     }
 
     [Fact]
@@ -100,7 +102,8 @@ public class VoterOtpAuthFlowTests : IntegrationTestBase
         Assert.NotNull(auth);
         Assert.Equal(email, auth.VoterId);
         Assert.Equal("E", auth.VoterIdType);
-        Assert.False(string.IsNullOrWhiteSpace(auth.Token));
+        Assert.True(string.IsNullOrEmpty(auth.Token));
+        Assert.False(string.IsNullOrWhiteSpace(GetSetCookieValue(response, "voter_token")));
     }
 
     private async Task<Guid> SetupOpenElectionWithVoter(string? email = null, string? phone = null)

--- a/Backend.Tests/UnitTests/SecureCookieMiddlewareTests.cs
+++ b/Backend.Tests/UnitTests/SecureCookieMiddlewareTests.cs
@@ -143,6 +143,60 @@ public class SecureCookieMiddlewareTests
     }
 
     [Fact]
+    public void SetVoterAuthCookies_SetsHttpOnlyTokenAndReadableSessionFlag()
+    {
+        var httpContext = new DefaultHttpContext();
+        var accessToken = "voter_jwt_value";
+
+        SecureCookieMiddleware.SetVoterAuthCookies(httpContext, accessToken, isHttps: true);
+
+        var cookies = httpContext.Response.GetTypedHeaders().SetCookie;
+        Assert.Equal(2, cookies.Count);
+
+        var tokenCookie = cookies.First(c => c.Name == SecureCookieMiddleware.VoterTokenCookieName);
+        Assert.Equal(accessToken, tokenCookie.Value.Value);
+        Assert.True(tokenCookie.HttpOnly);
+        Assert.True(tokenCookie.Secure);
+        Assert.Equal("Strict", tokenCookie.SameSite.ToString());
+
+        var sessionCookie = cookies.First(c => c.Name == SecureCookieMiddleware.VoterSessionCookieName);
+        Assert.Equal("1", sessionCookie.Value.Value);
+        Assert.False(sessionCookie.HttpOnly);
+        Assert.True(sessionCookie.Secure);
+        Assert.Equal("Strict", sessionCookie.SameSite.ToString());
+    }
+
+    [Fact]
+    public void ClearVoterAuthCookies_DoesNotClearTellerCookies()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.IsHttps = true;
+
+        SecureCookieMiddleware.ClearVoterAuthCookies(httpContext);
+
+        var cookies = httpContext.Response.GetTypedHeaders().SetCookie;
+        var cookieNames = cookies.Select(c => c.Name.Value).ToList();
+        Assert.Contains(SecureCookieMiddleware.VoterTokenCookieName, cookieNames);
+        Assert.Contains(SecureCookieMiddleware.VoterSessionCookieName, cookieNames);
+        Assert.DoesNotContain(SecureCookieMiddleware.AccessTokenCookieName, cookieNames);
+        Assert.DoesNotContain(SecureCookieMiddleware.RefreshTokenCookieName, cookieNames);
+    }
+
+    [Theory]
+    [InlineData("/api/online-voting/availableElections", true)]
+    [InlineData("/api/online-voting/me", true)]
+    [InlineData("/hubs/all-voters", true)]
+    [InlineData("/hubs/voter-personal", true)]
+    [InlineData("/hubs/all-voters/negotiate", true)]
+    [InlineData("/api/auth/me", false)]
+    [InlineData("/hubs/main", false)]
+    [InlineData("/api/elections", false)]
+    public void IsVoterScopedPath_ClassifiesVoterVsTellerPaths(string path, bool expected)
+    {
+        Assert.Equal(expected, SecureCookieMiddleware.IsVoterScopedPath(path));
+    }
+
+    [Fact]
     public void GetAccessToken_ReturnsTokenFromCookies()
     {
         // Arrange

--- a/Backend.Tests/UnitTests/SecureCookieMiddlewareTests.cs
+++ b/Backend.Tests/UnitTests/SecureCookieMiddlewareTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 using Backend.Middleware;
 using Xunit;
 using System.Collections;
@@ -148,7 +149,7 @@ public class SecureCookieMiddlewareTests
         var httpContext = new DefaultHttpContext();
         var accessToken = "voter_jwt_value";
 
-        SecureCookieMiddleware.SetVoterAuthCookies(httpContext, accessToken, isHttps: true);
+        SecureCookieMiddleware.SetVoterAuthCookies(httpContext, accessToken);
 
         var cookies = httpContext.Response.GetTypedHeaders().SetCookie;
         Assert.Equal(2, cookies.Count);
@@ -156,21 +157,31 @@ public class SecureCookieMiddlewareTests
         var tokenCookie = cookies.First(c => c.Name == SecureCookieMiddleware.VoterTokenCookieName);
         Assert.Equal(accessToken, tokenCookie.Value.Value);
         Assert.True(tokenCookie.HttpOnly);
-        Assert.True(tokenCookie.Secure);
-        Assert.Equal("Strict", tokenCookie.SameSite.ToString());
+        AssertAlwaysSecureStrictHostOnly(tokenCookie);
 
         var sessionCookie = cookies.First(c => c.Name == SecureCookieMiddleware.VoterSessionCookieName);
         Assert.Equal("1", sessionCookie.Value.Value);
         Assert.False(sessionCookie.HttpOnly);
-        Assert.True(sessionCookie.Secure);
-        Assert.Equal("Strict", sessionCookie.SameSite.ToString());
+        AssertAlwaysSecureStrictHostOnly(sessionCookie);
+    }
+
+    [Fact]
+    public void SetVoterAuthCookies_IsSecureStrictHostOnly_EvenWhenRequestIsHttp()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.IsHttps = false;
+
+        SecureCookieMiddleware.SetVoterAuthCookies(httpContext, "voter_jwt_value");
+
+        var cookies = httpContext.Response.GetTypedHeaders().SetCookie;
+        Assert.All(cookies, AssertAlwaysSecureStrictHostOnly);
     }
 
     [Fact]
     public void ClearVoterAuthCookies_DoesNotClearTellerCookies()
     {
         var httpContext = new DefaultHttpContext();
-        httpContext.Request.IsHttps = true;
+        httpContext.Request.IsHttps = false;
 
         SecureCookieMiddleware.ClearVoterAuthCookies(httpContext);
 
@@ -180,6 +191,14 @@ public class SecureCookieMiddlewareTests
         Assert.Contains(SecureCookieMiddleware.VoterSessionCookieName, cookieNames);
         Assert.DoesNotContain(SecureCookieMiddleware.AccessTokenCookieName, cookieNames);
         Assert.DoesNotContain(SecureCookieMiddleware.RefreshTokenCookieName, cookieNames);
+        Assert.All(cookies, AssertAlwaysSecureStrictHostOnly);
+    }
+
+    private static void AssertAlwaysSecureStrictHostOnly(SetCookieHeaderValue cookie)
+    {
+        Assert.True(cookie.Secure);
+        Assert.Equal("Strict", cookie.SameSite.ToString());
+        Assert.True(string.IsNullOrEmpty(cookie.Domain.ToString()));
     }
 
     [Theory]

--- a/backend/Controllers/OnlineVotingController.cs
+++ b/backend/Controllers/OnlineVotingController.cs
@@ -250,10 +250,7 @@ public class OnlineVotingController : ControllerBase
 
         if (!string.IsNullOrEmpty(response.Token))
         {
-            SecureCookieMiddleware.SetVoterAuthCookies(
-                HttpContext,
-                response.Token,
-                HttpContext.Request.IsHttps);
+            SecureCookieMiddleware.SetVoterAuthCookies(HttpContext, response.Token);
         }
 
         response.Token = null;

--- a/backend/Controllers/OnlineVotingController.cs
+++ b/backend/Controllers/OnlineVotingController.cs
@@ -1,4 +1,5 @@
 using Backend.DTOs.OnlineVoting;
+using Backend.Middleware;
 using Backend.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -51,13 +52,7 @@ public class OnlineVotingController : ControllerBase
     public async Task<ActionResult<OnlineVoterAuthResponse>> VerifyCode([FromBody] VerifyCodeDto dto)
     {
         var (success, error, response) = await _onlineVotingService.VerifyCodeAsync(dto);
-
-        if (!success)
-        {
-            return BadRequest(new { error });
-        }
-
-        return Ok(response);
+        return CompleteVoterAuth(success, error, response);
     }
 
     /// <summary>
@@ -70,13 +65,7 @@ public class OnlineVotingController : ControllerBase
     public async Task<ActionResult<OnlineVoterAuthResponse>> GoogleAuth([FromBody] GoogleAuthForVoterDto dto)
     {
         var (success, error, response) = await _onlineVotingService.AuthenticateVoterWithGoogleAsync(dto);
-
-        if (!success)
-        {
-            return BadRequest(new { error });
-        }
-
-        return Ok(response);
+        return CompleteVoterAuth(success, error, response);
     }
 
     /// <summary>
@@ -89,13 +78,7 @@ public class OnlineVotingController : ControllerBase
     public async Task<ActionResult<OnlineVoterAuthResponse>> FacebookAuth([FromBody] FacebookAuthForVoterDto dto)
     {
         var (success, error, response) = await _onlineVotingService.FacebookAuthAsync(dto);
-
-        if (!success)
-        {
-            return BadRequest(new { error });
-        }
-
-        return Ok(response);
+        return CompleteVoterAuth(success, error, response);
     }
 
     /// <summary>
@@ -108,13 +91,7 @@ public class OnlineVotingController : ControllerBase
     public async Task<ActionResult<OnlineVoterAuthResponse>> KakaoAuth([FromBody] KakaoAuthForVoterDto dto)
     {
         var (success, error, response) = await _onlineVotingService.KakaoAuthAsync(dto);
-
-        if (!success)
-        {
-            return BadRequest(new { error });
-        }
-
-        return Ok(response);
+        return CompleteVoterAuth(success, error, response);
     }
 
     /// <summary>
@@ -127,13 +104,7 @@ public class OnlineVotingController : ControllerBase
     public async Task<ActionResult<OnlineVoterAuthResponse>> TelegramAuth([FromBody] TelegramAuthForVoterDto dto)
     {
         var (success, error, response) = await _onlineVotingService.TelegramAuthAsync(dto);
-
-        if (!success)
-        {
-            return BadRequest(new { error });
-        }
-
-        return Ok(response);
+        return CompleteVoterAuth(success, error, response);
     }
 
     /// <summary>
@@ -153,6 +124,39 @@ public class OnlineVotingController : ControllerBase
 
         var elections = await _onlineVotingService.GetAvailableElectionsAsync(voterId);
         return Ok(elections);
+    }
+
+    /// <summary>
+    /// Returns the authenticated online voter's identity from the session cookie JWT.
+    /// Used by the SPA to restore voterId after refresh without reading the httpOnly token.
+    /// </summary>
+    [HttpGet("me")]
+    [Authorize(Policy = "OnlineVoter")]
+    public ActionResult<OnlineVoterSessionDto> GetSession()
+    {
+        var voterId = User.FindFirst("voterId")?.Value;
+        if (string.IsNullOrWhiteSpace(voterId))
+        {
+            return Unauthorized(new { error = "Invalid voter token." });
+        }
+
+        return Ok(new OnlineVoterSessionDto
+        {
+            VoterId = voterId,
+            VoterIdType = User.FindFirst("voterIdType")?.Value ?? string.Empty
+        });
+    }
+
+    /// <summary>
+    /// Clears online-voter cookies. Anonymous so an expired JWT can still log out.
+    /// Does not clear teller <c>auth_token</c> cookies.
+    /// </summary>
+    [HttpPost("logout")]
+    [AllowAnonymous]
+    public IActionResult Logout()
+    {
+        SecureCookieMiddleware.ClearVoterAuthCookies(HttpContext);
+        return Ok(new { message = "Logged out successfully" });
     }
 
     /// <summary>
@@ -229,5 +233,30 @@ public class OnlineVotingController : ControllerBase
 
         var status = await _onlineVotingService.GetVoteStatusAsync(electionGuid, voterId);
         return Ok(status);
+    }
+
+    /// <summary>
+    /// Issues httpOnly voter cookies and omits the JWT from the JSON body.
+    /// </summary>
+    private ActionResult<OnlineVoterAuthResponse> CompleteVoterAuth(
+        bool success,
+        string? error,
+        OnlineVoterAuthResponse? response)
+    {
+        if (!success || response == null)
+        {
+            return BadRequest(new { error });
+        }
+
+        if (!string.IsNullOrEmpty(response.Token))
+        {
+            SecureCookieMiddleware.SetVoterAuthCookies(
+                HttpContext,
+                response.Token,
+                HttpContext.Request.IsHttps);
+        }
+
+        response.Token = null;
+        return Ok(response);
     }
 }

--- a/backend/DTOs/OnlineVoting/OnlineVoterAuthResponse.cs
+++ b/backend/DTOs/OnlineVoting/OnlineVoterAuthResponse.cs
@@ -6,9 +6,10 @@
 public class OnlineVoterAuthResponse
 {
     /// <summary>
-    /// The authentication token for the voter.
+    /// Deprecated: the JWT is issued in the httpOnly <c>voter_token</c> cookie.
+    /// Left optional so older clients do not break; new responses omit it.
     /// </summary>
-    public string Token { get; set; } = null!;
+    public string? Token { get; set; }
 
     /// <summary>
     /// The voter's unique identifier.

--- a/backend/DTOs/OnlineVoting/OnlineVoterSessionDto.cs
+++ b/backend/DTOs/OnlineVoting/OnlineVoterSessionDto.cs
@@ -1,0 +1,17 @@
+namespace Backend.DTOs.OnlineVoting;
+
+/// <summary>
+/// Identity for an established online-voter cookie session (no JWT in the body).
+/// </summary>
+public class OnlineVoterSessionDto
+{
+    /// <summary>
+    /// The voter's unique identifier (email, phone, or kiosk code).
+    /// </summary>
+    public string VoterId { get; set; } = null!;
+
+    /// <summary>
+    /// The type of voter ID (E / P / C).
+    /// </summary>
+    public string VoterIdType { get; set; } = null!;
+}

--- a/backend/Middleware/SecureCookieMiddleware.cs
+++ b/backend/Middleware/SecureCookieMiddleware.cs
@@ -39,6 +39,23 @@ public class SecureCookieMiddleware
     public const string AuthMethodCookieName = "auth_method";
 
     /// <summary>
+    /// HttpOnly cookie holding the online-voter JWT. Distinct from <see cref="AccessTokenCookieName"/>
+    /// so teller and voter sessions can coexist in the same browser.
+    /// </summary>
+    public const string VoterTokenCookieName = "voter_token";
+
+    /// <summary>
+    /// Non-httpOnly flag cookie so the SPA can detect an online-voter session without reading the JWT.
+    /// Value is always <c>1</c> — not a secret and not PII.
+    /// </summary>
+    public const string VoterSessionCookieName = "voter_session";
+
+    /// <summary>
+    /// Default lifetime for voter session cookies, matching the 24-hour online-voter JWT.
+    /// </summary>
+    public const int VoterSessionExpiryMinutes = 24 * 60;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SecureCookieMiddleware"/> class.
     /// </summary>
     /// <param name="next">The next middleware in the pipeline.</param>
@@ -165,6 +182,96 @@ public class SecureCookieMiddleware
         context.Response.Cookies.Append(UserEmailCookieName, "", userCookieOptions);
         context.Response.Cookies.Append(UserNameCookieName, "", userCookieOptions);
         context.Response.Cookies.Append(AuthMethodCookieName, "", userCookieOptions);
+    }
+
+    /// <summary>
+    /// True for HTTP and SignalR paths that must authenticate as an online voter, not a teller.
+    /// Used so <c>voter_token</c> and <c>auth_token</c> can both be present without mix-up.
+    /// </summary>
+    public static bool IsVoterScopedPath(PathString path)
+    {
+        return path.StartsWithSegments("/api/online-voting")
+               || path.StartsWithSegments("/hubs/all-voters")
+               || path.StartsWithSegments("/hubs/voter-personal");
+    }
+
+    /// <summary>
+    /// Sets httpOnly <c>voter_token</c> plus a non-httpOnly <c>voter_session</c> flag.
+    /// Cookie attributes match teller auth (<c>HttpOnly</c>/<c>Secure</c>/<c>SameSite</c>/<c>Path</c>/<c>Domain</c>).
+    /// </summary>
+    public static void SetVoterAuthCookies(
+        HttpContext context,
+        string accessToken,
+        bool isHttps = true,
+        int? accessTokenExpiryMinutes = null)
+    {
+        var lifetimeMinutes = accessTokenExpiryMinutes ?? VoterSessionExpiryMinutes;
+        var expires = DateTimeOffset.UtcNow.AddMinutes(lifetimeMinutes);
+
+        var tokenOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
+            Expires = expires,
+            Path = "/",
+            Domain = isHttps ? null : "localhost"
+        };
+
+        context.Response.Cookies.Append(VoterTokenCookieName, accessToken, tokenOptions);
+
+        var sessionFlagOptions = new CookieOptions
+        {
+            HttpOnly = false,
+            Secure = isHttps,
+            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
+            Expires = expires,
+            Path = "/",
+            Domain = isHttps ? null : "localhost"
+        };
+
+        context.Response.Cookies.Append(VoterSessionCookieName, "1", sessionFlagOptions);
+    }
+
+    /// <summary>
+    /// Clears online-voter cookies without touching teller auth cookies.
+    /// </summary>
+    public static void ClearVoterAuthCookies(HttpContext context)
+    {
+        var isHttps = context.Request.IsHttps;
+        var expiredTokenOptions = new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = isHttps,
+            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
+            Expires = DateTimeOffset.UtcNow.AddDays(-1),
+            MaxAge = TimeSpan.Zero,
+            Path = "/",
+            Domain = isHttps ? null : "localhost"
+        };
+
+        context.Response.Cookies.Append(VoterTokenCookieName, "", expiredTokenOptions);
+
+        var expiredFlagOptions = new CookieOptions
+        {
+            HttpOnly = false,
+            Secure = isHttps,
+            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
+            Expires = DateTimeOffset.UtcNow.AddDays(-1),
+            MaxAge = TimeSpan.Zero,
+            Path = "/",
+            Domain = isHttps ? null : "localhost"
+        };
+
+        context.Response.Cookies.Append(VoterSessionCookieName, "", expiredFlagOptions);
+    }
+
+    /// <summary>
+    /// Gets the online-voter JWT from cookies.
+    /// </summary>
+    public static string? GetVoterAccessToken(HttpContext context)
+    {
+        return context.Request.Cookies[VoterTokenCookieName];
     }
 
     /// <summary>

--- a/backend/Middleware/SecureCookieMiddleware.cs
+++ b/backend/Middleware/SecureCookieMiddleware.cs
@@ -197,73 +197,60 @@ public class SecureCookieMiddleware
 
     /// <summary>
     /// Sets httpOnly <c>voter_token</c> plus a non-httpOnly <c>voter_session</c> flag.
-    /// Cookie attributes match teller auth (<c>HttpOnly</c>/<c>Secure</c>/<c>SameSite</c>/<c>Path</c>/<c>Domain</c>).
+    /// Always Secure + SameSite=Strict + host-only (no Domain). Vite local HTTPS
+    /// proxies /api to HTTP, so <see cref="HttpRequest.IsHttps"/> is false and must
+    /// not control these attributes (unlike teller cookies).
     /// </summary>
     public static void SetVoterAuthCookies(
         HttpContext context,
         string accessToken,
-        bool isHttps = true,
         int? accessTokenExpiryMinutes = null)
     {
         var lifetimeMinutes = accessTokenExpiryMinutes ?? VoterSessionExpiryMinutes;
         var expires = DateTimeOffset.UtcNow.AddMinutes(lifetimeMinutes);
 
-        var tokenOptions = new CookieOptions
-        {
-            HttpOnly = true,
-            Secure = isHttps,
-            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
-            Expires = expires,
-            Path = "/",
-            Domain = isHttps ? null : "localhost"
-        };
-
-        context.Response.Cookies.Append(VoterTokenCookieName, accessToken, tokenOptions);
-
-        var sessionFlagOptions = new CookieOptions
-        {
-            HttpOnly = false,
-            Secure = isHttps,
-            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
-            Expires = expires,
-            Path = "/",
-            Domain = isHttps ? null : "localhost"
-        };
-
-        context.Response.Cookies.Append(VoterSessionCookieName, "1", sessionFlagOptions);
+        context.Response.Cookies.Append(
+            VoterTokenCookieName,
+            accessToken,
+            CreateVoterCookieOptions(httpOnly: true, expires));
+        context.Response.Cookies.Append(
+            VoterSessionCookieName,
+            "1",
+            CreateVoterCookieOptions(httpOnly: false, expires));
     }
 
     /// <summary>
     /// Clears online-voter cookies without touching teller auth cookies.
+    /// Attributes match <see cref="SetVoterAuthCookies"/> so the browser expires the same cookies.
     /// </summary>
     public static void ClearVoterAuthCookies(HttpContext context)
     {
-        var isHttps = context.Request.IsHttps;
-        var expiredTokenOptions = new CookieOptions
+        var expired = DateTimeOffset.UtcNow.AddDays(-1);
+        var tokenOptions = CreateVoterCookieOptions(httpOnly: true, expired);
+        tokenOptions.MaxAge = TimeSpan.Zero;
+        var flagOptions = CreateVoterCookieOptions(httpOnly: false, expired);
+        flagOptions.MaxAge = TimeSpan.Zero;
+
+        context.Response.Cookies.Append(VoterTokenCookieName, "", tokenOptions);
+        context.Response.Cookies.Append(VoterSessionCookieName, "", flagOptions);
+    }
+
+    /// <summary>
+    /// Shared voter cookie attributes so set and clear stay aligned.
+    /// Always Secure + Strict + host-only; <paramref name="httpOnly"/> is the only difference
+    /// between the JWT cookie and the session flag.
+    /// </summary>
+    private static CookieOptions CreateVoterCookieOptions(bool httpOnly, DateTimeOffset expires)
+    {
+        return new CookieOptions
         {
-            HttpOnly = true,
-            Secure = isHttps,
-            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
-            Expires = DateTimeOffset.UtcNow.AddDays(-1),
-            MaxAge = TimeSpan.Zero,
+            HttpOnly = httpOnly,
+            Secure = true,
+            SameSite = SameSiteMode.Strict,
+            Expires = expires,
             Path = "/",
-            Domain = isHttps ? null : "localhost"
+            Domain = null
         };
-
-        context.Response.Cookies.Append(VoterTokenCookieName, "", expiredTokenOptions);
-
-        var expiredFlagOptions = new CookieOptions
-        {
-            HttpOnly = false,
-            Secure = isHttps,
-            SameSite = isHttps ? SameSiteMode.Strict : SameSiteMode.Lax,
-            Expires = DateTimeOffset.UtcNow.AddDays(-1),
-            MaxAge = TimeSpan.Zero,
-            Path = "/",
-            Domain = isHttps ? null : "localhost"
-        };
-
-        context.Response.Cookies.Append(VoterSessionCookieName, "", expiredFlagOptions);
     }
 
     /// <summary>

--- a/backend/Program.AuthSetup.cs
+++ b/backend/Program.AuthSetup.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Backend.Identity;
+using Backend.Middleware;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -55,7 +56,17 @@ public static class ProgramAuthSetup
                         return Task.CompletedTask;
                     }
 
-                    var tokenCookie = context.Request.Cookies["auth_token"];
+                    if (SecureCookieMiddleware.IsVoterScopedPath(path))
+                    {
+                        var voterCookie = context.Request.Cookies[SecureCookieMiddleware.VoterTokenCookieName];
+                        if (!string.IsNullOrEmpty(voterCookie))
+                        {
+                            context.Token = voterCookie;
+                            return Task.CompletedTask;
+                        }
+                    }
+
+                    var tokenCookie = context.Request.Cookies[SecureCookieMiddleware.AccessTokenCookieName];
                     if (!string.IsNullOrEmpty(tokenCookie))
                     {
                         context.Token = tokenCookie;

--- a/context/auth.md
+++ b/context/auth.md
@@ -26,11 +26,13 @@ User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? User.FindFirst("sub")?.Value
 
 Online voters use the same JWT claims as before (`voterType=online`, `voterId`, `voterIdType`). Only transport changed.
 
-- **Cookie `voter_token`:** httpOnly, Secure, SameSite, Path=/ — the session JWT (24h). Never written to `localStorage` / `sessionStorage` and not returned in auth JSON.
-- **Cookie `voter_session=1`:** same attribute family except **not** httpOnly — a boolean flag so the SPA can detect a session and call `GET /api/online-voting/me` to restore `voterId`.
+- **Cookie `voter_token`:** httpOnly, **always** Secure + SameSite=Strict + host-only (no Domain), Path=/ — the session JWT (24h). Never written to `localStorage` / `sessionStorage` and not returned in auth JSON.
+- **Cookie `voter_session=1`:** same attributes except **not** httpOnly — a boolean flag so the SPA can detect a session and call `GET /api/online-voting/me` to restore `voterId`.
 - **Cookie name is not `auth_token`.** Teller and voter JWTs can coexist in one browser. `OnMessageReceived` prefers `voter_token` on `/api/online-voting/*`, `/hubs/all-voters`, and `/hubs/voter-personal`; everywhere else it prefers `auth_token`. Bearer and hub `access_token` query still win when present (tests / tools).
-- **Logout:** `POST /api/online-voting/logout` clears only voter cookies. Teller logout still clears only teller cookies.
-- **Dev / prod cookie scope:** same family as teller — Vite HTTPS proxy makes `/api` and `/hubs` same-origin in development; production is same-site behind the reverse proxy.
+- **Logout:** `POST /api/online-voting/logout` clears only voter cookies, using the same Secure/Strict/host-only attributes so the browser expires them. Teller logout still clears only teller cookies.
+- **Dev / prod:** local Vite is HTTPS (`:8095`) and proxies `/api` and `/hubs` to HTTP `:5016`. The backend therefore sees `Request.IsHttps == false`. Voter cookies ignore that and stay Secure. UAT/prod are HTTPS.
+
+**Rejected alternative:** copy the teller HTTP-dev exception (`Secure`/`SameSite`/`Domain` from `Request.IsHttps`). Rejected — Vite already presents HTTPS to the browser; issuing `Secure=false` voter cookies behind the proxy is not what operators want. Teller cookies keep that exception in this slice.
 
 **Multi-tab:** cookies are shared across tabs on the same origin. Logging out in one tab clears cookies for all tabs; other tabs discover this on the next `/me` or `availableElections` call (401 → treat as logged out).
 

--- a/context/auth.md
+++ b/context/auth.md
@@ -16,3 +16,28 @@ User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? User.FindFirst("sub")?.Value
 **Reason:** on .NET 10, claim type mapping for the subject claim is not always the same as older stacks; reading only `ClaimTypes.NameIdentifier` or only `"sub"` fails depending on token and middleware configuration.
 
 **Rejected alternative:** assume a single claim type everywhere. That breaks in one of the two common configurations and produces hard-to-spot auth bugs (null user id, wrong scoping).
+
+## Online-voter session is a distinct httpOnly cookie
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #250; CodeQL `js/clear-text-storage-of-sensitive-data` on `voter_token` / `voter_id` in localStorage; teller cookie pattern in `SecureCookieMiddleware`  
+**Revisit when:** voter JWT lifetime or cookie attributes change, or teller/voter sessions must be mutually exclusive
+
+Online voters use the same JWT claims as before (`voterType=online`, `voterId`, `voterIdType`). Only transport changed.
+
+- **Cookie `voter_token`:** httpOnly, Secure, SameSite, Path=/ — the session JWT (24h). Never written to `localStorage` / `sessionStorage` and not returned in auth JSON.
+- **Cookie `voter_session=1`:** same attribute family except **not** httpOnly — a boolean flag so the SPA can detect a session and call `GET /api/online-voting/me` to restore `voterId`.
+- **Cookie name is not `auth_token`.** Teller and voter JWTs can coexist in one browser. `OnMessageReceived` prefers `voter_token` on `/api/online-voting/*`, `/hubs/all-voters`, and `/hubs/voter-personal`; everywhere else it prefers `auth_token`. Bearer and hub `access_token` query still win when present (tests / tools).
+- **Logout:** `POST /api/online-voting/logout` clears only voter cookies. Teller logout still clears only teller cookies.
+- **Dev / prod cookie scope:** same family as teller — Vite HTTPS proxy makes `/api` and `/hubs` same-origin in development; production is same-site behind the reverse proxy.
+
+**Multi-tab:** cookies are shared across tabs on the same origin. Logging out in one tab clears cookies for all tabs; other tabs discover this on the next `/me` or `availableElections` call (401 → treat as logged out).
+
+**Multi-device:** each device has its own cookie. A new login still notifies other sessions via VoterPersonal `updateVoter` (`login: true`). Logout on device A does not revoke device B’s JWT; B’s cookie lasts until expiry or its own logout.
+
+**Rejected alternative:** reuse `auth_token` for voters. A teller who then votes (or the reverse) would overwrite the other session.
+
+**Rejected alternative:** keep the JWT in the auth response body and only stop persisting it. XSS can still read the response; teller auth already omits tokens from the body.
+
+**Rejected alternative:** encrypt the JWT in `localStorage`. Not a fix under XSS (issue #250 / #249).

--- a/context/index.md
+++ b/context/index.md
@@ -3,7 +3,7 @@
 Lean index of project *why* knowledge. Load a topic file only when the work touches that area.
 
 - [architecture.md](architecture.md) — single backend host after domain consolidation; where code lives
-- [auth.md](auth.md) — JWT identity claims (`sub` / `NameIdentifier`) on .NET 10
+- [auth.md](auth.md) — JWT identity claims (`sub` / `NameIdentifier`); teller vs online-voter cookie transport
 - [realtime.md](realtime.md) — SignalR hub group naming (not a single `election-{guid}` pattern)
 - [api-contracts.md](api-contracts.md) — dual API response wrappers and OpenAPI client regeneration
 - [election-analysis.md](election-analysis.md) — core analysis engine; risk-first correctness vs v3

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -88,7 +88,7 @@ There is still no `/hubs/online-voting` hub and no `online-election-{guid}` grou
 **Source:** issue #233; v3 `AllVotersHub` / `VoterPersonalHub`; preferred thin-signal shape above  
 **Revisit when:** global `AllVoters` becomes too chatty, or kiosk multi-login needs different UX
 
-Online voters use two authenticated hubs (policy `OnlineVoter` — JWT claims `voterType=online` + `voterId`). FE connects with the voter Bearer token (`accessTokenFactory` + existing query `access_token` support).
+Online voters use two authenticated hubs (policy `OnlineVoter` — JWT claims `voterType=online` + `voterId`). FE connects with `withCredentials` only; the httpOnly `voter_token` cookie is accepted on `/hubs/all-voters` and `/hubs/voter-personal` by the same JWT `OnMessageReceived` path as HTTP. There is no client `accessTokenFactory` for voters.
 
 | Hub | Path | Group | Join | Events |
 | --- | ---- | ----- | ---- | ------ |

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -47,6 +47,12 @@ export function initApiClient() {
       return response;
     }
 
+    // Online-voter 401s must not run teller refresh or wipe teller cookies.
+    const requestUrl = request.url ?? response.url ?? "";
+    if (requestUrl.includes("/api/online-voting")) {
+      return response;
+    }
+
     if (
       response.url?.includes("/refreshToken") ||
       request.headers.get(AUTH_RETRY_HEADER) === "1"

--- a/frontend/src/pages/voting/VoterBallotPage.vue
+++ b/frontend/src/pages/voting/VoterBallotPage.vue
@@ -74,7 +74,8 @@ const allVotablePersonOptions = computed(() => {
 });
 
 onMounted(async () => {
-  if (!onlineVotingStore.voterId) {
+  const restored = await onlineVotingStore.restoreSession();
+  if (!restored) {
     showErrorMessage(t("voting.ballot.authRequired"));
     router.push({
       name: "voter-auth",

--- a/frontend/src/pages/voting/VoterConfirmationPage.vue
+++ b/frontend/src/pages/voting/VoterConfirmationPage.vue
@@ -22,8 +22,8 @@ function handleBackToElections() {
   router.push({ name: "voter-elections" });
 }
 
-function handleLogout() {
-  onlineVotingStore.logout();
+async function handleLogout() {
+  await onlineVotingStore.logout();
   router.push("/");
 }
 </script>

--- a/frontend/src/pages/voting/VoterElectionsPage.vue
+++ b/frontend/src/pages/voting/VoterElectionsPage.vue
@@ -12,7 +12,8 @@ const onlineVotingStore = useOnlineVotingStore();
 const { showErrorMessage } = useNotifications();
 
 onMounted(async () => {
-  if (!onlineVotingStore.voterToken) {
+  const restored = await onlineVotingStore.restoreSession();
+  if (!restored) {
     router.push({ name: "voter-auth" });
     return;
   }
@@ -105,8 +106,8 @@ function timeUntilClose(
   return t("voting.elections.status.open");
 }
 
-function handleLogout() {
-  onlineVotingStore.logout();
+async function handleLogout() {
+  await onlineVotingStore.logout();
   router.push("/");
 }
 </script>

--- a/frontend/src/services/__tests__/secureTokenService.test.ts
+++ b/frontend/src/services/__tests__/secureTokenService.test.ts
@@ -98,6 +98,22 @@ describe("secureTokenService", () => {
     }
   });
 
+  it("isVoterAuthenticated reads the non-httpOnly voter_session flag", () => {
+    cookieJar.push("voter_session=1");
+    expect(secureTokenService.isVoterAuthenticated()).toBe(true);
+  });
+
+  it("clearVoterSession expires the voter_session flag with secure flags", () => {
+    secureTokenService.clearVoterSession();
+
+    expect(cookieJar).toHaveLength(1);
+    const written = cookieJar[0].toLowerCase();
+    expect(written).toContain("voter_session=");
+    expect(written).toContain("max-age=0");
+    expect(written).toContain("secure");
+    expect(written).toContain("samesite=strict");
+  });
+
   it("getCookie decodes URI-encoded values", () => {
     // Simulate a browser cookie store string (name=value pairs only; no attributes).
     // Use the shared mock jar so we do not reassign document.cookie without Secure

--- a/frontend/src/services/__tests__/signalrService.voterHubs.spec.ts
+++ b/frontend/src/services/__tests__/signalrService.voterHubs.spec.ts
@@ -69,42 +69,36 @@ describe("signalrService voter hubs", () => {
     onreconnected.mockClear();
   });
 
-  it("connectVoterHubs joins AllVoters then VoterPersonal with token factory", async () => {
+  it("connectVoterHubs joins AllVoters then VoterPersonal with credentials only", async () => {
     const { signalrService } = await import("../signalrService");
-    const tokenFactory = vi.fn(() => "voter-jwt");
 
-    await signalrService.connectVoterHubs(tokenFactory);
+    await signalrService.connectVoterHubs();
 
     expect(withUrl).toHaveBeenCalledWith(
       "http://localhost:5016/hubs/all-voters",
       expect.objectContaining({
         withCredentials: true,
-        accessTokenFactory: expect.any(Function),
       }),
     );
     expect(withUrl).toHaveBeenCalledWith(
       "http://localhost:5016/hubs/voter-personal",
       expect.objectContaining({
         withCredentials: true,
-        accessTokenFactory: expect.any(Function),
       }),
     );
 
-    // Join order: AllVoters then VoterPersonal
+    for (const call of withUrl.mock.calls) {
+      const opts = call[1] as { accessTokenFactory?: unknown };
+      expect(opts.accessTokenFactory).toBeUndefined();
+    }
+
     const joinCalls = invoke.mock.calls.filter((c) => c[0] === "Join");
     expect(joinCalls).toHaveLength(2);
-
-    // accessTokenFactory from connect options should use the provided factory
-    const allVotersOpts = withUrl.mock.calls.find(
-      (c) => c[0] === "http://localhost:5016/hubs/all-voters",
-    )?.[1] as { accessTokenFactory: () => string };
-    expect(allVotersOpts.accessTokenFactory()).toBe("voter-jwt");
-    expect(tokenFactory).toHaveBeenCalled();
   });
 
   it("disconnectVoterHubs leaves then disconnects both hubs", async () => {
     const { signalrService } = await import("../signalrService");
-    await signalrService.connectVoterHubs(() => "voter-jwt");
+    await signalrService.connectVoterHubs();
     invoke.mockClear();
     stop.mockClear();
 
@@ -117,10 +111,9 @@ describe("signalrService voter hubs", () => {
 
   it("re-invokes Join after reconnect when voter groups were joined", async () => {
     const { signalrService } = await import("../signalrService");
-    await signalrService.connectVoterHubs(() => "voter-jwt");
+    await signalrService.connectVoterHubs();
     invoke.mockClear();
 
-    // Capture onreconnected handlers registered during connect
     expect(onreconnected).toHaveBeenCalled();
     const reconnectHandlers = onreconnected.mock.calls.map((c) => c[0]);
     expect(reconnectHandlers.length).toBeGreaterThanOrEqual(2);

--- a/frontend/src/services/onlineVotingService.ts
+++ b/frontend/src/services/onlineVotingService.ts
@@ -1,3 +1,4 @@
+import { client } from "@/api/gen/configService/client.gen";
 import {
   getApiOnlineVotingAvailableElections,
   getApiOnlineVotingByElectionGuidByVoterIdVoteStatus,
@@ -77,15 +78,25 @@ export const onlineVotingService = {
     return requireData(response.data, "telegramAuth");
   },
 
-  async getAvailableElections(
-    voterToken: string,
-  ): Promise<OnlineVotingAvailableElectionDto[]> {
-    const response = await getApiOnlineVotingAvailableElections({
-      headers: {
-        Authorization: `Bearer ${voterToken}`,
-      },
-    });
+  async getAvailableElections(): Promise<OnlineVotingAvailableElectionDto[]> {
+    const response = await getApiOnlineVotingAvailableElections();
     return requireData(response.data, "getAvailableElections");
+  },
+
+  async getSession(): Promise<{ voterId: string; voterIdType: string }> {
+    const response = await client.get({ url: "/api/online-voting/me" });
+    const payload = requireData(
+      response.data as { voterId?: string; voterIdType?: string } | undefined,
+      "getSession",
+    );
+    return {
+      voterId: payload.voterId ?? "",
+      voterIdType: payload.voterIdType ?? "",
+    };
+  },
+
+  async logout(): Promise<void> {
+    await client.post({ url: "/api/online-voting/logout" });
   },
 
   async getElectionInfo(

--- a/frontend/src/services/secureTokenService.ts
+++ b/frontend/src/services/secureTokenService.ts
@@ -38,6 +38,10 @@ export const secureTokenService = {
     userEmail: "user_email",
     userName: "user_name",
     authMethod: "auth_method",
+    /** HttpOnly voter JWT — not readable from JavaScript. */
+    voterToken: "voter_token",
+    /** Non-httpOnly flag so the SPA can detect a voter session. */
+    voterSession: "voter_session",
   } as const,
 
   /**
@@ -81,6 +85,21 @@ export const secureTokenService = {
     this.setCookie(this.cookieNames.userEmail, "", -1);
     this.setCookie(this.cookieNames.userName, "", -1);
     this.setCookie(this.cookieNames.authMethod, "", -1);
+  },
+
+  /**
+   * True when the backend set the non-httpOnly voter session flag.
+   * The JWT itself is httpOnly and cannot be read here.
+   */
+  isVoterAuthenticated(): boolean {
+    return this.getCookie(this.cookieNames.voterSession) === "1";
+  },
+
+  /**
+   * Expires the readable voter session flag. HttpOnly voter_token is cleared by the API.
+   */
+  clearVoterSession(): void {
+    this.setCookie(this.cookieNames.voterSession, "", -1);
   },
 
   /**

--- a/frontend/src/services/signalr/SignalRConnectionCore.ts
+++ b/frontend/src/services/signalr/SignalRConnectionCore.ts
@@ -13,23 +13,19 @@ export class SignalRConnectionCore {
   /** Known-teller dashboard multi-election listen set (MainHub JoinElections). */
   protected dashboardElectionGuids: string[] = [];
   protected publicGroupJoined = false;
-  /** Online voter hubs (Bearer voter JWT from localStorage). */
+  /** Online voter hubs (httpOnly voter_token cookie + withCredentials). */
   protected allVotersJoined = false;
   protected voterPersonalJoined = false;
-  protected voterAccessTokenFactory: (() => string | null) | null = null;
 
   protected get baseUrl(): string {
     return getAppConfig().apiUrl;
   }
 
   /**
-   * Connect to a hub. Optional accessTokenFactory is used for online-voter hubs
-   * (Bearer JWT in localStorage); teller hubs rely on cookies / default auth.
+   * Connect to a hub. Teller and online-voter hubs both send cookies via
+   * withCredentials; there is no client-side JWT factory.
    */
-  async connect(
-    hubPath: string,
-    accessTokenFactory?: () => string | null,
-  ): Promise<signalR.HubConnection> {
+  async connect(hubPath: string): Promise<signalR.HubConnection> {
     const existingConnection = this.connections.get(hubPath);
     if (existingConnection?.state === signalR.HubConnectionState.Connected) {
       return existingConnection;
@@ -39,12 +35,8 @@ export class SignalRConnectionCore {
 
     const connection = new signalR.HubConnectionBuilder()
       .withUrl(hubUrl, {
-        // Cookies are sent automatically by the browser with the initial HTTP request.
-        // Online-voter hubs also send the voter JWT via access_token / Authorization.
+        // Cookies (teller auth_token and/or voter_token) are sent automatically.
         withCredentials: true,
-        accessTokenFactory: accessTokenFactory
-          ? () => accessTokenFactory() ?? ""
-          : undefined,
       })
       .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
       .configureLogging(signalR.LogLevel.Warning)

--- a/frontend/src/services/signalrService.ts
+++ b/frontend/src/services/signalrService.ts
@@ -8,12 +8,9 @@ import { SignalRTellerHubs } from "./signalr/SignalRTellerHubs";
 export class SignalRService extends SignalRTellerHubs {
   /**
    * Connect + join online-voter hubs (AllVoters + VoterPersonal).
-   * Requires a factory that returns the current voter JWT (localStorage).
+   * Auth is the httpOnly voter_token cookie (withCredentials); no JS-readable JWT.
    */
-  async connectVoterHubs(
-    accessTokenFactory: () => string | null,
-  ): Promise<void> {
-    this.voterAccessTokenFactory = accessTokenFactory;
+  async connectVoterHubs(): Promise<void> {
     await this.connectToAllVotersHub();
     await this.joinAllVoters();
     await this.connectToVoterPersonalHub();
@@ -25,21 +22,14 @@ export class SignalRService extends SignalRTellerHubs {
     await this.leaveVoterPersonal();
     await this.disconnect("/hubs/all-voters");
     await this.disconnect("/hubs/voter-personal");
-    this.voterAccessTokenFactory = null;
   }
 
   async connectToAllVotersHub(): Promise<signalR.HubConnection> {
-    const factory =
-      this.voterAccessTokenFactory ??
-      (() => localStorage.getItem("voter_token"));
-    return this.connect("/hubs/all-voters", factory);
+    return this.connect("/hubs/all-voters");
   }
 
   async connectToVoterPersonalHub(): Promise<signalR.HubConnection> {
-    const factory =
-      this.voterAccessTokenFactory ??
-      (() => localStorage.getItem("voter_token"));
-    return this.connect("/hubs/voter-personal", factory);
+    return this.connect("/hubs/voter-personal");
   }
 
   async joinAllVoters(): Promise<void> {

--- a/frontend/src/stores/onlineVotingStore.ts
+++ b/frontend/src/stores/onlineVotingStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { onlineVotingService } from "../services/onlineVotingService";
+import { secureTokenService } from "../services/secureTokenService";
 import { signalrService } from "../services/signalrService";
 import { useApiErrorHandler } from "../composables/useApiErrorHandler";
 import type {
@@ -24,8 +25,7 @@ import type {
 export const useOnlineVotingStore = defineStore("onlineVoting", () => {
   const { handleApiError } = useApiErrorHandler();
 
-  const voterToken = ref<string | null>(localStorage.getItem("voter_token"));
-  const voterId = ref<string | null>(localStorage.getItem("voter_id"));
+  const voterId = ref<string | null>(null);
   const electionInfo = ref<OnlineElectionInfo | null>(null);
   const votablePeople = ref<OnlinePerson[]>([]);
   const voteStatus = ref<OnlineVoteStatus | null>(null);
@@ -37,12 +37,64 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
   const loginElsewhereNotice = ref(false);
 
   let voterHubHandlersBound = false;
+  let restorePromise: Promise<boolean> | null = null;
 
-  function persistAuth(token: string, id: string) {
-    voterToken.value = token;
+  // Drop pre-#250 JWTs that may still sit in JS-readable storage on this origin.
+  try {
+    localStorage.removeItem("voter_token");
+    localStorage.removeItem("voter_id");
+  } catch {
+    // Ignore quota / private-mode failures.
+  }
+
+  const isAuthenticated = computed(() => !!voterId.value);
+
+  function persistAuth(id: string) {
     voterId.value = id;
-    localStorage.setItem("voter_token", token);
-    localStorage.setItem("voter_id", id);
+  }
+
+  async function applyAuthResponse(response: {
+    voterId?: string | null;
+  }): Promise<void> {
+    if (response.voterId) {
+      persistAuth(response.voterId);
+      return;
+    }
+    await restoreSession();
+  }
+
+  /**
+   * Restores voterId from the httpOnly cookie session via GET /me.
+   * Uses the non-httpOnly voter_session flag to skip the call when logged out.
+   */
+  async function restoreSession(): Promise<boolean> {
+    if (voterId.value) {
+      return true;
+    }
+    if (!secureTokenService.isVoterAuthenticated()) {
+      return false;
+    }
+    if (restorePromise) {
+      return restorePromise;
+    }
+
+    restorePromise = (async () => {
+      try {
+        const session = await onlineVotingService.getSession();
+        if (!session.voterId) {
+          return false;
+        }
+        persistAuth(session.voterId);
+        return true;
+      } catch {
+        secureTokenService.clearVoterSession();
+        return false;
+      } finally {
+        restorePromise = null;
+      }
+    })();
+
+    return restorePromise;
   }
 
   async function requestVerificationCode(data: RequestCodeDto) {
@@ -59,9 +111,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.verifyCode(data);
-      if (response.token && response.voterId) {
-        persistAuth(response.token, response.voterId);
-      }
+      await applyAuthResponse(response);
       return response;
     } finally {
       loading.value = false;
@@ -72,9 +122,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.googleAuth(data);
-      if (response.token && response.voterId) {
-        persistAuth(response.token, response.voterId);
-      }
+      await applyAuthResponse(response);
       return response;
     } finally {
       loading.value = false;
@@ -85,9 +133,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.facebookAuth(data);
-      if (response.token && response.voterId) {
-        persistAuth(response.token, response.voterId);
-      }
+      await applyAuthResponse(response);
       return response;
     } finally {
       loading.value = false;
@@ -98,9 +144,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.kakaoAuth(data);
-      if (response.token && response.voterId) {
-        persistAuth(response.token, response.voterId);
-      }
+      await applyAuthResponse(response);
       return response;
     } finally {
       loading.value = false;
@@ -111,9 +155,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     try {
       loading.value = true;
       const response = await onlineVotingService.telegramAuth(data);
-      if (response.token && response.voterId) {
-        persistAuth(response.token, response.voterId);
-      }
+      await applyAuthResponse(response);
       return response;
     } finally {
       loading.value = false;
@@ -168,15 +210,14 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
   }
 
   async function loadAvailableElections() {
-    if (!voterToken.value) {
+    const authed = await restoreSession();
+    if (!authed) {
       throw new Error("Voter is not authenticated.");
     }
 
     try {
       loading.value = true;
-      const data = await onlineVotingService.getAvailableElections(
-        voterToken.value,
-      );
+      const data = await onlineVotingService.getAvailableElections();
       availableElections.value = data;
       return data;
     } catch (error) {
@@ -210,7 +251,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
 
   async function handleUpdateVoters(_payload: UpdateVotersEvent) {
     // Thin signal: re-fetch authoritative list (eligibility is server-side).
-    if (!voterToken.value) {
+    if (!(await restoreSession())) {
       return;
     }
     try {
@@ -225,7 +266,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
       loginElsewhereNotice.value = true;
     }
 
-    if (payload.updateRegistration && voterToken.value) {
+    if (payload.updateRegistration && (await restoreSession())) {
       try {
         await loadAvailableElections();
         if (payload.electionGuid && voterId.value) {
@@ -239,10 +280,10 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
 
   /**
    * Connect AllVoters + VoterPersonal hubs for the authenticated voter session.
-   * Safe to call multiple times (idempotent).
+   * Auth is the httpOnly voter cookie (withCredentials). Safe to call multiple times.
    */
   async function ensureVoterHubsConnected(): Promise<void> {
-    if (!voterToken.value) {
+    if (!(await restoreSession())) {
       return;
     }
 
@@ -251,9 +292,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     }
 
     try {
-      await signalrService.connectVoterHubs(
-        () => voterToken.value ?? localStorage.getItem("voter_token"),
-      );
+      await signalrService.connectVoterHubs();
 
       if (!voterHubHandlersBound) {
         const allVoters = signalrService.getConnection("/hubs/all-voters");
@@ -289,20 +328,23 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
 
   async function logout() {
     await disconnectVoterHubs();
-    voterToken.value = null;
+    try {
+      await onlineVotingService.logout();
+    } catch {
+      // Still clear local UI state if the logout request fails.
+    }
+    secureTokenService.clearVoterSession();
     voterId.value = null;
     electionInfo.value = null;
     votablePeople.value = [];
     voteStatus.value = null;
     availableElections.value = [];
     loginElsewhereNotice.value = false;
-    localStorage.removeItem("voter_token");
-    localStorage.removeItem("voter_id");
   }
 
   return {
-    voterToken,
     voterId,
+    isAuthenticated,
     electionInfo,
     votablePeople,
     voteStatus,
@@ -310,6 +352,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
     loading,
     voterHubsConnected,
     loginElsewhereNotice,
+    restoreSession,
     requestVerificationCode,
     verifyCode,
     googleAuth,

--- a/frontend/src/types/SignalRConnection.ts
+++ b/frontend/src/types/SignalRConnection.ts
@@ -11,5 +11,4 @@ export type ConnectionState =
 export interface SignalRConfig {
   hubUrl: string;
   automaticReconnect?: boolean;
-  accessTokenFactory?: () => string | null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #250.

Online-voter JWTs are no longer stored in `localStorage` or sent as `Authorization: Bearer` from the SPA. Successful verifyCode / OAuth / kiosk auth now issues an httpOnly `voter_token` cookie (same attribute family as teller `auth_token`) plus a non-httpOnly `voter_session=1` flag. HTTP APIs and AllVoters / VoterPersonal hubs authenticate from that cookie (`withCredentials`). The JWT is omitted from auth response bodies.

## Why a distinct cookie

Teller `auth_token` and voter `voter_token` can coexist. `OnMessageReceived` prefers `voter_token` only on `/api/online-voting/*`, `/hubs/all-voters`, and `/hubs/voter-personal`; other paths still use `auth_token`. Bearer and hub `access_token` query remain for tests/tools.

## Cookie attributes (Glen review)

Voter cookies are **always** `Secure`, `SameSite=Strict`, and host-only (`Domain` omitted). They do **not** copy the teller HTTP-dev exception (`Secure`/`SameSite`/`Domain` from `Request.IsHttps`). Local Vite is already HTTPS and proxies `/api` to HTTP `:5016`, so the backend sees `IsHttps == false`; voter set/clear still emit Secure cookies so the browser on `:8095` accepts them. Clear options match set options so logout expires the same cookies. Teller `SetAuthCookies` / `ClearAuthCookies` are unchanged.

## Session restore and logout

- SPA detects a session from `voter_session` and restores `voterId` via `GET /api/online-voting/me`.
- `POST /api/online-voting/logout` clears only voter cookies (teller logout unchanged).
- Multi-tab: cookies are shared; logout in one tab applies to all tabs on the next request.
- Multi-device: each device keeps its own cookie; login-elsewhere SignalR notice is unchanged. Logout does not revoke other devices’ JWTs.

## What was verified

**Code investigation (hypothesis confirmed):** tellers already used `secureTokenService` + httpOnly `auth_token` via JWT `OnMessageReceived`. Voters stored `voter_token` / `voter_id` in `localStorage` and sent Bearer plus SignalR `accessTokenFactory`.

**Follow-up (`c33e68a7`):** voter set+clear always Secure + Strict + no Domain, including when `Request.IsHttps` is false. Unit + integration cookie tests updated. Local `dotnet test` filter `SecureCookieMiddleware|VoterCookieAuth|VoterOtpAuth|VoterAuthentication|AuthControllerTests` — 90 passed. GitHub CI: all 5 checks passed.

**Earlier revision (`bc51db66`):** GitHub CI all 5 checks passed. Frontend `npm run check` + voter SignalR/token unit tests passed.

**Not verified here:** browser E2E of Google/Facebook/Kakao/Telegram/kiosk on a running SPA.

## Out of scope

Does not change eligibility/open-window rules, VoterCodeHub (#229), WhatsApp/GreenAPI (#255), or remaining SmsStatus work (#254). Teller cookie HTTP-dev exception is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b920356-5304-4b8a-b281-5330483327bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b920356-5304-4b8a-b281-5330483327bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

