### PR TITLE
Require main teller before starting a ballot

### DIFF
--- a/frontend/src/components/ballots/BallotEntryPanel.vue
+++ b/frontend/src/components/ballots/BallotEntryPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useNotifications } from "@/composables/useNotifications";
 import { getActiveTellerPayload } from "@/utils/activeTellerStorage";
+import type { BallotStartBlockReason } from "@/utils/ballotStartRequirements";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import InlineBallotEntry, {
@@ -15,6 +16,7 @@ import { formatComputerCodeLabel } from "@/utils/ballotDisplayCode";
 const emit = defineEmits<{
   "ballot-created": [ballotGuid: string];
   "ballot-deleted": [ballotGuid: string];
+  "ballot-start-blocked": [reason: BallotStartBlockReason];
 }>();
 
 const props = withDefaults(
@@ -236,6 +238,7 @@ async function handleVotesReordered(voteRowIds: number[]) {
           @votes-reordered="handleVotesReordered"
           @ballot-created="emit('ballot-created', $event)"
           @ballot-deleted="emit('ballot-deleted', $event)"
+          @ballot-start-blocked="emit('ballot-start-blocked', $event)"
         />
       </div>
     </div>

--- a/frontend/src/components/ballots/InlineBallotEntry.vue
+++ b/frontend/src/components/ballots/InlineBallotEntry.vue
@@ -16,7 +16,15 @@ import {
   formatBallotDisplayCode,
   isOnlineOrImportedComputerCode,
 } from "@/utils/ballotDisplayCode";
-import { getActiveTellerPayload } from "@/utils/activeTellerStorage";
+import {
+  getActiveTellerPayload,
+  getActiveTellers,
+} from "@/utils/activeTellerStorage";
+import {
+  BALLOT_START_BLOCK_MESSAGE_KEY,
+  getBallotStartBlockReason,
+  type BallotStartBlockReason,
+} from "@/utils/ballotStartRequirements";
 import {
   isUnresolvedRawVote,
   nextFindQuery,
@@ -49,6 +57,7 @@ const emit = defineEmits<{
   "ballot-saved": [];
   "ballot-created": [ballotGuid: string];
   "ballot-deleted": [ballotGuid: string];
+  "ballot-start-blocked": [reason: BallotStartBlockReason];
 }>();
 
 const { t } = useI18n();
@@ -324,12 +333,14 @@ async function handleDeleteBallot() {
 }
 
 async function handleNewBallot() {
-  if (!computerCode.value) {
-    showErrorMessage(t("ballots.computerCodeRequired"));
-    return;
-  }
-  if (!locationStore.selectedLocationGuid) {
-    showErrorMessage(t("ballots.locationRequired"));
+  const reason = getBallotStartBlockReason({
+    computerCode: computerCode.value,
+    locationGuid: locationStore.selectedLocationGuid,
+    teller1: getActiveTellers().teller1,
+  });
+  if (reason) {
+    showErrorMessage(t(BALLOT_START_BLOCK_MESSAGE_KEY[reason]));
+    emit("ballot-start-blocked", reason);
     return;
   }
   creatingNewBallot.value = true;

--- a/frontend/src/components/ballots/__tests__/InlineBallotEntry.spec.ts
+++ b/frontend/src/components/ballots/__tests__/InlineBallotEntry.spec.ts
@@ -45,7 +45,8 @@ const mockT = (key: string, values?: Record<string, string | number>) => {
     "common.warning": "Warning",
     "common.cancel": "Cancel",
     "ballots.computerCodeRequired": "Computer code required",
-    "ballots.locationRequired": "Location required",
+    "ballots.locationRequired": "Location is required",
+    "ballots.tellerRequired": "Teller is required",
     "ballots.markNeedsReview": "Mark as Needs Review",
     "ballots.clearNeedsReview": "Clear Needs Review",
     "ballots.needsReviewUpdated": "Needs Review status updated",
@@ -73,11 +74,18 @@ vi.mock("vue-i18n", () => ({
   }),
 }));
 
+const { mockShowErrorMessage, mockShowWarningMessage, mockShowSuccessMessage } =
+  vi.hoisted(() => ({
+    mockShowErrorMessage: vi.fn(),
+    mockShowWarningMessage: vi.fn(),
+    mockShowSuccessMessage: vi.fn(),
+  }));
+
 vi.mock("@/composables/useNotifications", () => ({
   useNotifications: () => ({
-    showWarningMessage: vi.fn(),
-    showErrorMessage: vi.fn(),
-    showSuccessMessage: vi.fn(),
+    showWarningMessage: mockShowWarningMessage,
+    showErrorMessage: mockShowErrorMessage,
+    showSuccessMessage: mockShowSuccessMessage,
     showInfoMessage: vi.fn(),
   }),
 }));
@@ -123,10 +131,14 @@ vi.mock("@/composables/useComputerCode", () => ({
   }),
 }));
 
+const { mockLocationStore } = vi.hoisted(() => ({
+  mockLocationStore: {
+    selectedLocationGuid: "location-1" as string | null,
+  },
+}));
+
 vi.mock("@/stores/locationStore", () => ({
-  useLocationStore: () => ({
-    selectedLocationGuid: "location-1",
-  }),
+  useLocationStore: () => mockLocationStore,
 }));
 
 vi.mock("@/composables/useApiErrorHandler", () => ({
@@ -135,11 +147,19 @@ vi.mock("@/composables/useApiErrorHandler", () => ({
   }),
 }));
 
-vi.mock("@/utils/activeTellerStorage", () => ({
-  getActiveTellerPayload: () => ({
+const { mockActiveTellers } = vi.hoisted(() => ({
+  mockActiveTellers: {
     teller1: "Alice",
     teller2: "Bob",
+  },
+}));
+
+vi.mock("@/utils/activeTellerStorage", () => ({
+  getActiveTellerPayload: () => ({
+    teller1: mockActiveTellers.teller1 || undefined,
+    teller2: mockActiveTellers.teller2 || undefined,
   }),
+  getActiveTellers: () => ({ ...mockActiveTellers }),
 }));
 
 vi.mock("@/composables/usePersonSearch", async () => {
@@ -219,6 +239,9 @@ describe("InlineBallotEntry", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLocationStore.selectedLocationGuid = "location-1";
+    mockActiveTellers.teller1 = "Alice";
+    mockActiveTellers.teller2 = "Bob";
     mockSearchablePeople = [
       createMockPerson("John", "Doe"),
       createMockPerson("Jane", "Smith"),
@@ -279,6 +302,57 @@ describe("InlineBallotEntry", () => {
       teller2: "Bob",
     });
     expect(wrapper.emitted("ballot-created")?.[0]).toEqual(["ballot-new"]);
+  });
+
+  it("does not start another ballot when location is unset", async () => {
+    mockLocationStore.selectedLocationGuid = null;
+
+    const wrapper = mount(InlineBallotEntry, {
+      props: {
+        electionGuid: "election-123",
+        ballot: createMockBallot(),
+        requiredVotes: 9,
+      },
+      ...mountOptions,
+    });
+
+    await flushPromises();
+
+    const addBallotButton = wrapper
+      .findAllComponents(ElButton)
+      .find((button) => button.text().includes("Start another ballot"));
+    await addBallotButton!.trigger("click");
+    await flushPromises();
+
+    expect(mockCreateBallot).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).toHaveBeenCalledWith("Location is required");
+    expect(wrapper.emitted("ballot-start-blocked")?.[0]).toEqual(["location"]);
+  });
+
+  it("does not start another ballot when the main teller is unset", async () => {
+    mockActiveTellers.teller1 = "";
+
+    const wrapper = mount(InlineBallotEntry, {
+      props: {
+        electionGuid: "election-123",
+        ballot: createMockBallot(),
+        requiredVotes: 9,
+        hasKeyboardTeller: false,
+      },
+      ...mountOptions,
+    });
+
+    await flushPromises();
+
+    const addBallotButton = wrapper
+      .findAllComponents(ElButton)
+      .find((button) => button.text().includes("Start another ballot"));
+    await addBallotButton!.trigger("click");
+    await flushPromises();
+
+    expect(mockCreateBallot).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).toHaveBeenCalledWith("Teller is required");
+    expect(wrapper.emitted("ballot-start-blocked")?.[0]).toEqual(["teller"]);
   });
 
   it("deletes ballot and emits ballot-deleted after confirmation", async () => {

--- a/frontend/src/components/tellers/ActiveTellerSelector.vue
+++ b/frontend/src/components/tellers/ActiveTellerSelector.vue
@@ -12,8 +12,11 @@ import { computed, onMounted, ref, watch } from "vue";
 const props = withDefaults(
   defineProps<{
     electionGuid: string;
+    highlightTeller1?: boolean;
   }>(),
-  {},
+  {
+    highlightTeller1: false,
+  },
 );
 
 const emit = defineEmits<{
@@ -118,7 +121,8 @@ watch(
       allow-create
       clearable
       :placeholder="$t('teller.active.teller1Placeholder')"
-      class="teller-select"
+      class="teller-select teller1-select"
+      :class="{ 'required-field-flash': highlightTeller1 }"
       @change="handleTeller1Change"
     >
       <el-option value="" disabled :label="$t('teller.active.typeToAdd')" />

--- a/frontend/src/composables/__tests__/useRequiredFieldFlash.spec.ts
+++ b/frontend/src/composables/__tests__/useRequiredFieldFlash.spec.ts
@@ -1,0 +1,68 @@
+import { defineComponent, h } from "vue";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  REQUIRED_FIELD_FLASH_MS,
+  useRequiredFieldFlash,
+} from "../useRequiredFieldFlash";
+
+describe("useRequiredFieldFlash", () => {
+  let wrapper: VueWrapper | null = null;
+  let api: ReturnType<typeof useRequiredFieldFlash> | undefined;
+
+  function mountHarness() {
+    wrapper?.unmount();
+    api = undefined;
+    wrapper = mount(
+      defineComponent({
+        setup() {
+          api = useRequiredFieldFlash();
+          return () => h("div");
+        },
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+    vi.useRealTimers();
+  });
+
+  it("turns flashing on then off after the attention duration", async () => {
+    mountHarness();
+
+    expect(api!.flashing.value).toBe(false);
+    const flashPromise = api!.flash();
+    await flushPromises();
+    await flashPromise;
+    expect(api!.flashing.value).toBe(true);
+
+    vi.advanceTimersByTime(REQUIRED_FIELD_FLASH_MS - 1);
+    expect(api!.flashing.value).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(api!.flashing.value).toBe(false);
+  });
+
+  it("restarts the flash when called again before it finishes", async () => {
+    mountHarness();
+
+    await api!.flash();
+    await flushPromises();
+    vi.advanceTimersByTime(800);
+
+    await api!.flash();
+    await flushPromises();
+    expect(api!.flashing.value).toBe(true);
+
+    vi.advanceTimersByTime(REQUIRED_FIELD_FLASH_MS - 1);
+    expect(api!.flashing.value).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(api!.flashing.value).toBe(false);
+  });
+});

--- a/frontend/src/composables/useRequiredFieldFlash.ts
+++ b/frontend/src/composables/useRequiredFieldFlash.ts
@@ -1,0 +1,31 @@
+import { nextTick, onBeforeUnmount, ref } from "vue";
+
+/** Matches the CSS animation on `.required-field-flash` (1–2 seconds). */
+export const REQUIRED_FIELD_FLASH_MS = 1600;
+
+export function useRequiredFieldFlash(durationMs = REQUIRED_FIELD_FLASH_MS) {
+  const flashing = ref(false);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function clearTimer() {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  }
+
+  async function flash() {
+    clearTimer();
+    flashing.value = false;
+    await nextTick();
+    flashing.value = true;
+    timer = setTimeout(() => {
+      flashing.value = false;
+      timer = undefined;
+    }, durationMs);
+  }
+
+  onBeforeUnmount(clearTimer);
+
+  return { flashing, flash };
+}

--- a/frontend/src/locales/en/ballots.json
+++ b/frontend/src/locales/en/ballots.json
@@ -71,6 +71,7 @@
   "ballots.loadError": "Failed to load ballots",
   "ballots.location": "Location",
   "ballots.locationRequired": "Location is required",
+  "ballots.tellerRequired": "Teller is required",
   "ballots.management": "Enter Ballots",
   "ballots.markNeedsReview": "Mark as Needs Review",
   "ballots.clearNeedsReview": "Clear Needs Review",

--- a/frontend/src/pages/ballots/BallotEntryPage.vue
+++ b/frontend/src/pages/ballots/BallotEntryPage.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import ActiveTellerSelector from "@/components/tellers/ActiveTellerSelector.vue";
+import { useRequiredFieldFlash } from "@/composables/useRequiredFieldFlash";
 import {
   getActiveTellers,
   type ActiveTellers,
 } from "@/utils/activeTellerStorage";
+import type { BallotStartBlockReason } from "@/utils/ballotStartRequirements";
 import {
   electionBallotEntryPath,
   electionBallotsPath,
@@ -26,12 +28,20 @@ function handleBallotDeleted() {
 }
 
 const activeTellers = ref<ActiveTellers>(getActiveTellers());
+const { flashing: tellerFlashing, flash: flashTeller } =
+  useRequiredFieldFlash();
 const hasKeyboardTeller = computed(() =>
   Boolean(activeTellers.value.teller1.trim()),
 );
 
 function onTellersChanged(tellers: ActiveTellers) {
   activeTellers.value = tellers;
+}
+
+function onBallotStartBlocked(reason: BallotStartBlockReason) {
+  if (reason === "teller") {
+    void flashTeller();
+  }
 }
 </script>
 
@@ -42,6 +52,7 @@ function onTellersChanged(tellers: ActiveTellers) {
         <div class="card-header">
           <ActiveTellerSelector
             :election-guid="electionGuid"
+            :highlight-teller1="tellerFlashing"
             @tellers-changed="onTellersChanged"
           />
         </div>
@@ -54,6 +65,7 @@ function onTellersChanged(tellers: ActiveTellers) {
         :has-keyboard-teller="hasKeyboardTeller"
         @ballot-created="handleBallotCreated"
         @ballot-deleted="handleBallotDeleted"
+        @ballot-start-blocked="onBallotStartBlocked"
       />
     </el-card>
   </div>

--- a/frontend/src/pages/ballots/BallotManagementPage.vue
+++ b/frontend/src/pages/ballots/BallotManagementPage.vue
@@ -4,6 +4,7 @@ import ActiveTellerSelector from "@/components/tellers/ActiveTellerSelector.vue"
 import { useApiErrorHandler } from "@/composables/useApiErrorHandler";
 import { useComputerCode } from "@/composables/useComputerCode";
 import { useNotifications } from "@/composables/useNotifications";
+import { useRequiredFieldFlash } from "@/composables/useRequiredFieldFlash";
 
 import type { ComputerDto } from "@/types/Computer";
 import {
@@ -11,6 +12,11 @@ import {
   getActiveTellers,
   type ActiveTellers,
 } from "@/utils/activeTellerStorage";
+import {
+  BALLOT_START_BLOCK_MESSAGE_KEY,
+  getBallotStartBlockReason,
+  type BallotStartBlockReason,
+} from "@/utils/ballotStartRequirements";
 import {
   ballotGuidFromRouteParams,
   electionBallotsPath,
@@ -52,6 +58,11 @@ const selectedViewFilter = ref(
   defaultBallotViewFilter("", locationStore.selectedLocationGuid),
 );
 const computersByLocation = ref<Record<string, ComputerDto[]>>({});
+
+const { flashing: locationFlashing, flash: flashLocation } =
+  useRequiredFieldFlash();
+const { flashing: tellerFlashing, flash: flashTeller } =
+  useRequiredFieldFlash();
 
 const hasKeyboardTeller = computed(() =>
   Boolean(activeTellers.value.teller1.trim()),
@@ -256,14 +267,27 @@ function handleBallotCreatedFromEntry(ballotGuid: string) {
   );
 }
 
-async function handleAddBallot() {
-  if (!computerCode.value) {
-    showErrorMessage(t("ballots.computerCodeRequired"));
-    return;
+function flashStartBlockField(reason: BallotStartBlockReason) {
+  if (reason === "location") {
+    void flashLocation();
+  } else if (reason === "teller") {
+    void flashTeller();
   }
+}
 
-  if (!locationStore.selectedLocationGuid) {
-    showErrorMessage(t("ballots.locationRequired"));
+function blockBallotStart(reason: BallotStartBlockReason) {
+  showErrorMessage(t(BALLOT_START_BLOCK_MESSAGE_KEY[reason]));
+  flashStartBlockField(reason);
+}
+
+async function handleAddBallot() {
+  const reason = getBallotStartBlockReason({
+    computerCode: computerCode.value,
+    locationGuid: locationStore.selectedLocationGuid,
+    teller1: activeTellers.value.teller1,
+  });
+  if (reason) {
+    blockBallotStart(reason);
     return;
   }
 
@@ -337,6 +361,7 @@ function handleLocationChange(locationGuid: string | null) {
           <ActiveTellerSelector
             :election-guid="electionGuid"
             class="header-tellers"
+            :highlight-teller1="tellerFlashing"
             @tellers-changed="onTellersChanged"
           />
 
@@ -353,6 +378,7 @@ function handleLocationChange(locationGuid: string | null) {
               clearable
               :aria-label="$t('locations.currentLocation')"
               class="location-select"
+              :class="{ 'required-field-flash': locationFlashing }"
               @update:model-value="handleLocationChange"
             >
               <el-option
@@ -451,11 +477,11 @@ function handleLocationChange(locationGuid: string | null) {
         :key="drawerBallotGuid"
         :election-guid="electionGuid"
         :ballot-guid="drawerBallotGuid"
-        :show-metadata="!isNewBallot"
         :manage-ballot-signal-r="false"
         :has-keyboard-teller="hasKeyboardTeller"
         @ballot-created="handleBallotCreatedFromEntry"
         @ballot-deleted="handleBallotDeletedFromEntry"
+        @ballot-start-blocked="flashStartBlockField"
       />
     </el-drawer>
   </div>

--- a/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
+++ b/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { createI18n } from "vue-i18n";
@@ -8,6 +8,8 @@ import { useLocationStore } from "@/stores/locationStore";
 import type { BallotSummaryDto } from "@/utils/ballotSummary";
 import { computerFilterValue } from "@/utils/ballotViewFilter";
 import { setComputerCode } from "@/utils/computerCodeStorage";
+import { setActiveTeller1 } from "@/utils/activeTellerStorage";
+import { REQUIRED_FIELD_FLASH_MS } from "@/composables/useRequiredFieldFlash";
 
 const mockReplace = vi.fn();
 const routeState = {
@@ -26,23 +28,41 @@ vi.mock("@/components/ballots/BallotEntryPanel.vue", () => ({
   default: {
     name: "BallotEntryPanel",
     template: '<div data-testid="ballot-entry-panel"></div>',
-    props: [
-      "electionGuid",
-      "ballotGuid",
-      "showMetadata",
-      "manageBallotSignalR",
-      "managePeopleSignalR",
-      "hasKeyboardTeller",
-    ],
+    props: {
+      electionGuid: { type: String, required: true },
+      ballotGuid: { type: String, required: true },
+      showMetadata: { type: Boolean, default: true },
+      manageBallotSignalR: { type: Boolean, default: true },
+      managePeopleSignalR: { type: Boolean, default: true },
+      hasKeyboardTeller: { type: Boolean, default: true },
+    },
   },
 }));
 
 vi.mock("@/components/tellers/ActiveTellerSelector.vue", () => ({
   default: {
     name: "ActiveTellerSelector",
-    template: "<div></div>",
-    props: ["electionGuid"],
+    template:
+      '<div class="active-teller-selector-stub" :class="{ \'required-field-flash\': highlightTeller1 }"></div>',
+    props: {
+      electionGuid: { type: String, required: true },
+      highlightTeller1: { type: Boolean, default: false },
+    },
   },
+}));
+
+const { mockShowErrorMessage, mockShowSuccessMessage } = vi.hoisted(() => ({
+  mockShowErrorMessage: vi.fn(),
+  mockShowSuccessMessage: vi.fn(),
+}));
+
+vi.mock("@/composables/useNotifications", () => ({
+  useNotifications: () => ({
+    showErrorMessage: mockShowErrorMessage,
+    showSuccessMessage: mockShowSuccessMessage,
+    showWarningMessage: vi.fn(),
+    showInfoMessage: vi.fn(),
+  }),
 }));
 
 describe("BallotManagementPage", () => {
@@ -101,6 +121,8 @@ describe("BallotManagementPage", () => {
           viewFilterPlaceholder: "Search computers or locations",
           computerCodeRequired:
             "Set this computer's code before creating a ballot",
+          locationRequired: "Location is required",
+          tellerRequired: "Teller is required",
           "statusValue.Ok": "Ok",
         },
         common: {
@@ -160,12 +182,24 @@ describe("BallotManagementPage", () => {
     });
   }
 
+  async function clickAddBallot(wrapper: ReturnType<typeof mountPage>) {
+    const addButton = wrapper
+      .findAll(".el-button")
+      .find((button) => button.text().includes("Add Ballot"));
+    expect(addButton).toBeDefined();
+    await addButton!.trigger("click");
+    await flushPromises();
+  }
+
   beforeEach(() => {
     localStorage.clear();
     mockReplace.mockReset();
+    mockShowErrorMessage.mockReset();
+    mockShowSuccessMessage.mockReset();
     routeState.params = { id: "test-election-guid" };
     routeState.path = "/elections/test-election-guid/ballots";
     setComputerCode("test-election-guid", "AA");
+    setActiveTeller1("Alice");
     setActivePinia(createPinia());
     ballotStore = useBallotStore();
     locationStore = useLocationStore();
@@ -218,6 +252,10 @@ describe("BallotManagementPage", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("loads ballots and joins signalr on mount", async () => {
     mountPage();
     await flushPromises();
@@ -227,20 +265,79 @@ describe("BallotManagementPage", () => {
     expect(ballotStore.joinElection).toHaveBeenCalledWith("test-election-guid");
   });
 
-  it("creates a new ballot and opens drawer without metadata", async () => {
+  it("creates a new ballot and opens the drawer with the same header as an existing ballot", async () => {
     const wrapper = mountPage();
     await flushPromises();
 
-    const addButtons = wrapper.findAll(".el-button");
-    const addButton = addButtons.find((b) => b.text().includes("Add Ballot"));
-    expect(addButton).toBeDefined();
-    await addButton!.trigger("click");
-    await flushPromises();
+    await clickAddBallot(wrapper);
 
     expect(ballotStore.createBallot).toHaveBeenCalled();
     const panel = wrapper.findComponent({ name: "BallotEntryPanel" });
     expect(panel.exists()).toBe(true);
-    expect(panel.props("showMetadata")).toBe(false);
+    expect(panel.props("showMetadata")).toBe(true);
+  });
+
+  it("shows the metadata header when opening an existing ballot", async () => {
+    routeState.params = {
+      id: "test-election-guid",
+      ballotId: "ballot-1",
+    };
+    routeState.path = "/elections/test-election-guid/ballot/ballot-1";
+    const wrapper = mountPage();
+    await flushPromises();
+
+    const panel = wrapper.findComponent({ name: "BallotEntryPanel" });
+    expect(panel.exists()).toBe(true);
+    expect(panel.props("ballotGuid")).toBe("ballot-1");
+    expect(panel.props("showMetadata")).toBe(true);
+  });
+
+  it("does not start a ballot when location is unset and flashes the location select", async () => {
+    vi.useFakeTimers();
+    locationStore.selectedLocationGuid = null;
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await clickAddBallot(wrapper);
+
+    expect(ballotStore.createBallot).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).toHaveBeenCalledWith("Location is required");
+    expect(wrapper.find(".location-select").classes()).toContain(
+      "required-field-flash",
+    );
+
+    vi.advanceTimersByTime(REQUIRED_FIELD_FLASH_MS);
+    await flushPromises();
+    expect(wrapper.find(".location-select").classes()).not.toContain(
+      "required-field-flash",
+    );
+
+    wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  it("does not start a ballot when the main teller is unset and flashes the teller select", async () => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    setComputerCode("test-election-guid", "AA");
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await clickAddBallot(wrapper);
+
+    expect(ballotStore.createBallot).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).toHaveBeenCalledWith("Teller is required");
+    const tellerSelector = wrapper.findComponent({
+      name: "ActiveTellerSelector",
+    });
+    expect(tellerSelector.props("highlightTeller1")).toBe(true);
+
+    vi.advanceTimersByTime(REQUIRED_FIELD_FLASH_MS);
+    await flushPromises();
+    expect(tellerSelector.props("highlightTeller1")).toBe(false);
+
+    wrapper.unmount();
+    vi.useRealTimers();
   });
 
   it("does not render an actions column", async () => {
@@ -272,14 +369,10 @@ describe("BallotManagementPage", () => {
     const wrapper = mountPage();
     await flushPromises();
 
-    const addButton = wrapper
-      .findAll(".el-button")
-      .find((button) => button.text().includes("Add Ballot"));
-    await addButton!.trigger("click");
-    await flushPromises();
+    await clickAddBallot(wrapper);
 
     const panel = wrapper.findComponent({ name: "BallotEntryPanel" });
-    expect(panel.props("hasKeyboardTeller")).toBe(false);
+    expect(panel.props("hasKeyboardTeller")).toBe(true);
   });
 
   it("opens a ballot from the ballot route param on load", async () => {
@@ -320,11 +413,7 @@ describe("BallotManagementPage", () => {
     const wrapper = mountPage();
     await flushPromises();
 
-    const addButton = wrapper
-      .findAll(".el-button")
-      .find((button) => button.text().includes("Add Ballot"));
-    await addButton!.trigger("click");
-    await flushPromises();
+    await clickAddBallot(wrapper);
 
     expect(mockReplace).toHaveBeenCalledWith(
       "/elections/test-election-guid/ballot/new-ballot-guid",

--- a/frontend/src/styles/effects.less
+++ b/frontend/src/styles/effects.less
@@ -350,6 +350,27 @@
   }
 }
 
+/* Attention flash when a required location/teller select blocked starting a ballot */
+@keyframes required-field-flash {
+  0%,
+  40% {
+    box-shadow: 0 0 0 2px var(--el-color-warning);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+.required-field-flash {
+  animation: required-field-flash 1.6s ease-out;
+
+  .el-select__wrapper {
+    box-shadow: 0 0 0 2px var(--el-color-warning) !important;
+    animation: required-field-flash 1.6s ease-out;
+  }
+}
+
 .el-dropdown-menu {
   background-color: var(--el-bg-color);
 

--- a/frontend/src/utils/__tests__/ballotStartRequirements.test.ts
+++ b/frontend/src/utils/__tests__/ballotStartRequirements.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  BALLOT_START_BLOCK_MESSAGE_KEY,
+  getBallotStartBlockReason,
+} from "../ballotStartRequirements";
+
+describe("getBallotStartBlockReason", () => {
+  const ready = {
+    computerCode: "AA",
+    locationGuid: "loc-1",
+    teller1: "Alice",
+  };
+
+  it("allows a ballot to start when computer, location, and teller 1 are set", () => {
+    expect(getBallotStartBlockReason(ready)).toBeNull();
+  });
+
+  it("does not require teller 2", () => {
+    expect(
+      getBallotStartBlockReason({
+        ...ready,
+        teller1: "Alice",
+      }),
+    ).toBeNull();
+  });
+
+  it("blocks when the computer code is unset", () => {
+    expect(getBallotStartBlockReason({ ...ready, computerCode: "" })).toBe(
+      "computerCode",
+    );
+    expect(getBallotStartBlockReason({ ...ready, computerCode: "  " })).toBe(
+      "computerCode",
+    );
+    expect(getBallotStartBlockReason({ ...ready, computerCode: null })).toBe(
+      "computerCode",
+    );
+  });
+
+  it("blocks when the location is unset", () => {
+    expect(getBallotStartBlockReason({ ...ready, locationGuid: "" })).toBe(
+      "location",
+    );
+    expect(getBallotStartBlockReason({ ...ready, locationGuid: null })).toBe(
+      "location",
+    );
+  });
+
+  it("blocks when the main teller is unset", () => {
+    expect(getBallotStartBlockReason({ ...ready, teller1: "" })).toBe("teller");
+    expect(getBallotStartBlockReason({ ...ready, teller1: "  " })).toBe(
+      "teller",
+    );
+    expect(getBallotStartBlockReason({ ...ready, teller1: null })).toBe(
+      "teller",
+    );
+  });
+
+  it("checks computer code before location and teller", () => {
+    expect(
+      getBallotStartBlockReason({
+        computerCode: "",
+        locationGuid: "",
+        teller1: "",
+      }),
+    ).toBe("computerCode");
+  });
+
+  it("checks location before teller when the computer code is set", () => {
+    expect(
+      getBallotStartBlockReason({
+        computerCode: "AA",
+        locationGuid: "",
+        teller1: "",
+      }),
+    ).toBe("location");
+  });
+
+  it("maps each block reason to the matching i18n key", () => {
+    expect(BALLOT_START_BLOCK_MESSAGE_KEY.location).toBe(
+      "ballots.locationRequired",
+    );
+    expect(BALLOT_START_BLOCK_MESSAGE_KEY.teller).toBe(
+      "ballots.tellerRequired",
+    );
+    expect(BALLOT_START_BLOCK_MESSAGE_KEY.computerCode).toBe(
+      "ballots.computerCodeRequired",
+    );
+  });
+});

--- a/frontend/src/utils/ballotStartRequirements.ts
+++ b/frontend/src/utils/ballotStartRequirements.ts
@@ -1,0 +1,31 @@
+export type BallotStartBlockReason = "computerCode" | "location" | "teller";
+
+export const BALLOT_START_BLOCK_MESSAGE_KEY: Record<
+  BallotStartBlockReason,
+  string
+> = {
+  computerCode: "ballots.computerCodeRequired",
+  location: "ballots.locationRequired",
+  teller: "ballots.tellerRequired",
+};
+
+/**
+ * A new paper ballot must not start without a computer code, location, and
+ * main teller (teller 1). Teller 2 is optional.
+ */
+export function getBallotStartBlockReason(input: {
+  computerCode?: string | null;
+  locationGuid?: string | null;
+  teller1?: string | null;
+}): BallotStartBlockReason | null {
+  if (!input.computerCode?.trim()) {
+    return "computerCode";
+  }
+  if (!input.locationGuid?.trim()) {
+    return "location";
+  }
+  if (!input.teller1?.trim()) {
+    return "teller";
+  }
+  return null;
+}


### PR DESCRIPTION
Related: #287 (issue stays open).

First slice of ballot entry issues: starting a ballot, teller/location requirements, and the first-view header.

UI verification is deferred to Glen on UAT. This PR is covered by unit tests only. No Playwright/browser tools.

## What this does
- A new ballot does not start if the main teller (teller 1) is unset, using the same gate that already blocks when location is unset.
- When the UI shows “Location is required” or “Teller is required”, the matching select flashes a yellow/warning border for ~1.6 seconds.
- The first view of a new ballot now shows the same Location / Computer / Teller 1 / Teller 2 header that appears when an existing ballot is opened.

## What I verified
Hiding that header on first view (`showMetadata=!isNewBallot`) was a separate path from the teller gate. Restoring the header does **not** enforce teller 1; the create/start checks now do that. Teller 1/2 in the ballot header remain read-only, matching existing-ballot behavior (not turned into session-global editors).

## Out of scope (still on #287)
- New ballots ignoring the browser location and starting in “Online” / cannot create at Online
- Making Teller 1/2 on the ballot into editable inputs that write session globals

## Tests
- `getBallotStartBlockReason` (computer → location → teller 1; teller 2 optional)
- Required-field flash on/off
- Ballot list: block + flash when location or teller 1 is unset; new ballot opens with the same metadata header as an existing ballot
- Inline “Start another ballot”: same location and teller blocks