### PR TITLE
Show a persistent Test Election banner on teller pages

### DIFF
--- a/context/index.md
+++ b/context/index.md
@@ -13,4 +13,4 @@ Lean index of project *why* knowledge. Load a topic file only when the work touc
 - [people.md](people.md) — person fields; AgeGroup removed (eligibility is V01/X05)
 - [people-import.md](people-import.md) — three-action import pipeline (not a Next/Previous wizard)
 - [sms-eligibility.md](sms-eligibility.md) — reject reserved/fictional/malformed phones before paid SMS/voice/WhatsApp; OnlineVoter.SmsStatus; ensure phone row on Person write; person detail phone status; Twilio callback auto-learn
-- [test-elections.md](test-elections.md) — duplicate as test copy (`ShowAsTest`); people/locations/settings only; banner/reset later
+- [test-elections.md](test-elections.md) — duplicate as test copy (`ShowAsTest`); people/locations/settings only; teller test banner; reset later

--- a/context/test-elections.md
+++ b/context/test-elections.md
@@ -5,7 +5,7 @@
 **Status:** active  
 **Evidence:** confirmed (issue #193 first slice)  
 **Source:** issue #193; v4 `CreateElectionAsync` / `JoinElectionUser` ownership; v3 `ElectionHelper.Copy` (commented; guest tellers denied; SQL `CloneElection`)  
-**Revisit when:** banner or test-only reset slices land, or copy scope needs ballots
+**Revisit when:** test-only reset slice lands, or copy scope needs ballots
 
 `POST /api/Elections/{guid}/duplicateElection` creates a new election from one the caller already owns. The copy gets a new `ElectionGuid`, `ShowAsTest = true`, stage `SettingUp`, and the same ownership row create uses (`JoinElectionUser` Role `Admin`). People and locations are copied with new GUIDs. Person phones go through `EnsureOnlineVotersForPhonesAsync` (same helper as person create/import). Ballots, results, computers, tellers, online votes (`OnlineVotingInfo`), SMS logs, and analysis rows are not copied. Check-in / envelope / teller-name / `HasOnlineBallot` fields on people are cleared. Teller access (`ListedForPublicAsOf`) starts closed. The online window starts closed: `OnlineWhenOpen` / `OnlineWhenClose` are cleared and `UseOnlineVoting` is false. `GetAvailableElectionsAsync` does not filter `ShowAsTest` and treats `UseOnlineVoting` plus a null window as open, so leaving those copied would list the test copy to the same phone/email/kiosk voters. A teller can turn online voting back on and set a window.
 
@@ -13,11 +13,28 @@
 
 **Rejected alternative:** `[Authorize]` only (same as create) or `ElectionAccess`. Create has no source election; duplicate does. `ElectionAccess` would let guest tellers copy. `FullTellerAccess` plus a service-side Owner/Admin join check matches “owner can duplicate their election” and v3’s guest-teller deny. SuperAdmin / global Admin is not given a bypass they do not already have on this route.
 
-**Rejected alternative:** add a new `IsTest` column. `Election.ShowAsTest` already exists (dashboard TEST badge, create/update DTOs, v3 `IsTest`). The later banner/reset slices hang on this flag.
+**Rejected alternative:** add a new `IsTest` column. `Election.ShowAsTest` already exists (dashboard TEST badge, create/update DTOs, teller banner, v3 `IsTest`). The later reset slice hangs on this flag.
 
 **Rejected alternative:** copy `UseOnlineVoting` and only null the window dates. Availability treats a null window as already open when `UseOnlineVoting` is true, so the copy would still appear to voters.
 
-Banner UI and “reset only if Test” are later slices of #193.
+“Reset only if Test” is a later slice of #193.
+
+## Teller pages show a persistent Test Election banner
+
+**Status:** active  
+**Evidence:** confirmed (issue #193 second slice)  
+**Source:** issue #193  
+**Revisit when:** test-only reset lands, or voter-facing chrome is added
+
+While a teller is on an election-scoped route (`/elections/:id/…`) whose `currentElection.showAsTest` is true, MainLayout shows a full-width “Test Election” strip between the fixed header and main content. It reads the existing `Election.ShowAsTest` / `showAsTest` field — no new column. Hidden when there is no current election, `showAsTest` is false or null, or the route has no election id (Dashboard, Profile, create). Leftover `currentElection` after leaving a test election does not keep the banner up. Voter pages use PublicLayout and do not get this chrome.
+
+Colors are an explicit pair (white on `--color-error-700`), not inherited header text/background. The translucent public header and dark Front Desk toolbar already produced a dark-on-dark miss on the dashboard icon-only Copy control.
+
+**Rejected alternative:** a chip inside `AppHeader` only. The header is a fixed 60px bar (48px on Front Desk). A strip there is clipped, and the bar is already crowded with status controls.
+
+**Rejected alternative:** page-local banners on `ElectionDetailPage`. Tellers also work Front Desk, ballots, people, setup, and results; a detail-only mark is easy to leave.
+
+**Rejected alternative:** show whenever `currentElection.showAsTest` is true, ignoring the route. `currentElection` stays set after returning to the dashboard, so the banner would appear on pages that are not “inside” that election.
 
 ## Default copy name
 

--- a/context/test-elections.md
+++ b/context/test-elections.md
@@ -28,7 +28,11 @@
 
 While a teller is on an election-scoped route (`/elections/:id/…`) whose `currentElection.showAsTest` is true, MainLayout shows a full-width “Test Election” strip between the fixed header and main content. It reads the existing `Election.ShowAsTest` / `showAsTest` field — no new column. Hidden when there is no current election, `showAsTest` is false or null, or the route has no election id (Dashboard, Profile, create). Leftover `currentElection` after leaving a test election does not keep the banner up. Voter pages use PublicLayout and do not get this chrome.
 
-Colors are an explicit pair (white on `--color-error-700`), not inherited header text/background. The translucent public header and dark Front Desk toolbar already produced a dark-on-dark miss on the dashboard icon-only Copy control.
+Colors are an explicit pair (white on `--color-stage-gather`, the same burnt orange as the selected Gathering Ballots mode chip), not inherited header text/background. The strip always uses that token — it is a test-election marker, not a stage indicator. Error/danger red was too attention-getting; being in a test election is not a bad thing. The translucent public header and dark Front Desk toolbar already produced a dark-on-dark miss on the dashboard icon-only Copy control.
+
+**Rejected alternative:** `--color-error-700` (white on dark red). UAT: too attention-getting; test is not an error.
+
+**Rejected alternative:** follow `STAGE_META` for the current election stage. That would make the banner look like another stage chip and change color as the election advances.
 
 **Rejected alternative:** a chip inside `AppHeader` only. The header is a fixed 60px bar (48px on Front Desk). A strip there is clipped, and the bar is already crowded with status controls.
 

--- a/context/test-elections.md
+++ b/context/test-elections.md
@@ -22,8 +22,8 @@
 ## Teller pages show a persistent Test Election banner
 
 **Status:** active  
-**Evidence:** confirmed (issue #193 second slice)  
-**Source:** issue #193  
+**Evidence:** confirmed (issue #193 second slice; UAT: gather orange, not error red)  
+**Source:** issue #193; PR #284 UAT  
 **Revisit when:** test-only reset lands, or voter-facing chrome is added
 
 While a teller is on an election-scoped route (`/elections/:id/…`) whose `currentElection.showAsTest` is true, MainLayout shows a full-width “Test Election” strip between the fixed header and main content. It reads the existing `Election.ShowAsTest` / `showAsTest` field — no new column. Hidden when there is no current election, `showAsTest` is false or null, or the route has no election id (Dashboard, Profile, create). Leftover `currentElection` after leaving a test election does not keep the banner up. Voter pages use PublicLayout and do not get this chrome.

--- a/frontend/src/components/common/TestElectionBanner.test.ts
+++ b/frontend/src/components/common/TestElectionBanner.test.ts
@@ -1,0 +1,150 @@
+import { createTestingPinia } from "@pinia/testing";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { createRouter, createWebHistory } from "vue-router";
+import { useElectionStore } from "@/stores/electionStore";
+import type { ElectionDto } from "@/types";
+import { i18n } from "@/test/setup";
+import TestElectionBanner from "./TestElectionBanner.vue";
+
+const TEST_GUID = "election-test-guid";
+
+function testElection(overrides: Partial<ElectionDto> = {}): ElectionDto {
+  return {
+    electionGuid: TEST_GUID,
+    name: "Copy of Live Election",
+    electionStage: "SettingUp",
+    showAsTest: true,
+    ...overrides,
+  };
+}
+
+async function mountBanner(options: {
+  path: string;
+  currentElection: ElectionDto | null;
+}) {
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      {
+        path: "/dashboard",
+        name: "Dashboard",
+        component: { template: "<div />" },
+      },
+      {
+        path: "/profile",
+        name: "Profile",
+        component: { template: "<div />" },
+      },
+      {
+        path: "/elections/:id/frontdesk",
+        name: "FrontDesk",
+        component: { template: "<div />" },
+      },
+      {
+        path: "/elections/:id",
+        name: "Election",
+        component: { template: "<div />" },
+      },
+    ],
+  });
+
+  await router.push(options.path);
+  await router.isReady();
+
+  const pinia = createTestingPinia({ stubActions: true });
+  const electionStore = useElectionStore();
+  electionStore.currentElection = options.currentElection;
+
+  return mount(TestElectionBanner, {
+    global: {
+      plugins: [pinia, router, i18n],
+      stubs: {
+        ElIcon: { template: "<span class='el-icon-stub'><slot /></span>" },
+        WarningFilled: { template: "<span />" },
+      },
+    },
+  });
+}
+
+describe("TestElectionBanner", () => {
+  it("shows the Test Election banner when the current election has showAsTest true", async () => {
+    const wrapper = await mountBanner({
+      path: `/elections/${TEST_GUID}/frontdesk`,
+      currentElection: testElection({ showAsTest: true }),
+    });
+
+    const banner = wrapper.find("[data-testid='test-election-banner']");
+    expect(banner.exists()).toBe(true);
+    expect(banner.text()).toContain("Test Election");
+  });
+
+  it("hides the banner when showAsTest is false", async () => {
+    const wrapper = await mountBanner({
+      path: `/elections/${TEST_GUID}/frontdesk`,
+      currentElection: testElection({ showAsTest: false }),
+    });
+
+    expect(wrapper.find("[data-testid='test-election-banner']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("hides the banner when showAsTest is null", async () => {
+    const wrapper = await mountBanner({
+      path: `/elections/${TEST_GUID}`,
+      currentElection: {
+        ...testElection(),
+        showAsTest: null,
+      } as ElectionDto,
+    });
+
+    expect(wrapper.find("[data-testid='test-election-banner']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("hides the banner when showAsTest is omitted", async () => {
+    const wrapper = await mountBanner({
+      path: `/elections/${TEST_GUID}`,
+      currentElection: testElection({ showAsTest: undefined }),
+    });
+
+    expect(wrapper.find("[data-testid='test-election-banner']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("hides the banner when there is no current election", async () => {
+    const wrapper = await mountBanner({
+      path: `/elections/${TEST_GUID}/frontdesk`,
+      currentElection: null,
+    });
+
+    expect(wrapper.find("[data-testid='test-election-banner']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("hides the banner on Dashboard even if leftover currentElection is a test copy", async () => {
+    const wrapper = await mountBanner({
+      path: "/dashboard",
+      currentElection: testElection({ showAsTest: true }),
+    });
+
+    expect(wrapper.find("[data-testid='test-election-banner']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("hides the banner when the route election does not match currentElection", async () => {
+    const wrapper = await mountBanner({
+      path: "/elections/other-guid/frontdesk",
+      currentElection: testElection({ showAsTest: true }),
+    });
+
+    expect(wrapper.find("[data-testid='test-election-banner']").exists()).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/components/common/TestElectionBanner.vue
+++ b/frontend/src/components/common/TestElectionBanner.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { useElectionStore } from "@/stores/electionStore";
+import { WarningFilled } from "@element-plus/icons-vue";
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
+
+const { t } = useI18n();
+const route = useRoute();
+const electionStore = useElectionStore();
+
+const routeElectionGuid = computed(() => {
+  const id = route.params.id;
+  return typeof id === "string" ? id : "";
+});
+
+/**
+ * Persistent teller chrome for the election currently on the route.
+ * Hidden when there is no current election, the route is not election-scoped
+ * (Dashboard, Profile, … — leftover store state does not count), the route
+ * election does not match currentElection, or showAsTest is false/null.
+ */
+const showTestElectionBanner = computed(() => {
+  const current = electionStore.currentElection;
+  if (!routeElectionGuid.value || !current) {
+    return false;
+  }
+  if (current.electionGuid !== routeElectionGuid.value) {
+    return false;
+  }
+  return current.showAsTest === true;
+});
+</script>
+
+<template>
+  <div
+    v-if="showTestElectionBanner"
+    class="test-election-banner"
+    role="status"
+    data-testid="test-election-banner"
+  >
+    <el-icon aria-hidden="true">
+      <WarningFilled />
+    </el-icon>
+    <span>{{ t("elections.testElectionBanner") }}</span>
+  </div>
+</template>
+
+<style lang="less">
+.test-election-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex-shrink: 0;
+  padding: 6px 16px;
+  font-size: var(--el-font-size-small);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.2;
+  text-align: center;
+  /* Explicit pair — do not inherit header text/bg (dark-on-dark on the
+     translucent / Front Desk header). White on error-700 meets contrast
+     in both light (#b91c1c) and dark (#dc2626) tokens. */
+  background-color: var(--color-error-700);
+  color: #fff;
+
+  .el-icon {
+    font-size: 16px;
+    color: #fff;
+  }
+}
+</style>

--- a/frontend/src/components/common/TestElectionBanner.vue
+++ b/frontend/src/components/common/TestElectionBanner.vue
@@ -60,9 +60,11 @@ const showTestElectionBanner = computed(() => {
   line-height: 1.2;
   text-align: center;
   /* Explicit pair — do not inherit header text/bg (dark-on-dark on the
-     translucent / Front Desk header). White on error-700 meets contrast
-     in both light (#b91c1c) and dark (#dc2626) tokens. */
-  background-color: var(--color-error-700);
+     translucent / Front Desk header). Always gather-stage orange, not the
+     current election stage and not error/danger red. White on
+     --color-stage-gather meets contrast in both light (#d97706) and
+     dark (#f59e0b) tokens. */
+  background-color: var(--color-stage-gather);
   color: #fff;
 
   .el-icon {

--- a/frontend/src/layouts/MainLayout.test.ts
+++ b/frontend/src/layouts/MainLayout.test.ts
@@ -1,0 +1,87 @@
+import { createTestingPinia } from "@pinia/testing";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { createRouter, createWebHistory } from "vue-router";
+import { useElectionStore } from "@/stores/electionStore";
+import { i18n } from "@/test/setup";
+import MainLayout from "./MainLayout.vue";
+
+vi.mock("@/composables/useGuestTellerStageRedirect", () => ({
+  useGuestTellerStageRedirect: () => {},
+}));
+
+vi.mock("@/composables/useResponsive", () => ({
+  useResponsive: () => ({ isMobile: { value: false } }),
+}));
+
+const TEST_GUID = "election-test-guid";
+
+const layoutStubs = {
+  AppHeader: { template: "<div class='app-header-stub' />" },
+  AppSidebar: { template: "<div class='app-sidebar-stub' />" },
+  ElContainer: { template: "<div class='el-container'><slot /></div>" },
+  ElAside: { template: "<aside><slot /></aside>" },
+  ElHeader: { template: "<header><slot /></header>" },
+  ElMain: { template: "<main><slot /></main>" },
+  RouterView: { template: "<div class='router-view-stub' />" },
+  ElIcon: { template: "<span><slot /></span>" },
+  WarningFilled: { template: "<span />" },
+};
+
+async function mountLayout(path: string, showAsTest: boolean | null) {
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      {
+        path: "/dashboard",
+        component: { template: "<div />" },
+      },
+      {
+        path: "/elections/:id/frontdesk",
+        component: { template: "<div />" },
+      },
+    ],
+  });
+  await router.push(path);
+  await router.isReady();
+
+  const pinia = createTestingPinia({ stubActions: true });
+  const electionStore = useElectionStore();
+  electionStore.currentElection =
+    showAsTest === null
+      ? null
+      : {
+          electionGuid: TEST_GUID,
+          name: "Copy of Live Election",
+          electionStage: "SettingUp",
+          showAsTest,
+        };
+
+  return mount(MainLayout, {
+    global: {
+      plugins: [pinia, router, i18n],
+      stubs: layoutStubs,
+    },
+  });
+}
+
+describe("MainLayout test-election banner", () => {
+  it("renders the Test Election banner on an election page when showAsTest is true", async () => {
+    const wrapper = await mountLayout(
+      `/elections/${TEST_GUID}/frontdesk`,
+      true,
+    );
+
+    const banner = wrapper.find("[data-testid='test-election-banner']");
+    expect(banner.exists()).toBe(true);
+    expect(banner.text()).toContain("Test Election");
+  });
+
+  it("does not render the banner on Dashboard when leftover currentElection is a test copy", async () => {
+    const wrapper = await mountLayout("/dashboard", true);
+
+    expect(wrapper.find("[data-testid='test-election-banner']").exists()).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -6,6 +6,7 @@ import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import AppHeader from "../components/AppHeader.vue";
 import AppSidebar from "../components/AppSidebar.vue";
+import TestElectionBanner from "../components/common/TestElectionBanner.vue";
 import { useElectionStore } from "../stores/electionStore";
 import { useNavUiStore } from "../stores/navUiStore";
 
@@ -122,7 +123,7 @@ function dockSidebar() {
         @dock-sidebar="dockSidebar"
       />
     </el-aside>
-    <el-container>
+    <el-container direction="vertical">
       <el-header height="60px" role="banner">
         <AppHeader
           :show-menu-button="sidebarOverlayMode"
@@ -130,6 +131,9 @@ function dockSidebar() {
           @toggle-mobile-menu="toggleMobileSidebar"
         />
       </el-header>
+      <!-- Below the fixed-height header (60px / Front Desk 48px) so the
+           strip is not clipped. Hidden unless the route election is a test. -->
+      <TestElectionBanner />
       <el-main id="main-content" role="main" tabindex="-1">
         <router-view />
       </el-main>

--- a/frontend/src/locales/en/elections.json
+++ b/frontend/src/locales/en/elections.json
@@ -198,6 +198,7 @@
   "elections.tabs.tellers": "Tellers",
   "elections.tabs.votingMethods": "Voting Methods",
   "elections.guestTellerAccess": "Guest tellers",
+  "elections.testElectionBanner": "Test Election",
   "elections.tellerAccess": "Teller Access",
   "elections.tellerAccessCode": "Access Code",
   "elections.tellerAccessQrCode": "QR Code of Shareable URL",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the second slice of test-election chrome: when a teller is inside an election with `ShowAsTest` true, they see a persistent “Test Election” banner.

## What the banner is and where it appears
- A full-width “Test Election” strip (`TestElectionBanner`) between the fixed app header and main content
- Rendered from `MainLayout`, so it appears on every election-scoped teller page (Front Desk, ballots, people, setup, results, etc.)
- Driven by `electionStore.currentElection.showAsTest`
- Hidden when there is no current election, `showAsTest` is false or null, or the route is not election-scoped (Dashboard, Profile, create)
- Leftover `currentElection` after leaving a test election does not keep the banner up
- Uses existing `Election.ShowAsTest` / `showAsTest` — no new `IsTest` column
- High-contrast colors: white on `--color-stage-gather` (same burnt orange as the selected Gathering Ballots mode chip; light `#d97706`, dark `#f59e0b`). Always that token — not the current election stage, and not error/danger red (UAT: too attention-getting; test is not a bad thing)
- Voter-facing online voting pages use `PublicLayout` and do not get this chrome

## Tests
- Banner present when the current route election has `showAsTest` true
- Banner absent when `showAsTest` is false/null, there is no current election, or the page is not election-scoped (including leftover store state on Dashboard)
- `MainLayout` mounts the banner on Front Desk when the flag is true

## Out of scope
- Reset election data only if Test (third slice)
- Changing the duplicate API
- Voter-facing online voting chrome

Related: #193 (issue stays open)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8756079f-519a-4b27-875d-afa7ed95387e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8756079f-519a-4b27-875d-afa7ed95387e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

