### PR TITLE
Ensure OnlineVoter phone row on Person write (#254 next slice)

### DIFF
--- a/Backend.Tests/UnitTests/Helpers/OnlineVoterPhoneHelperTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/OnlineVoterPhoneHelperTests.cs
@@ -1,0 +1,90 @@
+using Backend.Entities;
+using Backend.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class OnlineVoterPhoneHelperTests : ServiceTestBase
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task EnsureOnlineVoterForPhoneAsync_NoPhone_DoesNotAddRow(string? phone)
+    {
+        await OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync(Context, phone);
+        await Context.SaveChangesAsync();
+
+        Assert.Empty(Context.OnlineVoters);
+    }
+
+    [Fact]
+    public async Task EnsureOnlineVoterForPhoneAsync_NewPhone_AddsPhoneRowWithNullAuthFields()
+    {
+        const string phone = "+14168972671";
+
+        await OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync(Context, phone);
+        await Context.SaveChangesAsync();
+
+        var row = Assert.Single(Context.OnlineVoters);
+        Assert.Equal(phone, row.VoterId);
+        Assert.Equal(OnlineVoterPhoneHelper.PhoneVoterIdType, row.VoterIdType);
+        Assert.Null(row.WhenRegistered);
+        Assert.Null(row.WhenLastLogin);
+        Assert.Null(row.SmsStatus);
+    }
+
+    [Fact]
+    public async Task EnsureOnlineVoterForPhoneAsync_ExistingRow_DoesNotDuplicateOrWipeFields()
+    {
+        const string phone = "+14168972671";
+        var registered = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+        var lastLogin = DateTimeOffset.Parse("2026-01-02T00:00:00Z");
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = phone,
+            VoterIdType = "P",
+            SmsStatus = "landline",
+            WhenRegistered = registered,
+            WhenLastLogin = lastLogin
+        });
+        await Context.SaveChangesAsync();
+
+        await OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync(Context, phone);
+        await Context.SaveChangesAsync();
+
+        var row = Assert.Single(await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync());
+        Assert.Equal("P", row.VoterIdType);
+        Assert.Equal("landline", row.SmsStatus);
+        Assert.Equal(registered, row.WhenRegistered);
+        Assert.Equal(lastLogin, row.WhenLastLogin);
+    }
+
+    [Fact]
+    public async Task EnsureOnlineVotersForPhonesAsync_Batch_AddsMissingOnly()
+    {
+        const string existing = "+14168972671";
+        const string added = "+14168972672";
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = existing,
+            VoterIdType = "P",
+            SmsStatus = "OK",
+            WhenRegistered = DateTimeOffset.Parse("2026-04-01T00:00:00Z")
+        });
+        await Context.SaveChangesAsync();
+
+        await OnlineVoterPhoneHelper.EnsureOnlineVotersForPhonesAsync(
+            Context,
+            [existing, added, added, null, ""]);
+        await Context.SaveChangesAsync();
+
+        Assert.Equal(2, await Context.OnlineVoters.CountAsync());
+        var existingRow = await Context.OnlineVoters.SingleAsync(ov => ov.VoterId == existing);
+        Assert.Equal("OK", existingRow.SmsStatus);
+        Assert.NotNull(existingRow.WhenRegistered);
+        var newRow = await Context.OnlineVoters.SingleAsync(ov => ov.VoterId == added);
+        Assert.Equal("P", newRow.VoterIdType);
+        Assert.Null(newRow.WhenRegistered);
+    }
+}

--- a/Backend.Tests/UnitTests/Helpers/OnlineVoterPhoneHelperTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/OnlineVoterPhoneHelperTests.cs
@@ -60,6 +60,40 @@ public class OnlineVoterPhoneHelperTests : ServiceTestBase
         Assert.Equal(lastLogin, row.WhenLastLogin);
     }
 
+    [Theory]
+    [InlineData("E")]
+    [InlineData("C")]
+    [InlineData("T")]
+    public async Task EnsureOnlineVoterForPhoneAsync_VoterIdOccupiedByOtherType_SkipsWithoutWipeOrThrow(
+        string existingType)
+    {
+        const string phone = "+14168972671";
+        var registered = DateTimeOffset.Parse("2026-06-01T00:00:00Z");
+        var lastLogin = DateTimeOffset.Parse("2026-06-02T00:00:00Z");
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = phone,
+            VoterIdType = existingType,
+            SmsStatus = "admin",
+            WhenRegistered = registered,
+            WhenLastLogin = lastLogin
+        });
+        await Context.SaveChangesAsync();
+
+        var thrown = await Record.ExceptionAsync(async () =>
+        {
+            await OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync(Context, phone);
+            await Context.SaveChangesAsync();
+        });
+
+        Assert.Null(thrown);
+        var row = Assert.Single(await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync());
+        Assert.Equal(existingType, row.VoterIdType);
+        Assert.Equal("admin", row.SmsStatus);
+        Assert.Equal(registered, row.WhenRegistered);
+        Assert.Equal(lastLogin, row.WhenLastLogin);
+    }
+
     [Fact]
     public async Task EnsureOnlineVotersForPhonesAsync_Batch_AddsMissingOnly()
     {

--- a/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
+++ b/Backend.Tests/UnitTests/Services/OnlineVotingServiceRequestCodePaidPhoneTests.cs
@@ -185,6 +185,49 @@ public class OnlineVotingServiceRequestCodePaidPhoneTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task RequestCode_ExistingPhoneRow_NullWhenRegistered_StampsOnSuccessfulRequest()
+    {
+        await SeedOpenElectionWithPerson(phone: ValidPhone);
+        await SeedOnlineVoter(ValidPhone, smsStatus: null);
+        _paidSender
+            .Setup(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        var before = DateTimeOffset.UtcNow.AddSeconds(-1);
+        await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+        var after = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        var row = await Context.OnlineVoters.SingleAsync(ov => ov.VoterId == ValidPhone);
+        Assert.NotNull(row.WhenRegistered);
+        Assert.InRange(row.WhenRegistered.Value, before, after);
+        Assert.Equal("P", row.VoterIdType);
+    }
+
+    [Fact]
+    public async Task RequestCode_ExistingPhoneRow_WhenRegisteredPreserved()
+    {
+        var registered = DateTimeOffset.Parse("2026-01-10T00:00:00Z");
+        await SeedOpenElectionWithPerson(phone: ValidPhone);
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = ValidPhone,
+            VoterIdType = "P",
+            SmsStatus = OnlineVoterSmsStatus.Ok,
+            WhenRegistered = registered
+        });
+        await Context.SaveChangesAsync();
+        _paidSender
+            .Setup(s => s.SendSmsAsync(ValidPhone, It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        await _service.RequestVerificationCodeAsync(PaidSmsRequest(ValidPhone));
+
+        var row = await Context.OnlineVoters.SingleAsync(ov => ov.VoterId == ValidPhone);
+        Assert.Equal(registered, row.WhenRegistered);
+        Assert.Equal(OnlineVoterSmsStatus.Ok, row.SmsStatus);
+    }
+
+    [Fact]
     public async Task RequestCode_SmsStatusOk_NotRegistered_ReachesRegistrationCheck()
     {
         await SeedOpenElectionWithPerson(email: "other@example.com");

--- a/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
@@ -704,6 +704,123 @@ public class PeopleImportServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task ImportPeopleAsync_WithPhone_CreatesOnlineVoterPhoneRow_WhenRegisteredNull()
+    {
+        const string phone = "+14168972671";
+        var electionGuid = Guid.NewGuid();
+        var fileContent = $"FirstName,LastName,Phone\nPat,Smith,{phone}";
+        var mappings = new List<ColumnMappingDto>
+        {
+            new() { FileColumn = "FirstName", TargetField = "FirstName" },
+            new() { FileColumn = "LastName", TargetField = "LastName" },
+            new() { FileColumn = "Phone", TargetField = "Phone" }
+        };
+
+        var importFile = new ImportFile
+        {
+            ElectionGuid = electionGuid,
+            FileType = "csv",
+            CodePage = 65001,
+            FirstDataRow = 1,
+            Contents = Encoding.UTF8.GetBytes(fileContent),
+            HasContent = true,
+            ColumnsToRead = System.Text.Json.JsonSerializer.Serialize(mappings)
+        };
+        Context.ImportFiles.Add(importFile);
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.PeopleAdded);
+        var row = Assert.Single(await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync());
+        Assert.Equal("P", row.VoterIdType);
+        Assert.Null(row.WhenRegistered);
+        Assert.Null(row.WhenLastLogin);
+        Assert.Null(row.SmsStatus);
+    }
+
+    [Fact]
+    public async Task ImportPeopleAsync_WithoutPhone_DoesNotCreatePhoneOnlineVoter()
+    {
+        var electionGuid = Guid.NewGuid();
+        var fileContent = "FirstName,LastName,Email\nPat,Smith,pat@example.com";
+        var mappings = new List<ColumnMappingDto>
+        {
+            new() { FileColumn = "FirstName", TargetField = "FirstName" },
+            new() { FileColumn = "LastName", TargetField = "LastName" },
+            new() { FileColumn = "Email", TargetField = "Email" }
+        };
+
+        var importFile = new ImportFile
+        {
+            ElectionGuid = electionGuid,
+            FileType = "csv",
+            CodePage = 65001,
+            FirstDataRow = 1,
+            Contents = Encoding.UTF8.GetBytes(fileContent),
+            HasContent = true,
+            ColumnsToRead = System.Text.Json.JsonSerializer.Serialize(mappings)
+        };
+        Context.ImportFiles.Add(importFile);
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.PeopleAdded);
+        Assert.False(await Context.OnlineVoters.AnyAsync(ov => ov.VoterIdType == "P"));
+        Assert.False(await Context.OnlineVoters.AnyAsync());
+    }
+
+    [Fact]
+    public async Task ImportPeopleAsync_ExistingPhoneOnlineVoter_DoesNotDuplicateOrWipeFields()
+    {
+        const string phone = "+14168972671";
+        var registered = DateTimeOffset.Parse("2026-05-01T00:00:00Z");
+        var lastLogin = DateTimeOffset.Parse("2026-05-02T00:00:00Z");
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = phone,
+            VoterIdType = "P",
+            SmsStatus = "premium",
+            WhenRegistered = registered,
+            WhenLastLogin = lastLogin
+        });
+        await Context.SaveChangesAsync();
+
+        var electionGuid = Guid.NewGuid();
+        var fileContent = $"FirstName,LastName,Phone\nPat,Smith,{phone}";
+        var mappings = new List<ColumnMappingDto>
+        {
+            new() { FileColumn = "FirstName", TargetField = "FirstName" },
+            new() { FileColumn = "LastName", TargetField = "LastName" },
+            new() { FileColumn = "Phone", TargetField = "Phone" }
+        };
+
+        var importFile = new ImportFile
+        {
+            ElectionGuid = electionGuid,
+            FileType = "csv",
+            CodePage = 65001,
+            FirstDataRow = 1,
+            Contents = Encoding.UTF8.GetBytes(fileContent),
+            HasContent = true,
+            ColumnsToRead = System.Text.Json.JsonSerializer.Serialize(mappings)
+        };
+        Context.ImportFiles.Add(importFile);
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
+
+        Assert.True(result.Success);
+        var row = Assert.Single(await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync());
+        Assert.Equal("premium", row.SmsStatus);
+        Assert.Equal(registered, row.WhenRegistered);
+        Assert.Equal(lastLogin, row.WhenLastLogin);
+    }
+
+    [Fact]
     public async Task ImportPeopleAsync_XlsxHeadersOnRow6_ReportsExcelRowNumbers()
     {
         var electionGuid = Guid.NewGuid();

--- a/Backend.Tests/UnitTests/Services/PeopleServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleServiceTests.cs
@@ -699,6 +699,168 @@ public class PeopleServiceTests : ServiceTestBase
         Assert.StartsWith("N", details.KioskCode);
         Assert.True(details.CanDelete);
     }
+
+    [Fact]
+    public async Task CreatePersonAsync_WithPhone_CreatesOnlineVoterPhoneRow_WhenRegisteredNull()
+    {
+        const string phone = "+14168972671";
+        var result = await _service.CreatePersonAsync(new CreatePersonDto
+        {
+            ElectionGuid = Guid.NewGuid(),
+            LastName = "Smith",
+            FirstName = "Pat",
+            Phone = phone
+        });
+
+        Assert.NotNull(result);
+        var rows = await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync();
+        var row = Assert.Single(rows);
+        Assert.Equal("P", row.VoterIdType);
+        Assert.Null(row.WhenRegistered);
+        Assert.Null(row.WhenLastLogin);
+        Assert.Null(row.SmsStatus);
+    }
+
+    [Fact]
+    public async Task CreatePersonAsync_WithoutPhone_DoesNotCreatePhoneOnlineVoter()
+    {
+        var before = await Context.OnlineVoters.CountAsync();
+        await _service.CreatePersonAsync(new CreatePersonDto
+        {
+            ElectionGuid = Guid.NewGuid(),
+            LastName = "Smith",
+            FirstName = "Pat",
+            Email = "pat@example.com"
+        });
+
+        Assert.Equal(before, await Context.OnlineVoters.CountAsync());
+        Assert.False(await Context.OnlineVoters.AnyAsync(ov => ov.VoterIdType == "P"));
+    }
+
+    [Fact]
+    public async Task CreatePersonAsync_ExistingPhoneOnlineVoter_DoesNotDuplicateOrWipeFields()
+    {
+        const string phone = "+14168972671";
+        var registered = DateTimeOffset.Parse("2026-01-15T12:00:00Z");
+        var lastLogin = DateTimeOffset.Parse("2026-02-01T08:30:00Z");
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = phone,
+            VoterIdType = "P",
+            SmsStatus = "undeliverable",
+            WhenRegistered = registered,
+            WhenLastLogin = lastLogin
+        });
+        await Context.SaveChangesAsync();
+
+        await _service.CreatePersonAsync(new CreatePersonDto
+        {
+            ElectionGuid = Guid.NewGuid(),
+            LastName = "Smith",
+            FirstName = "Pat",
+            Phone = phone
+        });
+
+        var rows = await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync();
+        var row = Assert.Single(rows);
+        Assert.Equal("P", row.VoterIdType);
+        Assert.Equal("undeliverable", row.SmsStatus);
+        Assert.Equal(registered, row.WhenRegistered);
+        Assert.Equal(lastLogin, row.WhenLastLogin);
+    }
+
+    [Fact]
+    public async Task UpdatePersonAsync_AddingPhone_CreatesOnlineVoterPhoneRow_WhenRegisteredNull()
+    {
+        const string phone = "+14168972672";
+        var person = new Person
+        {
+            PersonGuid = Guid.NewGuid(),
+            ElectionGuid = Guid.NewGuid(),
+            LastName = "Smith",
+            FirstName = "Pat",
+            RowVersion = new byte[8]
+        };
+        Context.People.Add(person);
+        await Context.SaveChangesAsync();
+
+        await _service.UpdatePersonAsync(person.PersonGuid, new UpdatePersonDto
+        {
+            LastName = "Smith",
+            FirstName = "Pat",
+            Phone = phone
+        });
+
+        var row = Assert.Single(await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync());
+        Assert.Equal("P", row.VoterIdType);
+        Assert.Null(row.WhenRegistered);
+        Assert.Null(row.WhenLastLogin);
+        Assert.Null(row.SmsStatus);
+    }
+
+    [Fact]
+    public async Task UpdatePersonAsync_ExistingPhoneOnlineVoter_DoesNotDuplicateOrWipeFields()
+    {
+        const string phone = "+14168972673";
+        var registered = DateTimeOffset.Parse("2026-03-01T00:00:00Z");
+        var lastLogin = DateTimeOffset.Parse("2026-03-02T00:00:00Z");
+        var person = new Person
+        {
+            PersonGuid = Guid.NewGuid(),
+            ElectionGuid = Guid.NewGuid(),
+            LastName = "Smith",
+            FirstName = "Pat",
+            Phone = phone,
+            RowVersion = new byte[8]
+        };
+        Context.People.Add(person);
+        Context.OnlineVoters.Add(new OnlineVoter
+        {
+            VoterId = phone,
+            VoterIdType = "P",
+            SmsStatus = "OK",
+            WhenRegistered = registered,
+            WhenLastLogin = lastLogin
+        });
+        await Context.SaveChangesAsync();
+
+        await _service.UpdatePersonAsync(person.PersonGuid, new UpdatePersonDto
+        {
+            LastName = "Smith",
+            FirstName = "Pat",
+            Phone = phone
+        });
+
+        var row = Assert.Single(await Context.OnlineVoters.Where(ov => ov.VoterId == phone).ToListAsync());
+        Assert.Equal("OK", row.SmsStatus);
+        Assert.Equal(registered, row.WhenRegistered);
+        Assert.Equal(lastLogin, row.WhenLastLogin);
+    }
+
+    [Fact]
+    public async Task UpdatePersonAsync_WithoutPhone_DoesNotCreatePhoneOnlineVoter()
+    {
+        var person = new Person
+        {
+            PersonGuid = Guid.NewGuid(),
+            ElectionGuid = Guid.NewGuid(),
+            LastName = "Smith",
+            FirstName = "Pat",
+            Email = "pat@example.com",
+            RowVersion = new byte[8]
+        };
+        Context.People.Add(person);
+        await Context.SaveChangesAsync();
+
+        await _service.UpdatePersonAsync(person.PersonGuid, new UpdatePersonDto
+        {
+            LastName = "Smith",
+            FirstName = "Pat",
+            Email = "pat@example.com"
+        });
+
+        Assert.False(await Context.OnlineVoters.AnyAsync(ov => ov.VoterIdType == "P"));
+    }
 }
 
 

--- a/backend/EF/Data/DbSeeder.cs
+++ b/backend/EF/Data/DbSeeder.cs
@@ -1,4 +1,5 @@
 using Backend.Context;
+using Backend.Helpers;
 using Backend.Identity;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -31,6 +32,7 @@ public static partial class DbSeeder
             logger.LogInformation("Database already seeded");
             await SeedElection1OnlineVotingAsync(context, logger);
             await SeedOnlineVotingTestElectionsAsync(context, logger);
+            await EnsureOnlineVotersForSeededPhonesAsync(context);
             await context.SaveChangesAsync();
             return;
         }
@@ -43,8 +45,22 @@ public static partial class DbSeeder
         await SeedElection2Async(context, userManager, logger);
         await SeedOnlineVotingTestElectionsAsync(context, logger);
         await SeedLogsAsync(context, logger);
+        await EnsureOnlineVotersForSeededPhonesAsync(context);
 
         await context.SaveChangesAsync();
         logger.LogInformation("Database seeding complete");
+    }
+
+    /// <summary>
+    /// Seed people may have phones without going through PeopleService. Ensure a global
+    /// phone OnlineVoter row so a local SeedOnStartup database is usable for SMS-status work.
+    /// </summary>
+    private static async Task EnsureOnlineVotersForSeededPhonesAsync(MainDbContext context)
+    {
+        var persistedPhones = await context.People
+            .Select(p => p.Phone)
+            .ToListAsync();
+        var phones = context.People.Local.Select(p => p.Phone).Concat(persistedPhones);
+        await OnlineVoterPhoneHelper.EnsureOnlineVotersForPhonesAsync(context, phones);
     }
 }

--- a/backend/Helpers/OnlineVoterPhoneHelper.cs
+++ b/backend/Helpers/OnlineVoterPhoneHelper.cs
@@ -1,0 +1,83 @@
+using Backend.Context;
+using Backend.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Helpers;
+
+/// <summary>
+/// Ensures a global phone <see cref="OnlineVoter"/> row exists when a Person phone is written.
+/// Does not record registration or login — those stay null until real auth use.
+/// </summary>
+public static class OnlineVoterPhoneHelper
+{
+    /// <summary>
+    /// <see cref="OnlineVoter.VoterIdType"/> for a phone identifier (E.164 as stored on Person).
+    /// </summary>
+    public const string PhoneVoterIdType = "P";
+
+    /// <summary>
+    /// If <paramref name="phone"/> is non-whitespace, add an <see cref="OnlineVoter"/> row
+    /// with <see cref="PhoneVoterIdType"/> when none exists for that <see cref="OnlineVoter.VoterId"/>.
+    /// Does not call <see cref="DbContext.SaveChangesAsync(CancellationToken)"/>.
+    /// Does not change <see cref="OnlineVoter.WhenRegistered"/>, <see cref="OnlineVoter.WhenLastLogin"/>,
+    /// or <see cref="OnlineVoter.SmsStatus"/> on an existing row.
+    /// </summary>
+    public static Task EnsureOnlineVoterForPhoneAsync(
+        MainDbContext context,
+        string? phone,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        return EnsureOnlineVotersForPhonesAsync(context, [phone], cancellationToken);
+    }
+
+    /// <summary>
+    /// Same as <see cref="EnsureOnlineVoterForPhoneAsync"/> for each distinct non-whitespace phone.
+    /// Used by people import so one lookup covers a batch.
+    /// </summary>
+    public static async Task EnsureOnlineVotersForPhonesAsync(
+        MainDbContext context,
+        IEnumerable<string?> phones,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(phones);
+
+        var distinctPhones = phones
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => p!)
+            .Distinct()
+            .ToList();
+
+        if (distinctPhones.Count == 0)
+        {
+            return;
+        }
+
+        var alreadyHave = await context.OnlineVoters
+            .Where(ov => distinctPhones.Contains(ov.VoterId))
+            .Select(ov => ov.VoterId)
+            .ToListAsync(cancellationToken);
+
+        var have = new HashSet<string>(alreadyHave, StringComparer.Ordinal);
+        foreach (var local in context.OnlineVoters.Local)
+        {
+            have.Add(local.VoterId);
+        }
+
+        foreach (var phone in distinctPhones)
+        {
+            if (!have.Add(phone))
+            {
+                continue;
+            }
+
+            context.OnlineVoters.Add(new OnlineVoter
+            {
+                VoterId = phone,
+                VoterIdType = PhoneVoterIdType,
+                WhenRegistered = null
+            });
+        }
+    }
+}

--- a/backend/Helpers/OnlineVoterPhoneHelper.cs
+++ b/backend/Helpers/OnlineVoterPhoneHelper.cs
@@ -11,13 +11,17 @@ namespace Backend.Helpers;
 public static class OnlineVoterPhoneHelper
 {
     /// <summary>
-    /// <see cref="OnlineVoter.VoterIdType"/> for a phone identifier (E.164 as stored on Person).
+    /// <see cref="OnlineVoter.VoterIdType"/> for a phone identifier (phone string as stored on Person).
     /// </summary>
     public const string PhoneVoterIdType = "P";
 
     /// <summary>
     /// If <paramref name="phone"/> is non-whitespace, add an <see cref="OnlineVoter"/> row
-    /// with <see cref="PhoneVoterIdType"/> when none exists for that <see cref="OnlineVoter.VoterId"/>.
+    /// with <see cref="PhoneVoterIdType"/> when no row exists for that <see cref="OnlineVoter.VoterId"/>.
+    /// Lookup is by <see cref="OnlineVoter.VoterId"/> only: <c>IX_OnlineVoter_Id</c> is unique on
+    /// that column, so a second row cannot be inserted if any type already owns the string.
+    /// If the existing row is not <see cref="PhoneVoterIdType"/>, it is left unchanged
+    /// (no convert, no wipe, no second row).
     /// Does not call <see cref="DbContext.SaveChangesAsync(CancellationToken)"/>.
     /// Does not change <see cref="OnlineVoter.WhenRegistered"/>, <see cref="OnlineVoter.WhenLastLogin"/>,
     /// or <see cref="OnlineVoter.SmsStatus"/> on an existing row.

--- a/backend/Services/OnlineVotingService.Auth.Code.cs
+++ b/backend/Services/OnlineVotingService.Auth.Code.cs
@@ -103,6 +103,13 @@ public partial class OnlineVotingService
                 }
             }
 
+            // Person create/import may have inserted the phone row with WhenRegistered null.
+            // First successful code request is the first auth use — stamp it then, never earlier.
+            if (onlineVoter.WhenRegistered == null)
+            {
+                onlineVoter.WhenRegistered = DateTimeOffset.UtcNow;
+            }
+
             var verifyCode = GenerateVerificationCode();
 
             onlineVoter.VerifyCode = verifyCode;

--- a/backend/Services/PeopleImportService.Import.cs
+++ b/backend/Services/PeopleImportService.Import.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Backend.Entities;
 using Backend.Enumerations;
 using Backend.DTOs.Import;
+using Backend.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Services;
@@ -159,6 +160,9 @@ public partial class PeopleImportService
                 // Save batch
                 if (!errorsFound && (peopleToAdd.Count >= batchSize || i == dataRows.Count - 1))
                 {
+                    await OnlineVoterPhoneHelper.EnsureOnlineVotersForPhonesAsync(
+                        _context,
+                        peopleToAdd.Select(p => p.Phone));
                     _context.People.AddRange(peopleToAdd);
                     try
                     {

--- a/backend/Services/PeopleService.cs
+++ b/backend/Services/PeopleService.cs
@@ -143,6 +143,7 @@ public class PeopleService : IPeopleService
         SyncEligibility(person);
 
         _context.People.Add(person);
+        await OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync(_context, person.Phone);
         await _context.SaveChangesAsync();
 
         _logger.LogInformation("Created person {PersonGuid} - {FullName}", person.PersonGuid, person.FullName);
@@ -214,6 +215,7 @@ public class PeopleService : IPeopleService
             await VoteStatusRefresher.RefreshVotesForPersonAsync(_context, person, _logger);
         }
 
+        await OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync(_context, person.Phone);
         await _context.SaveChangesAsync();
 
         _logger.LogInformation("Updated person {PersonGuid}", personGuid);

--- a/context/index.md
+++ b/context/index.md
@@ -12,4 +12,4 @@ Lean index of project *why* knowledge. Load a topic file only when the work touc
 - [online-ballots.md](online-ballots.md) — online acceptance and random name resolution
 - [people.md](people.md) — person fields; AgeGroup removed (eligibility is V01/X05)
 - [people-import.md](people-import.md) — three-action import pipeline (not a Next/Previous wizard)
-- [sms-eligibility.md](sms-eligibility.md) — reject reserved/fictional/malformed phones before paid SMS/voice/WhatsApp
+- [sms-eligibility.md](sms-eligibility.md) — reject reserved/fictional/malformed phones before paid SMS/voice/WhatsApp; OnlineVoter.SmsStatus; ensure phone row on Person write

--- a/context/sms-eligibility.md
+++ b/context/sms-eligibility.md
@@ -5,7 +5,7 @@
 ## Evidence: confirmed
 
 **Source:** issue #254 (maintainer); July 555-range send incident described there  
-**Revisit when:** later #254 slices land (Person UI, EnsureOnlineVoterForPhoneAsync, Twilio callback auto-learn), or NANP reserved-range rules change
+**Revisit when:** later #254 slices land (Person UI, Twilio callback auto-learn), or NANP reserved-range rules change
 
 ## In-code gate before any paid provider
 
@@ -58,7 +58,30 @@ Skip logs method + status only (no raw phone or email). Voter-facing message reu
 
 **Rejected alternative:** persist the in-code `PaidDestinationPhone` reason onto an existing `OnlineVoter` row when the format gate rejects. Useful only when a row already exists; creating a row here would pull in `EnsureOnlineVoterForPhoneAsync` (later slice). Not done.
 
-**Not in this slice:** Person UI / Front Desk display, `EnsureOnlineVoterForPhoneAsync` on Person create/import/update, Twilio status-callback auto-learn, WhatsAppStatus / GreenAPI `checkWhatsapp` (#255).
+**Not in this slice (at the time):** Person UI / Front Desk display, `EnsureOnlineVoterForPhoneAsync` on Person create/import/update, Twilio status-callback auto-learn, WhatsAppStatus / GreenAPI `checkWhatsapp` (#255).
+
+## Ensure phone `OnlineVoter` on Person write (third slice)
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #254 (maintainer)  
+**Revisit when:** Person UI or Twilio auto-learn lands, or email/kiosk rows need the same ensure
+
+`OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync` (and the batch `EnsureOnlineVotersForPhonesAsync` for import) inserts a `VoterIdType = "P"` row keyed by `VoterId` = the phone as stored on `Person`. Callers: `PeopleService` create/update, `PeopleImportService` load batches, and `DbSeeder` so SeedOnStartup phones are usable locally.
+
+`WhenRegistered`, `WhenLastLogin`, and `SmsStatus` stay null on insert. An existing row is left untouched (no duplicate, no field wipe). Whitespace-only / missing phone does nothing. Email / kiosk / Telegram rows are not created here.
+
+`WhenRegistered` is stamped in `RequestVerificationCodeAsync` only after the voter passes the open-election registration check, and only when it is still null. That is the first successful code request — the same moment a brand-new row used to get `WhenRegistered`. Person write must not set it.
+
+`VoterId` is the Person phone string as stored. `PaidDestinationPhone` does not return a normalized E.164 form, and auth still matches `Person.Phone == dto.VoterId`. This helper does not rewrite Person phones.
+
+**Rejected alternative:** also hook JSON / v2 election-package person import. Those copy an existing election; the issue names Person create / people import / update. Package load can call the same helper later if Person UI needs rows for packaged phones.
+
+**Rejected alternative:** put the helper on `OnlineVotingService`. People write paths should not take a voting-auth dependency just to insert a global phone row.
+
+**Rejected alternative:** set `WhenRegistered` when the Person phone is saved. That would mark import/edit as registration and break “never seen vs imported-only” for the Person UI slice.
+
+**Not in this slice:** Person UI / Front Desk SMS-status display, Twilio status-callback auto-learn, WhatsAppStatus / GreenAPI `checkWhatsapp` (#255).
 
 ## Related
 

--- a/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
+++ b/docs/VOTER_AUTHENTICATION_IMPLEMENTATION.md
@@ -195,7 +195,7 @@ POST /api/online-voting/{electionGuid}/submitBallot
    - Election discovery endpoint
 
 4. **Database**
-   - `OnlineVoter` - Tracks verification codes and attempts; for phone rows, `SmsStatus` is the global paid-channel eligibility (null = unchecked, `"OK"` = allowed, any other short value = blocked)
+   - `OnlineVoter` - Tracks verification codes and attempts; for phone rows, `SmsStatus` is the global paid-channel eligibility (null = unchecked, `"OK"` = allowed, any other short value = blocked). Person create / people import / update with a phone ensures a `VoterIdType` `"P"` row (`VoterId` = the Person phone). `WhenRegistered` stays null until the first successful code request.
    - `Person` - Voter registration in elections
    - `Election` - Election configuration and open/close times
 


### PR DESCRIPTION
Next contained slice of #254: ensure a global phone `OnlineVoter` row when a Person phone is written.

Related: #254 (issue stays open). Person UI and Twilio auto-learn remain.

## What this slice does

- Adds `OnlineVoterPhoneHelper.EnsureOnlineVoterForPhoneAsync(phone)` (plus a batch overload for people import).
- Calls it from Person **create**, **update** (`PeopleService`), and **people import** (`PeopleImportService`).
- `DbSeeder` uses the same helper so SeedOnStartup phones get a usable local row.
- Key remains `VoterId` (Person phone as stored) with `VoterIdType = "P"`.
- `WhenRegistered` stays null on insert; first successful code request stamps it if still null (same moment a brand-new row already did).
- `WhenLastLogin` is not set by this helper.
- Existing `SmsStatus` / `WhenRegistered` / `WhenLastLogin` on an existing row are not wiped; no duplicate row.
- No-phone / whitespace-only Person does not create a phone `OnlineVoter`.
- Email / kiosk / Telegram rows are out of scope.
- Paid-send `SmsStatus` gate and 555/E.164 validators are unchanged.

## Still open on #254 (not this PR)

- Person UI (show SMS status for a phone)
- Twilio auto-learn from status callbacks

## Tests

Person create / update / import with a phone creates the `P` row; `WhenRegistered` stays null; existing row is not duplicated; no-phone person does not create a phone `OnlineVoter`; existing `SmsStatus` / `WhenRegistered` / `WhenLastLogin` are preserved.
