### PR TITLE
Use the selected location when starting a teller ballot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,8 @@ Any change to backend DTOs, controllers, or new endpoints requires regenerating 
 
    The `--` is required so `--exit-after-start` is passed to the app, not to `dotnet run`. That flag also skips SQL (`--skip-database` is implied). The app writes `frontend/openApi/tallyj.json` (`app.WriteOpenApiSpecToFile(...)` in `backend/Program.AppPipeline.cs`) and then stops. It does not listen on a port and does not open a database, so **run this even if `dotnet watch` / IDE already has a backend listening**.
 
+   `dotnet watch` hot-reloads many C# edits but fails on a lot of them, and it **never** rewrites the OpenAPI spec — that file is written only on a fresh start. Do not treat a running watch process as having an up-to-date `tallyj.json`.
+
    On Windows, if `dotnet run` fails with MSB3026 because `Backend.exe` is locked by the watch process, retry with `dotnet run --no-build -- --exit-after-start` (watch already compiled).
 
 2. `cd frontend`
@@ -188,8 +190,8 @@ Other languages are updated separately in periodic review cycles — do not add 
 - frontend default dev URL: `https://localhost:8095` (Vite HTTPS via mkcert-trusted certs; `/api` and `/hubs` proxied to the backend)
 - backend development config seeds the database on startup
 - Swagger is the source of truth for current routes and schemas
-- **Contributor workflow:** the repo owner usually keeps their own backend dev instance running (`dotnet watch` / `dotnet run` / IDE) and the Vite dev server (`npm run dev`) for hot reload. **Do not rebuild backend or frontend for routine code changes** — `dotnet watch` recompiles C# on save and Vite hot-reloads Vue/TS. Avoid `dotnet build`, `dotnet run`, `npm run build`, and `npm run dev` unless the task explicitly requires it, the OpenAPI regen steps above apply, or the contributor asks you to verify a build. If you must rebuild for something other than `--exit-after-start`, ask them to stop their running backend first (file-lock on `Backend.exe` causes MSB3026 copy failures). Prefer `dotnet test --no-build` when a recent build already exists.
-- **OpenAPI regen:** when backend DTOs, controllers, or routes changed, run `dotnet run -- --exit-after-start` from `backend/` (even if `dotnet watch` is already running — that command does not listen) and then `npm run gen` from `frontend/`. Frontend-only edits do not need OpenAPI regeneration.
+- **Contributor workflow:** the repo owner usually keeps their own backend dev instance running (`dotnet watch` / `dotnet run` / IDE) and the Vite dev server (`npm run dev`) for hot reload. **Do not rebuild backend or frontend for routine code changes** — `dotnet watch` hot-reloads many C# edits (it also fails on a lot of them) and Vite hot-reloads Vue/TS. Avoid `dotnet build`, `dotnet run`, `npm run build`, and `npm run dev` unless the task explicitly requires it, the OpenAPI regen steps above apply, or the contributor asks you to verify a build. If you must rebuild for something other than `--exit-after-start`, ask them to stop their running backend first (file-lock on `Backend.exe` causes MSB3026 copy failures). Prefer `dotnet test --no-build` when a recent build already exists.
+- **OpenAPI regen:** when backend DTOs, controllers, or routes changed, run `dotnet run -- --exit-after-start` from `backend/` and then `npm run gen` from `frontend/`. Do this even if `dotnet watch` is already running: that command does not listen, and watch never rewrites `tallyj.json` (the spec is written only on a fresh start). Frontend-only edits do not need OpenAPI regeneration.
 
 ### Configuration sources (Program.cs)
 
@@ -274,7 +276,7 @@ with normal POSIX quoting._
 
 These apply on both Windows and Linux:
 
-- **Default:** do not run `dotnet build` or restart the backend — the contributor's `dotnet watch` picks up C# changes automatically.
+- **Default:** do not run `dotnet build` or restart the backend — the contributor's `dotnet watch` hot-reloads many C# edits, though it fails on a lot of them. It never rewrites the OpenAPI spec; use `--exit-after-start` for that (see above).
 - If a backend rebuild is needed, confirm the contributor has stopped their locally running backend first (see **Local development assumptions**). A running `Backend.exe` locks the output and causes MSB3026 copy failures.
 - For targeted test runs, `dotnet test --filter "FullyQualifiedName~ClassName.MethodPrefix"` works
   well. Multiple filters can be OR-combined with `|`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,10 +139,17 @@ Any change to backend DTOs, controllers, or new endpoints requires regenerating 
 
 **Steps (clean dev environment)**:
 
-1. Start (or restart) the backend in the **Development** environment (`dotnet run` from the `backend/` directory).  
-   On startup it automatically executes `app.WriteOpenApiSpecToFile(...)` which writes the live contract to `frontend/openApi/tallyj.json` (see `backend/Program.AppPipeline.cs`).
+1. Write the live contract in the **Development** environment. From `backend/`:
 
-2. In another terminal: `cd frontend`
+   ```bash
+   dotnet run -- --exit-after-start
+   ```
+
+   The `--` is required so `--exit-after-start` is passed to the app, not to `dotnet run`. On startup the app writes `frontend/openApi/tallyj.json` (`app.WriteOpenApiSpecToFile(...)` in `backend/Program.AppPipeline.cs`) and then stops.
+
+   If a Development backend is already running (`dotnet watch` / IDE), skip this step — that process writes the spec on its own startup.
+
+2. `cd frontend`
 
 3. `npm run gen` (runs `@hey-api/openapi-ts` using the config at `frontend/openApi/config.backend.ts`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,9 +145,9 @@ Any change to backend DTOs, controllers, or new endpoints requires regenerating 
    dotnet run -- --exit-after-start
    ```
 
-   The `--` is required so `--exit-after-start` is passed to the app, not to `dotnet run`. That flag also skips SQL (`--skip-database` is implied). On startup the app writes `frontend/openApi/tallyj.json` (`app.WriteOpenApiSpecToFile(...)` in `backend/Program.AppPipeline.cs`) and then stops, without listening or opening a database connection.
+   The `--` is required so `--exit-after-start` is passed to the app, not to `dotnet run`. That flag also skips SQL (`--skip-database` is implied). The app writes `frontend/openApi/tallyj.json` (`app.WriteOpenApiSpecToFile(...)` in `backend/Program.AppPipeline.cs`) and then stops. It does not listen on a port and does not open a database, so **run this even if `dotnet watch` / IDE already has a backend listening**.
 
-   If a Development backend is already running (`dotnet watch` / IDE), skip this step — that process writes the spec on its own startup.
+   On Windows, if `dotnet run` fails with MSB3026 because `Backend.exe` is locked by the watch process, retry with `dotnet run --no-build -- --exit-after-start` (watch already compiled).
 
 2. `cd frontend`
 
@@ -188,8 +188,8 @@ Other languages are updated separately in periodic review cycles — do not add 
 - frontend default dev URL: `https://localhost:8095` (Vite HTTPS via mkcert-trusted certs; `/api` and `/hubs` proxied to the backend)
 - backend development config seeds the database on startup
 - Swagger is the source of truth for current routes and schemas
-- **Contributor workflow:** the repo owner usually keeps their own backend dev instance running (`dotnet watch` / `dotnet run` / IDE) and the Vite dev server (`npm run dev`) for hot reload. **Do not rebuild backend or frontend for routine code changes** — `dotnet watch` recompiles C# on save and Vite hot-reloads Vue/TS. Avoid `dotnet build`, `dotnet run`, `npm run build`, and `npm run dev` unless the task explicitly requires it or the contributor asks you to verify a build. If you must rebuild, ask them to stop their running backend first (file-lock on `Backend.exe` causes MSB3026 copy failures). Prefer `dotnet test --no-build` when a recent build already exists.
-- **OpenAPI regen:** only mention `frontend/openApi/tallyj.json` / `npm run gen` when backend DTOs, controllers, or routes changed. Frontend-only edits do not need OpenAPI regeneration.
+- **Contributor workflow:** the repo owner usually keeps their own backend dev instance running (`dotnet watch` / `dotnet run` / IDE) and the Vite dev server (`npm run dev`) for hot reload. **Do not rebuild backend or frontend for routine code changes** — `dotnet watch` recompiles C# on save and Vite hot-reloads Vue/TS. Avoid `dotnet build`, `dotnet run`, `npm run build`, and `npm run dev` unless the task explicitly requires it, the OpenAPI regen steps above apply, or the contributor asks you to verify a build. If you must rebuild for something other than `--exit-after-start`, ask them to stop their running backend first (file-lock on `Backend.exe` causes MSB3026 copy failures). Prefer `dotnet test --no-build` when a recent build already exists.
+- **OpenAPI regen:** when backend DTOs, controllers, or routes changed, run `dotnet run -- --exit-after-start` from `backend/` (even if `dotnet watch` is already running — that command does not listen) and then `npm run gen` from `frontend/`. Frontend-only edits do not need OpenAPI regeneration.
 
 ### Configuration sources (Program.cs)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Any change to backend DTOs, controllers, or new endpoints requires regenerating 
    dotnet run -- --exit-after-start
    ```
 
-   The `--` is required so `--exit-after-start` is passed to the app, not to `dotnet run`. On startup the app writes `frontend/openApi/tallyj.json` (`app.WriteOpenApiSpecToFile(...)` in `backend/Program.AppPipeline.cs`) and then stops.
+   The `--` is required so `--exit-after-start` is passed to the app, not to `dotnet run`. That flag also skips SQL (`--skip-database` is implied). On startup the app writes `frontend/openApi/tallyj.json` (`app.WriteOpenApiSpecToFile(...)` in `backend/Program.AppPipeline.cs`) and then stops, without listening or opening a database connection.
 
    If a Development backend is already running (`dotnet watch` / IDE), skip this step — that process writes the spec on its own startup.
 

--- a/Backend.Tests/UnitTests/ElectionServiceTests.cs
+++ b/Backend.Tests/UnitTests/ElectionServiceTests.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using Backend.DTOs.Elections;
 using Backend.Entities;
 using Backend.Enumerations;
+using Backend.Helpers;
 using Backend.Services;
 
 namespace Backend.Tests.UnitTests;
@@ -61,6 +62,112 @@ public class ElectionServiceTests : ServiceTestBase
         var electionInDb = Context.Elections.FirstOrDefault(e => e.ElectionGuid == result.ElectionGuid);
         Assert.NotNull(electionInDb);
         Assert.Equal("Test Election", electionInDb.Name);
+        Assert.Empty(Context.Locations.Where(l => l.ElectionGuid == result.ElectionGuid));
+    }
+
+    [Fact]
+    public async Task CreateElectionAsync_WhenOnlineVotingEnabled_AddsOnlineLocation()
+    {
+        var result = await _service.CreateElectionAsync(new CreateElectionDto
+        {
+            Name = "Online Enabled",
+            DateOfElection = DateTime.UtcNow.AddDays(30),
+            ElectionType = ElectionTypeCode.LSA,
+            NumberToElect = 5,
+            UseOnlineVoting = true
+        });
+
+        var location = Context.Locations.Single(l => l.ElectionGuid == result.ElectionGuid);
+        Assert.Equal(LocationType.Online, location.LocationTypeEnum);
+    }
+
+    [Fact]
+    public async Task UpdateElectionAsync_EnablingOnlineVoting_AddsOnlineLocation()
+    {
+        var election = new Election
+        {
+            ElectionGuid = Guid.NewGuid(),
+            Name = "Toggle Online",
+            ElectionType = "LSA",
+            NumberToElect = 3,
+            ElectionStage = ElectionStage.SettingUp,
+            UseOnlineVoting = false,
+            RowVersion = new byte[8]
+        };
+        Context.Elections.Add(election);
+        await Context.SaveChangesAsync();
+
+        await _service.UpdateElectionAsync(election.ElectionGuid, new UpdateElectionDto
+        {
+            Name = election.Name,
+            UseOnlineVoting = true
+        });
+
+        Assert.Single(Context.Locations.Where(l =>
+            l.ElectionGuid == election.ElectionGuid
+            && l.LocationTypeCode == nameof(LocationType.Online)));
+    }
+
+    [Fact]
+    public async Task UpdateElectionAsync_DisablingOnlineVoting_RemovesEmptyOnlineLocation()
+    {
+        var election = new Election
+        {
+            ElectionGuid = Guid.NewGuid(),
+            Name = "Toggle Online Off",
+            ElectionType = "LSA",
+            NumberToElect = 3,
+            ElectionStage = ElectionStage.SettingUp,
+            UseOnlineVoting = true,
+            RowVersion = new byte[8]
+        };
+        Context.Elections.Add(election);
+        await Context.SaveChangesAsync();
+        await OnlineLocationHelper.EnsureExistsAsync(Context, election.ElectionGuid);
+
+        await _service.UpdateElectionAsync(election.ElectionGuid, new UpdateElectionDto
+        {
+            Name = election.Name,
+            UseOnlineVoting = false
+        });
+
+        Assert.Empty(Context.Locations.Where(l => l.ElectionGuid == election.ElectionGuid));
+    }
+
+    [Fact]
+    public async Task UpdateElectionAsync_DisablingOnlineVoting_KeepsOnlineLocationWhenItHasBallots()
+    {
+        var election = new Election
+        {
+            ElectionGuid = Guid.NewGuid(),
+            Name = "Has Online Ballots",
+            ElectionType = "LSA",
+            NumberToElect = 3,
+            ElectionStage = ElectionStage.GatheringBallots,
+            UseOnlineVoting = true,
+            RowVersion = new byte[8]
+        };
+        Context.Elections.Add(election);
+        await Context.SaveChangesAsync();
+        var location = await OnlineLocationHelper.EnsureExistsAsync(Context, election.ElectionGuid);
+        Context.Ballots.Add(new Ballot
+        {
+            BallotGuid = Guid.NewGuid(),
+            LocationGuid = location.LocationGuid,
+            ComputerCode = ComputerCodeHelper.Online,
+            BallotNumAtComputer = 1,
+            StatusCode = BallotStatus.Ok,
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        await _service.UpdateElectionAsync(election.ElectionGuid, new UpdateElectionDto
+        {
+            Name = election.Name,
+            UseOnlineVoting = false
+        });
+
+        Assert.Single(Context.Locations.Where(l => l.ElectionGuid == election.ElectionGuid));
     }
 
     [Fact]

--- a/Backend.Tests/UnitTests/Helpers/OnlineLocationHelperTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/OnlineLocationHelperTests.cs
@@ -1,0 +1,74 @@
+using Backend.Entities;
+using Backend.Enumerations;
+using Backend.Helpers;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class OnlineLocationHelperTests : ServiceTestBase
+{
+    private static readonly Guid ElectionGuid = Guid.NewGuid();
+
+    public OnlineLocationHelperTests()
+    {
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = ElectionGuid,
+            Name = "Test",
+            NumberToElect = 3,
+            ElectionType = "Loc",
+            RowVersion = new byte[8]
+        });
+        Context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task EnsureExistsAsync_CreatesTypedLocation_Once()
+    {
+        var first = await OnlineLocationHelper.EnsureExistsAsync(Context, ElectionGuid);
+        var second = await OnlineLocationHelper.EnsureExistsAsync(Context, ElectionGuid);
+
+        Assert.Equal(LocationType.Online, first.LocationTypeEnum);
+        Assert.Equal(first.LocationGuid, second.LocationGuid);
+        Assert.Equal(1, Context.Locations.Count(l => l.ElectionGuid == ElectionGuid));
+    }
+
+    [Fact]
+    public async Task RemoveIfNoBallotsAsync_DeletesWhenEmpty()
+    {
+        await OnlineLocationHelper.EnsureExistsAsync(Context, ElectionGuid);
+
+        await OnlineLocationHelper.RemoveIfNoBallotsAsync(Context, ElectionGuid);
+
+        Assert.Empty(Context.Locations.Where(l => l.ElectionGuid == ElectionGuid));
+    }
+
+    [Fact]
+    public async Task RemoveIfNoBallotsAsync_KeepsLocationWhenItHasBallots()
+    {
+        var location = await OnlineLocationHelper.EnsureExistsAsync(Context, ElectionGuid);
+        Context.Ballots.Add(new Ballot
+        {
+            BallotGuid = Guid.NewGuid(),
+            LocationGuid = location.LocationGuid,
+            ComputerCode = ComputerCodeHelper.Online,
+            BallotNumAtComputer = 1,
+            StatusCode = BallotStatus.Ok,
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        await OnlineLocationHelper.RemoveIfNoBallotsAsync(Context, ElectionGuid);
+
+        Assert.Single(Context.Locations.Where(l => l.ElectionGuid == ElectionGuid));
+    }
+
+    [Fact]
+    public async Task SyncAsync_Enabled_Creates_Disabled_RemovesWhenEmpty()
+    {
+        await OnlineLocationHelper.SyncAsync(Context, ElectionGuid, useOnlineVoting: true);
+        Assert.Single(Context.Locations);
+
+        await OnlineLocationHelper.SyncAsync(Context, ElectionGuid, useOnlineVoting: false);
+        Assert.Empty(Context.Locations);
+    }
+}

--- a/Backend.Tests/UnitTests/Helpers/OnlineLocationHelperTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/OnlineLocationHelperTests.cs
@@ -33,17 +33,17 @@ public class OnlineLocationHelperTests : ServiceTestBase
     }
 
     [Fact]
-    public async Task RemoveIfNoBallotsAsync_DeletesWhenEmpty()
+    public async Task RemoveIfUnusedAsync_DeletesWhenEmpty()
     {
         await OnlineLocationHelper.EnsureExistsAsync(Context, ElectionGuid);
 
-        await OnlineLocationHelper.RemoveIfNoBallotsAsync(Context, ElectionGuid);
+        await OnlineLocationHelper.RemoveIfUnusedAsync(Context, ElectionGuid);
 
         Assert.Empty(Context.Locations.Where(l => l.ElectionGuid == ElectionGuid));
     }
 
     [Fact]
-    public async Task RemoveIfNoBallotsAsync_KeepsLocationWhenItHasBallots()
+    public async Task RemoveIfUnusedAsync_KeepsLocationWhenItHasBallots()
     {
         var location = await OnlineLocationHelper.EnsureExistsAsync(Context, ElectionGuid);
         Context.Ballots.Add(new Ballot
@@ -57,9 +57,29 @@ public class OnlineLocationHelperTests : ServiceTestBase
         });
         await Context.SaveChangesAsync();
 
-        await OnlineLocationHelper.RemoveIfNoBallotsAsync(Context, ElectionGuid);
+        await OnlineLocationHelper.RemoveIfUnusedAsync(Context, ElectionGuid);
 
         Assert.Single(Context.Locations.Where(l => l.ElectionGuid == ElectionGuid));
+    }
+
+    [Fact]
+    public async Task RemoveIfUnusedAsync_KeepsLocationWhenItHasComputers()
+    {
+        var location = await OnlineLocationHelper.EnsureExistsAsync(Context, ElectionGuid);
+        Context.Computers.Add(new Computer
+        {
+            ElectionGuid = ElectionGuid,
+            LocationGuid = location.LocationGuid,
+            ComputerGuid = Guid.NewGuid(),
+            ComputerCode = "A1"
+        });
+        await Context.SaveChangesAsync();
+
+        await OnlineLocationHelper.RemoveIfUnusedAsync(Context, ElectionGuid);
+        await OnlineLocationHelper.SyncAsync(Context, ElectionGuid, useOnlineVoting: false);
+
+        Assert.Single(Context.Locations.Where(l => l.ElectionGuid == ElectionGuid));
+        Assert.Empty(Context.Ballots.Where(b => b.LocationGuid == location.LocationGuid));
     }
 
     [Fact]

--- a/Backend.Tests/UnitTests/Helpers/StartupCommandLineTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/StartupCommandLineTests.cs
@@ -1,0 +1,39 @@
+using Backend.Helpers;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class StartupCommandLineTests
+{
+    [Fact]
+    public void ExitAfterStart_false_when_absent()
+    {
+        Assert.False(StartupCommandLine.ExitAfterStart([]));
+        Assert.False(StartupCommandLine.ExitAfterStart(["--skip-database"]));
+    }
+
+    [Fact]
+    public void ExitAfterStart_true_when_present()
+    {
+        Assert.True(StartupCommandLine.ExitAfterStart(["--exit-after-start"]));
+        Assert.True(StartupCommandLine.ExitAfterStart(["--urls", "http://localhost:5016", "--exit-after-start"]));
+    }
+
+    [Fact]
+    public void SkipDatabase_true_when_skip_database_flag_present()
+    {
+        Assert.True(StartupCommandLine.SkipDatabase(["--skip-database"]));
+    }
+
+    [Fact]
+    public void SkipDatabase_true_when_exit_after_start_is_present()
+    {
+        Assert.True(StartupCommandLine.SkipDatabase(["--exit-after-start"]));
+    }
+
+    [Fact]
+    public void SkipDatabase_false_when_neither_flag_present()
+    {
+        Assert.False(StartupCommandLine.SkipDatabase([]));
+        Assert.False(StartupCommandLine.SkipDatabase(["--urls", "http://localhost:5016"]));
+    }
+}

--- a/Backend.Tests/UnitTests/Services/BallotServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/BallotServiceTests.cs
@@ -59,6 +59,121 @@ public class BallotServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task CreateBallotAsync_UsesRequestedLocation_WhenOnlineLocationExistsFirst()
+    {
+        var onlineLocationGuid = Guid.NewGuid();
+        var hallLocationGuid = Guid.NewGuid();
+        Context.Locations.Add(new Location
+        {
+            RowId = 2,
+            LocationGuid = onlineLocationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Online",
+            LocationTypeCode = nameof(LocationType.Online),
+            SortOrder = 999
+        });
+        Context.Locations.Add(new Location
+        {
+            RowId = 3,
+            LocationGuid = hallLocationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Main Hall"
+        });
+        await Context.SaveChangesAsync();
+
+        var result = await _service.CreateBallotAsync(new CreateBallotDto
+        {
+            ElectionGuid = ElectionGuid,
+            LocationGuid = hallLocationGuid,
+            ComputerCode = "A",
+            Teller1 = "Alice"
+        });
+
+        Assert.Equal(hallLocationGuid, result.LocationGuid);
+        Assert.Equal("Main Hall", result.LocationName);
+        Assert.Equal("A", result.ComputerCode);
+        Assert.Equal(hallLocationGuid, Context.Ballots.Single(b => b.BallotGuid == result.BallotGuid).LocationGuid);
+    }
+
+    [Fact]
+    public async Task CreateBallotAsync_OnlineLocation_Throws()
+    {
+        var onlineLocationGuid = Guid.NewGuid();
+        Context.Locations.Add(new Location
+        {
+            RowId = 2,
+            LocationGuid = onlineLocationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Online",
+            LocationTypeCode = nameof(LocationType.Online)
+        });
+        await Context.SaveChangesAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreateBallotAsync(new CreateBallotDto
+            {
+                ElectionGuid = ElectionGuid,
+                LocationGuid = onlineLocationGuid,
+                ComputerCode = "A",
+                Teller1 = "Alice"
+            }));
+
+        Assert.Equal("Ballots cannot be created at the Online location", ex.Message);
+        Assert.Equal(1, Context.Ballots.Count());
+    }
+
+    [Fact]
+    public async Task CreateBallotAsync_UnknownLocation_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreateBallotAsync(new CreateBallotDto
+            {
+                ElectionGuid = ElectionGuid,
+                LocationGuid = Guid.NewGuid(),
+                ComputerCode = "A",
+                Teller1 = "Alice"
+            }));
+
+        Assert.Equal("Location not found", ex.Message);
+        Assert.Equal(1, Context.Ballots.Count());
+    }
+
+    [Fact]
+    public async Task CreateBallotAsync_LocationFromAnotherElection_Throws()
+    {
+        var otherElectionGuid = Guid.NewGuid();
+        var otherLocationGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            RowId = 2,
+            ElectionGuid = otherElectionGuid,
+            Name = "Other Election",
+            NumberToElect = 3,
+            ElectionType = "Loc",
+            RowVersion = new byte[8]
+        });
+        Context.Locations.Add(new Location
+        {
+            RowId = 2,
+            LocationGuid = otherLocationGuid,
+            ElectionGuid = otherElectionGuid,
+            Name = "Other Hall"
+        });
+        await Context.SaveChangesAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreateBallotAsync(new CreateBallotDto
+            {
+                ElectionGuid = ElectionGuid,
+                LocationGuid = otherLocationGuid,
+                ComputerCode = "A",
+                Teller1 = "Alice"
+            }));
+
+        Assert.Equal("Location not found", ex.Message);
+    }
+
+    [Fact]
     public async Task UpdateBallotAsync_ReviewBallotWithoutClearNeedsReview_KeepsReview()
     {
         var result = await _service.UpdateBallotAsync(BallotGuid, new UpdateBallotDto

--- a/Backend.Tests/UnitTests/Validators/CreateBallotDtoValidatorTests.cs
+++ b/Backend.Tests/UnitTests/Validators/CreateBallotDtoValidatorTests.cs
@@ -1,0 +1,36 @@
+using Backend.DTOs.Ballots;
+using Backend.Validators;
+
+namespace Backend.Tests.UnitTests.Validators;
+
+public class CreateBallotDtoValidatorTests
+{
+    private readonly CreateBallotDtoValidator _validator = new();
+
+    [Fact]
+    public void ValidDto_Passes()
+    {
+        var result = _validator.Validate(new CreateBallotDto
+        {
+            ElectionGuid = Guid.NewGuid(),
+            LocationGuid = Guid.NewGuid(),
+            ComputerCode = "A",
+            Teller1 = "Alice"
+        });
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void EmptyLocationGuid_Fails()
+    {
+        var result = _validator.Validate(new CreateBallotDto
+        {
+            ElectionGuid = Guid.NewGuid(),
+            LocationGuid = Guid.Empty,
+            ComputerCode = "A"
+        });
+
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Location GUID is required");
+    }
+}

--- a/backend/Controllers/LocationsController.cs
+++ b/backend/Controllers/LocationsController.cs
@@ -159,14 +159,21 @@ public class LocationsController : ControllerBase
             return BadRequest(ApiResponse<bool>.ErrorResponse("Location does not belong to the specified election"));
         }
 
-        var result = await _locationService.DeleteLocationAsync(locationGuid);
-
-        if (!result)
+        try
         {
-            return NotFound(ApiResponse<bool>.ErrorResponse("Location not found"));
-        }
+            var result = await _locationService.DeleteLocationAsync(locationGuid);
 
-        return Ok(ApiResponse<bool>.SuccessResponse(true, "Location deleted successfully"));
+            if (!result)
+            {
+                return NotFound(ApiResponse<bool>.ErrorResponse("Location not found"));
+            }
+
+            return Ok(ApiResponse<bool>.SuccessResponse(true, "Location deleted successfully"));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ApiResponse<bool>.ErrorResponse(ex.Message));
+        }
     }
 
 }

--- a/backend/DTOs/Ballots/CreateBallotDto.cs
+++ b/backend/DTOs/Ballots/CreateBallotDto.cs
@@ -13,6 +13,11 @@ public class CreateBallotDto
     public Guid ElectionGuid { get; set; }
 
     /// <summary>
+    /// The location selected in the teller's browser. The Online location is rejected.
+    /// </summary>
+    public Guid LocationGuid { get; set; }
+
+    /// <summary>
     /// The code of the computer creating this ballot.
     /// </summary>
     public string ComputerCode { get; set; } = null!;

--- a/backend/EF/Data/DbSeeder.cs
+++ b/backend/EF/Data/DbSeeder.cs
@@ -34,6 +34,7 @@ public static partial class DbSeeder
             await SeedOnlineVotingTestElectionsAsync(context, logger);
             await EnsureOnlineVotersForSeededPhonesAsync(context);
             await context.SaveChangesAsync();
+            await EnsureOnlineLocationsForEnabledElectionsAsync(context);
             return;
         }
 
@@ -46,9 +47,22 @@ public static partial class DbSeeder
         await SeedOnlineVotingTestElectionsAsync(context, logger);
         await SeedLogsAsync(context, logger);
         await EnsureOnlineVotersForSeededPhonesAsync(context);
-
         await context.SaveChangesAsync();
+        await EnsureOnlineLocationsForEnabledElectionsAsync(context);
         logger.LogInformation("Database seeding complete");
+    }
+
+    private static async Task EnsureOnlineLocationsForEnabledElectionsAsync(MainDbContext context)
+    {
+        var enabledElectionGuids = await context.Elections
+            .Where(e => e.UseOnlineVoting)
+            .Select(e => e.ElectionGuid)
+            .ToListAsync();
+
+        foreach (var electionGuid in enabledElectionGuids)
+        {
+            await OnlineLocationHelper.EnsureExistsAsync(context, electionGuid);
+        }
     }
 
     /// <summary>

--- a/backend/Helpers/OnlineLocationHelper.cs
+++ b/backend/Helpers/OnlineLocationHelper.cs
@@ -6,7 +6,8 @@ using Microsoft.EntityFrameworkCore;
 namespace Backend.Helpers;
 
 /// <summary>
-/// Ensures the reserved Online location exists only while online voting is enabled.
+/// Ensures the reserved Online location exists when online voting is enabled.
+/// Disable keeps the row when it still has ballots or computers; unused rows are removed.
 /// Identity is LocationTypeCode, not the display name.
 /// </summary>
 public static class OnlineLocationHelper
@@ -38,7 +39,7 @@ public static class OnlineLocationHelper
         return location;
     }
 
-    public static async Task RemoveIfNoBallotsAsync(
+    public static async Task RemoveIfUnusedAsync(
         MainDbContext context,
         Guid electionGuid,
         CancellationToken cancellationToken = default)
@@ -81,7 +82,7 @@ public static class OnlineLocationHelper
             return;
         }
 
-        await RemoveIfNoBallotsAsync(context, electionGuid, cancellationToken);
+        await RemoveIfUnusedAsync(context, electionGuid, cancellationToken);
     }
 
     private static Task<Location?> FindOnlineLocationAsync(

--- a/backend/Helpers/OnlineLocationHelper.cs
+++ b/backend/Helpers/OnlineLocationHelper.cs
@@ -1,0 +1,94 @@
+using Backend.Context;
+using Backend.Entities;
+using Backend.Enumerations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Helpers;
+
+/// <summary>
+/// Ensures the reserved Online location exists only while online voting is enabled.
+/// Identity is LocationTypeCode, not the display name.
+/// </summary>
+public static class OnlineLocationHelper
+{
+    public static async Task<Location> EnsureExistsAsync(
+        MainDbContext context,
+        Guid electionGuid,
+        CancellationToken cancellationToken = default)
+    {
+        var location = await FindOnlineLocationAsync(context, electionGuid, cancellationToken);
+        if (location != null)
+        {
+            return location;
+        }
+
+        location = new Location
+        {
+            LocationGuid = Guid.NewGuid(),
+            ElectionGuid = electionGuid,
+            // Fallback for reports; UI labels this location from LocationType, not Name.
+            Name = nameof(LocationType.Online),
+            SortOrder = 999,
+            LocationTypeCode = nameof(LocationType.Online),
+            LocationTallyStatus = LocationTallyStatus.NotStarted,
+            BallotsCollected = 0
+        };
+        context.Locations.Add(location);
+        await context.SaveChangesAsync(cancellationToken);
+        return location;
+    }
+
+    public static async Task RemoveIfNoBallotsAsync(
+        MainDbContext context,
+        Guid electionGuid,
+        CancellationToken cancellationToken = default)
+    {
+        var location = await FindOnlineLocationAsync(context, electionGuid, cancellationToken);
+        if (location == null)
+        {
+            return;
+        }
+
+        var hasBallots = await context.Ballots.AnyAsync(
+            b => b.LocationGuid == location.LocationGuid,
+            cancellationToken);
+        if (hasBallots)
+        {
+            return;
+        }
+
+        var hasComputers = await context.Computers.AnyAsync(
+            c => c.LocationGuid == location.LocationGuid,
+            cancellationToken);
+        if (hasComputers)
+        {
+            return;
+        }
+
+        context.Locations.Remove(location);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public static async Task SyncAsync(
+        MainDbContext context,
+        Guid electionGuid,
+        bool useOnlineVoting,
+        CancellationToken cancellationToken = default)
+    {
+        if (useOnlineVoting)
+        {
+            await EnsureExistsAsync(context, electionGuid, cancellationToken);
+            return;
+        }
+
+        await RemoveIfNoBallotsAsync(context, electionGuid, cancellationToken);
+    }
+
+    private static Task<Location?> FindOnlineLocationAsync(
+        MainDbContext context,
+        Guid electionGuid,
+        CancellationToken cancellationToken) =>
+        context.Locations.FirstOrDefaultAsync(
+            l => l.ElectionGuid == electionGuid && l.LocationTypeCode == nameof(LocationType.Online),
+            cancellationToken);
+}

--- a/backend/Helpers/StartupCommandLine.cs
+++ b/backend/Helpers/StartupCommandLine.cs
@@ -1,0 +1,20 @@
+namespace Backend.Helpers;
+
+/// <summary>
+/// Command-line flags for one-shot startup (OpenAPI write without SQL or a listening host).
+/// </summary>
+public static class StartupCommandLine
+{
+    public const string ExitAfterStartArgument = "--exit-after-start";
+    public const string SkipDatabaseArgument = "--skip-database";
+
+    public static bool ExitAfterStart(IEnumerable<string> arguments) =>
+        arguments.Contains(ExitAfterStartArgument);
+
+    /// <summary>
+    /// True when --skip-database is present, or when --exit-after-start is present
+    /// so OpenAPI regen does not need SQL.
+    /// </summary>
+    public static bool SkipDatabase(IEnumerable<string> arguments) =>
+        arguments.Contains(SkipDatabaseArgument) || ExitAfterStart(arguments);
+}

--- a/backend/Program.AppPipeline.cs
+++ b/backend/Program.AppPipeline.cs
@@ -24,9 +24,14 @@ public static class ProgramAppPipeline
         IConfiguration configuration,
         bool isDevelopment,
         bool isTesting,
-        string siteType)
+        string siteType,
+        bool skipDatabase = false)
     {
-        var migrateOnStartup = configuration.GetValue("Database:MigrateOnStartup", false);
+        var migrateOnStartup = !skipDatabase && configuration.GetValue("Database:MigrateOnStartup", false);
+        if (skipDatabase)
+        {
+            Log.Information("Skipping database migrate/seed");
+        }
         if (migrateOnStartup)
         {
             Log.Information("Migrating the database on startup as configured");
@@ -38,7 +43,7 @@ public static class ProgramAppPipeline
             await context.Database.MigrateAsync();
         }
 
-        var seedOnStartup = configuration.GetValue("Database:SeedOnStartup", false);
+        var seedOnStartup = !skipDatabase && configuration.GetValue("Database:SeedOnStartup", false);
         if (seedOnStartup)
         {
             if (!migrateOnStartup)
@@ -62,7 +67,7 @@ public static class ProgramAppPipeline
             await DbSeeder.SeedAsync(context, userManager, roleManager, logger);
         }
 
-        // Send startup notification to remote log
+        if (!skipDatabase)
         {
             using var scope = app.Services.CreateScope();
             var remoteLogService = scope.ServiceProvider.GetRequiredService<IRemoteLogService>();

--- a/backend/Program.ServiceRegistration.cs
+++ b/backend/Program.ServiceRegistration.cs
@@ -63,11 +63,15 @@ public static class ProgramServiceRegistration
         services.AddScoped<ISecurityAuditService, SecurityAuditService>();
     }
 
-    public static void RegisterBackgroundServices(IServiceCollection services, bool isTesting)
+    public static void RegisterBackgroundServices(
+        IServiceCollection services,
+        bool isTesting,
+        bool skipDatabase = false)
     {
         services.AddSingleton<RateLimitStore>();
 
-        if (isTesting) // don't register the real broadcast service during testing, to avoid interference with tests and allow testing of the broadcast mechanism itself
+        // Testing and --skip-database must not start hosted services that open SQL.
+        if (isTesting || skipDatabase)
         {
             services.AddSingleton<IVoteCountBroadcastService, NullVoteCountBroadcastService>();
             return;

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -225,4 +225,15 @@ Log.Logger = loggerConfiguration
 
 await ProgramAppPipeline.ConfigureApp(app, builder.Configuration, isDevelopment, isTesting, siteType);
 
+// `dotnet run -- --exit-after-start` writes the OpenAPI spec (Development) then stops.
+if (args.Contains("--exit-after-start"))
+{
+    var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+    lifetime.ApplicationStarted.Register(() =>
+    {
+        Log.Information("Startup completed. Stopping.");
+        lifetime.StopApplication();
+    });
+}
+
 await app.RunAsync();

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -24,6 +24,8 @@ var machineName = Environment.MachineName;
 var isDevelopment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development";
 var isTesting = AppDomain.CurrentDomain.GetAssemblies().Any(a => a.GetName().Name == "testhost");
 var siteType = Environment.CommandLine.DetermineSiteType();
+var exitAfterStart = StartupCommandLine.ExitAfterStart(args);
+var skipDatabase = StartupCommandLine.SkipDatabase(args);
 
 var nonTestMode = isDevelopment ? "DEVELOPMENT" : "PRODUCTION";
 var siteMode = isTesting ? "TESTING" : nonTestMode;
@@ -80,27 +82,40 @@ void ConfigureServices(WebApplicationBuilder builder)
         var connectionStringName = "TallyJ4";
         var connectionString = builderConfiguration.GetConnectionString(connectionStringName);
 
-        var regexToRemovePw = new System.Text.RegularExpressions.Regex("(Password|pwd)=[^;]*;");
-        Log.Information(
-          "Connection string {Name}: {ConnectionString}",
-          connectionStringName,
-          regexToRemovePw.Replace(connectionString ?? "(Empty)", "---;")
-        );
-        if (connectionString == null)
+        if (skipDatabase)
         {
-            Log.Fatal(
-              "Connection string {Name} is not set. Check your appsettings.json configuration.",
-              connectionStringName
-            );
-            Environment.Exit(1);
+            Log.Information("Skipping SQL Server connections");
+            // Identity and other services still need MainDbContext registered; it is never opened.
+            connectionString ??= "Server=127.0.0.1;Database=unused;TrustServerCertificate=True";
+            services.AddDbContext<MainDbContext>(connectionStringName, connectionString);
+            services.AddDbContext<DataProtectionDbContext>(options =>
+                options.UseSqlServer(connectionString));
+            services.AddDataProtection();
         }
+        else
+        {
+            var regexToRemovePw = new System.Text.RegularExpressions.Regex("(Password|pwd)=[^;]*;");
+            Log.Information(
+              "Connection string {Name}: {ConnectionString}",
+              connectionStringName,
+              regexToRemovePw.Replace(connectionString ?? "(Empty)", "---;")
+            );
+            if (connectionString == null)
+            {
+                Log.Fatal(
+                  "Connection string {Name} is not set. Check your appsettings.json configuration.",
+                  connectionStringName
+                );
+                Environment.Exit(1);
+            }
 
-        services.AddDbContext<MainDbContext>(connectionStringName, connectionString);
-        services.AddDbContext<DataProtectionDbContext>(options =>
-            options.UseSqlServer(connectionString));
+            services.AddDbContext<MainDbContext>(connectionStringName, connectionString);
+            services.AddDbContext<DataProtectionDbContext>(options =>
+                options.UseSqlServer(connectionString));
 
-        services.AddDataProtection()
-            .PersistKeysToDbContext<DataProtectionDbContext>();
+            services.AddDataProtection()
+                .PersistKeysToDbContext<DataProtectionDbContext>();
+        }
     }
 
     services.AddCors(options =>
@@ -170,7 +185,7 @@ void ConfigureServices(WebApplicationBuilder builder)
 
     ProgramServiceRegistration.RegisterApplicationServices(services);
     ProgramServiceRegistration.RegisterAuthServices(services);
-    ProgramServiceRegistration.RegisterBackgroundServices(services, isTesting);
+    ProgramServiceRegistration.RegisterBackgroundServices(services, isTesting, skipDatabase);
 
     services.AddSignalR();
     services.AddSingleton<ISignalRNotificationService, SignalRNotificationService>();
@@ -223,17 +238,14 @@ Log.Logger = loggerConfiguration
     )
     .CreateLogger();
 
-await ProgramAppPipeline.ConfigureApp(app, builder.Configuration, isDevelopment, isTesting, siteType);
+await ProgramAppPipeline.ConfigureApp(app, builder.Configuration, isDevelopment, isTesting, siteType, skipDatabase);
 
-// `dotnet run -- --exit-after-start` writes the OpenAPI spec (Development) then stops.
-if (args.Contains("--exit-after-start"))
+// `dotnet run -- --exit-after-start` writes the OpenAPI spec (Development) then stops
+// without opening a SQL connection or listening.
+if (exitAfterStart)
 {
-    var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
-    lifetime.ApplicationStarted.Register(() =>
-    {
-        Log.Information("Startup completed. Stopping.");
-        lifetime.StopApplication();
-    });
+    Log.Information("Startup completed. Stopping.");
+    return;
 }
 
 await app.RunAsync();

--- a/backend/README.md
+++ b/backend/README.md
@@ -62,14 +62,14 @@ dotnet ef database update
 dotnet run
 ```
 
-To write the OpenAPI spec and exit (no long-running server):
+To write the OpenAPI spec and exit (no database, no long-running server):
 
 ```bash
 cd backend
 dotnet run -- --exit-after-start
 ```
 
-The `--` passes `--exit-after-start` to the app. The http launch profile sets `ASPNETCORE_ENVIRONMENT=Development`, which is required for the spec write.
+The `--` passes `--exit-after-start` to the app. That flag also skips SQL (`--skip-database` is implied). The http launch profile sets `ASPNETCORE_ENVIRONMENT=Development`, which is required for the spec write.
 
 Development URLs from `Properties/launchSettings.json`:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -69,7 +69,7 @@ cd backend
 dotnet run -- --exit-after-start
 ```
 
-The `--` passes `--exit-after-start` to the app. That flag also skips SQL (`--skip-database` is implied). The http launch profile sets `ASPNETCORE_ENVIRONMENT=Development`, which is required for the spec write.
+The `--` passes `--exit-after-start` to the app. That flag also skips SQL (`--skip-database` is implied). The process does not listen, so it can run while `dotnet watch` is already serving. The http launch profile sets `ASPNETCORE_ENVIRONMENT=Development`, which is required for the spec write.
 
 Development URLs from `Properties/launchSettings.json`:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -62,6 +62,15 @@ dotnet ef database update
 dotnet run
 ```
 
+To write the OpenAPI spec and exit (no long-running server):
+
+```bash
+cd backend
+dotnet run -- --exit-after-start
+```
+
+The `--` passes `--exit-after-start` to the app. The http launch profile sets `ASPNETCORE_ENVIRONMENT=Development`, which is required for the spec write.
+
 Development URLs from `Properties/launchSettings.json`:
 
 - `http://localhost:5016`

--- a/backend/README.md
+++ b/backend/README.md
@@ -69,7 +69,7 @@ cd backend
 dotnet run -- --exit-after-start
 ```
 
-The `--` passes `--exit-after-start` to the app. That flag also skips SQL (`--skip-database` is implied). The process does not listen, so it can run while `dotnet watch` is already serving. The http launch profile sets `ASPNETCORE_ENVIRONMENT=Development`, which is required for the spec write.
+The `--` passes `--exit-after-start` to the app. That flag also skips SQL (`--skip-database` is implied). The process does not listen, so it can run while `dotnet watch` is already serving. `dotnet watch` never rewrites the OpenAPI spec — that happens only on a fresh start. The http launch profile sets `ASPNETCORE_ENVIRONMENT=Development`, which is required for the spec write.
 
 Development URLs from `Properties/launchSettings.json`:
 

--- a/backend/Services/BallotService.cs
+++ b/backend/Services/BallotService.cs
@@ -92,38 +92,29 @@ public class BallotService : IBallotService
     }
 
     /// <summary>
-    /// Creates a new ballot for an election.
+    /// Creates a new teller-entered ballot at the location selected in the browser.
     /// </summary>
     /// <param name="createDto">The data transfer object containing ballot creation information.</param>
     /// <returns>A BallotDto representing the created ballot.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the election is not found.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the location is missing, not in the election, or is the Online location
+    /// (reserved for voter-initiated ballots).
+    /// </exception>
     public async Task<BallotDto> CreateBallotAsync(CreateBallotDto createDto)
     {
-        // Find or create a default location for the election
-        var location = await _context.Locations.FirstOrDefaultAsync(l => l.ElectionGuid == createDto.ElectionGuid);
+        var location = await _context.Locations.FirstOrDefaultAsync(l =>
+            l.LocationGuid == createDto.LocationGuid
+            && l.ElectionGuid == createDto.ElectionGuid);
 
         if (location == null)
         {
-            // For testing purposes, create a default location if none exists
-            // In production, locations should be created through proper setup
-            var election = await _context.Elections.FirstOrDefaultAsync(e => e.ElectionGuid == createDto.ElectionGuid);
-            if (election != null)
-            {
-                location = new Location
-                {
-                    LocationGuid = Guid.NewGuid(),
-                    ElectionGuid = election.ElectionGuid,
-                    Name = "Default Location"
-                };
-                _context.Locations.Add(location);
-                await _context.SaveChangesAsync();
-                _logger.LogInformation("Created default location {LocationGuid} for election {ElectionGuid}",
-                    location.LocationGuid, election.ElectionGuid);
-            }
-            else
-            {
-                throw new InvalidOperationException($"Election with GUID '{createDto.ElectionGuid}' not found");
-            }
+            throw new InvalidOperationException("Location not found");
+        }
+
+        if (location.LocationTypeEnum == LocationType.Online)
+        {
+            throw new InvalidOperationException(
+                "Ballots cannot be created at the Online location");
         }
 
         var nextBallotNum = await _context.Ballots

--- a/backend/Services/ElectionService.cs
+++ b/backend/Services/ElectionService.cs
@@ -200,6 +200,8 @@ public class ElectionService : IElectionService
             await _context.SaveChangesAsync();
         }
 
+        await OnlineLocationHelper.SyncAsync(_context, election.ElectionGuid, election.UseOnlineVoting);
+
         _logger.LogInformation("Created election {ElectionGuid} - {Name}", election.ElectionGuid, election.Name);
 
         return await GetElectionByGuidAsync(election.ElectionGuid) ?? MapToElectionDto(election);
@@ -269,6 +271,11 @@ public class ElectionService : IElectionService
 
         foreach (var location in sourceLocations)
         {
+            if (location.LocationTypeEnum == LocationType.Online)
+            {
+                continue;
+            }
+
             _context.Locations.Add(CopyLocationForElection(location, copy.ElectionGuid));
         }
 
@@ -359,6 +366,7 @@ public class ElectionService : IElectionService
             election.ElectionStage = ElectionStage.SettingUp;
 
             await _context.SaveChangesAsync();
+            await OnlineLocationHelper.SyncAsync(_context, electionGuid, useOnlineVoting: false);
             if (transaction is not null)
             {
                 await transaction.CommitAsync();
@@ -439,6 +447,7 @@ public class ElectionService : IElectionService
         updateDto.CopyMatchingPropertiesTo(election, ignoreNulls: true);
         ElectionTellerAccessHelper.ApplyListForPublicFlag(election, listForPublic);
         await _context.SaveChangesAsync();
+        await OnlineLocationHelper.SyncAsync(_context, electionGuid, election.UseOnlineVoting);
 
         _logger.LogInformation("Updated election {ElectionGuid}", electionGuid);
 

--- a/backend/Services/LocationService.cs
+++ b/backend/Services/LocationService.cs
@@ -160,6 +160,12 @@ public class LocationService : ILocationService
             return false;
         }
 
+        if (location.LocationTypeEnum == LocationType.Online)
+        {
+            throw new InvalidOperationException(
+                "The Online location is managed by online voting setup and cannot be deleted.");
+        }
+
         _context.Locations.Remove(location);
         await _context.SaveChangesAsync();
 

--- a/backend/Services/OnlineVotingService.Ballot.cs
+++ b/backend/Services/OnlineVotingService.Ballot.cs
@@ -74,23 +74,7 @@ public partial class OnlineVotingService
                 }
             }
 
-            var location = await _context.Locations
-                .FirstOrDefaultAsync(l => l.ElectionGuid == dto.ElectionGuid && l.LocationTypeCode == nameof(LocationType.Online));
-
-            if (location == null)
-            {
-                location = new Location
-                {
-                    LocationGuid = Guid.NewGuid(),
-                    ElectionGuid = dto.ElectionGuid,
-                    Name = "Online",
-                    ContactInfo = "Online voting",
-                    SortOrder = 999,
-                    LocationTypeCode = nameof(LocationType.Online)
-                };
-                _context.Locations.Add(location);
-                await _context.SaveChangesAsync();
-            }
+            var location = await OnlineLocationHelper.EnsureExistsAsync(_context, dto.ElectionGuid);
 
             var nextBallotNum = await SpecialBallotNumbering.RepairOnlineAndGetNextAsync(
                 _context, location.LocationGuid);

--- a/backend/Validators/CreateBallotDtoValidator.cs
+++ b/backend/Validators/CreateBallotDtoValidator.cs
@@ -5,7 +5,7 @@ namespace Backend.Validators;
 
 /// <summary>
 /// Validator for CreateBallotDto that enforces ballot creation requirements.
-/// Validates election GUID presence and computer code format.
+/// Validates election GUID, location GUID, and computer code format.
 /// </summary>
 public class CreateBallotDtoValidator : AbstractValidator<CreateBallotDto>
 {
@@ -17,6 +17,10 @@ public class CreateBallotDtoValidator : AbstractValidator<CreateBallotDto>
         RuleFor(x => x.ElectionGuid)
             .NotEmpty()
             .WithMessage("Election GUID is required");
+
+        RuleFor(x => x.LocationGuid)
+            .NotEmpty()
+            .WithMessage("Location GUID is required");
 
         RuleFor(x => x.ComputerCode)
             .NotEmpty()

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -26,6 +26,19 @@ When voters type names (online random/both modes) or an import cannot match a na
 
 **Reason:** tellers already know this workflow from v3; shortening is how they widen a misspelled search without retyping.
 
+## Teller-created ballots stay off the Online location
+
+**Status:** active  
+**Evidence:** confirmed (issue #287; maintainer)
+
+The Online location is only for voter-initiated ballots (computer code `OL`). A teller starting a paper ballot must store it at the location currently selected in that browser. If that selection is Online, starting is blocked.
+
+Create used to ignore the requested location and take `Locations.FirstOrDefault` for the election, so new teller ballots could land on Online.
+
+**Rejected alternative:** allow tellers to create ballots at the Online location (the original #287 wording). Mixing teller-entered paper ballots into the voter-submitted set hides which ballots came from voters.
+
+**Reason:** the browser location is the teller's workstation context; Online is not a paper station.
+
 ## Online and imported ballot codes
 
 **Status:** active  

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -45,6 +45,10 @@ Older submit code (and the locations form) could store a row *named* â€œOnlineâ€
 
 **Reason:** the browser location is the teller's workstation context; the Online *type* is not a paper station.
 
+The typed Online location is added when setup enables online voting, and removed if online voting is turned off and that location has no ballots (or computers). Voter submit still ensures the row exists if setup enabled voting but the location is missing.
+
+**Rejected alternative:** create the location only on the first voter ballot. Tellers would not see it in the location list until a vote arrived, and disabling unused online voting would leave an empty reserved location behind.
+
 ## Online and imported ballot codes
 
 **Status:** active  

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -31,13 +31,19 @@ When voters type names (online random/both modes) or an import cannot match a na
 **Status:** active  
 **Evidence:** confirmed (issue #287; maintainer)
 
-The Online location is only for voter-initiated ballots (computer code `OL`). A teller starting a paper ballot must store it at the location currently selected in that browser. If that selection is Online, starting is blocked.
+The reserved location is only for voter-initiated ballots (computer code `OL`). Identify it by `LocationTypeCode` / `LocationType.Online`, never by the display name. Names are user-facing and translated; the English word “Online” is not a stable key.
 
-Create used to ignore the requested location and take `Locations.FirstOrDefault` for the election, so new teller ballots could land on Online.
+A teller starting a paper ballot must store it at the location currently selected in that browser. If that selection has type Online, starting is blocked.
 
-**Rejected alternative:** allow tellers to create ballots at the Online location (the original #287 wording). Mixing teller-entered paper ballots into the voter-submitted set hides which ballots came from voters.
+Create used to ignore the requested location and take `Locations.FirstOrDefault` for the election, so new teller ballots could land on the reserved location.
 
-**Reason:** the browser location is the teller's workstation context; Online is not a paper station.
+Older submit code (and the locations form) could store a row *named* “Online” with a null type. `LocationTypeEnum` treats a missing code as Manual, so that row is a normal paper location as far as create-ballot is concerned.
+
+**Rejected alternative:** allow tellers to create ballots at the Online-typed location (the original #287 wording). Mixing teller-entered paper ballots into the voter-submitted set hides which ballots came from voters.
+
+**Rejected alternative:** treat a location named “Online” as reserved. The product is multilingual; English names cannot be used as identifiers.
+
+**Reason:** the browser location is the teller's workstation context; the Online *type* is not a paper station.
 
 ## Online and imported ballot codes
 

--- a/frontend/openApi/tallyj.json
+++ b/frontend/openApi/tallyj.json
@@ -8764,6 +8764,10 @@
             "type": "string",
             "format": "uuid"
           },
+          "locationGuid": {
+            "type": "string",
+            "format": "uuid"
+          },
           "computerCode": {
             "type": "string",
             "nullable": true

--- a/frontend/src/api/gen/configService/schemas.gen.ts
+++ b/frontend/src/api/gen/configService/schemas.gen.ts
@@ -1389,6 +1389,10 @@ export const Ballots_CreateBallotDtoSchema = {
             type: 'string',
             format: 'uuid'
         },
+        locationGuid: {
+            type: 'string',
+            format: 'uuid'
+        },
         computerCode: {
             type: 'string',
             nullable: true

--- a/frontend/src/api/gen/configService/types.gen.ts
+++ b/frontend/src/api/gen/configService/types.gen.ts
@@ -427,6 +427,7 @@ export type BallotsBallotDto = {
 
 export type BallotsCreateBallotDto = {
     electionGuid?: string;
+    locationGuid?: string;
     computerCode?: string | null;
     teller1?: string | null;
     teller2?: string | null;

--- a/frontend/src/components/ballots/BallotViewFilterSelect.vue
+++ b/frontend/src/components/ballots/BallotViewFilterSelect.vue
@@ -12,6 +12,7 @@ import {
 import type { ComputerDto } from "@/types/Computer";
 import type { LocationDto } from "@/types/Location";
 import { formatComputerCodeLabel } from "@/utils/ballotDisplayCode";
+import { formatLocationLabel } from "@/utils/locationDisplay";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
@@ -39,7 +40,10 @@ const { t } = useI18n();
 
 const filterGroups = computed<BallotViewFilterGroup[]>(() =>
   buildBallotViewFilterGroups(
-    props.locations,
+    props.locations.map((location) => ({
+      ...location,
+      name: formatLocationLabel(t, location),
+    })),
     props.ballots,
     props.computersByLocation,
     props.ensureComputerCode,

--- a/frontend/src/components/ballots/InlineBallotEntry.vue
+++ b/frontend/src/components/ballots/InlineBallotEntry.vue
@@ -23,6 +23,7 @@ import {
 import {
   BALLOT_START_BLOCK_MESSAGE_KEY,
   getBallotStartBlockReason,
+  isOnlineLocationType,
   locationTypeForGuid,
   type BallotStartBlockReason,
 } from "@/utils/ballotStartRequirements";
@@ -81,6 +82,14 @@ const searchPanelRef = ref<InstanceType<typeof BallotPersonSearchPanel> | null>(
 );
 
 const canAddVotes = computed(() => props.hasKeyboardTeller !== false);
+const isOnlineLocationSelected = computed(() =>
+  isOnlineLocationType(
+    locationTypeForGuid(
+      locationStore.locations,
+      locationStore.selectedLocationGuid,
+    ),
+  ),
+);
 const isOnlineOrImported = computed(() =>
   isOnlineOrImportedComputerCode(props.ballot.computerCode),
 );
@@ -462,6 +471,12 @@ onMounted(async () => {
             type="primary"
             plain
             :loading="creatingNewBallot"
+            :disabled="isOnlineLocationSelected"
+            :title="
+              isOnlineLocationSelected
+                ? $t('ballots.onlineLocationNotAllowed')
+                : undefined
+            "
             @click="handleNewBallot"
           >
             <el-icon><Plus /></el-icon>

--- a/frontend/src/components/ballots/InlineBallotEntry.vue
+++ b/frontend/src/components/ballots/InlineBallotEntry.vue
@@ -23,6 +23,7 @@ import {
 import {
   BALLOT_START_BLOCK_MESSAGE_KEY,
   getBallotStartBlockReason,
+  locationTypeForGuid,
   type BallotStartBlockReason,
 } from "@/utils/ballotStartRequirements";
 import {
@@ -336,6 +337,10 @@ async function handleNewBallot() {
   const reason = getBallotStartBlockReason({
     computerCode: computerCode.value,
     locationGuid: locationStore.selectedLocationGuid,
+    locationType: locationTypeForGuid(
+      locationStore.locations,
+      locationStore.selectedLocationGuid,
+    ),
     teller1: getActiveTellers().teller1,
   });
   if (reason) {

--- a/frontend/src/components/ballots/__tests__/InlineBallotEntry.spec.ts
+++ b/frontend/src/components/ballots/__tests__/InlineBallotEntry.spec.ts
@@ -46,6 +46,8 @@ const mockT = (key: string, values?: Record<string, string | number>) => {
     "common.cancel": "Cancel",
     "ballots.computerCodeRequired": "Computer code required",
     "ballots.locationRequired": "Location is required",
+    "ballots.onlineLocationNotAllowed":
+      "Cannot start a ballot at the Online location",
     "ballots.tellerRequired": "Teller is required",
     "ballots.markNeedsReview": "Mark as Needs Review",
     "ballots.clearNeedsReview": "Clear Needs Review",
@@ -134,6 +136,10 @@ vi.mock("@/composables/useComputerCode", () => ({
 const { mockLocationStore } = vi.hoisted(() => ({
   mockLocationStore: {
     selectedLocationGuid: "location-1" as string | null,
+    locations: [
+      { locationGuid: "location-1", locationType: "Manual" as const },
+      { locationGuid: "location-online", locationType: "Online" as const },
+    ],
   },
 }));
 
@@ -240,6 +246,10 @@ describe("InlineBallotEntry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLocationStore.selectedLocationGuid = "location-1";
+    mockLocationStore.locations = [
+      { locationGuid: "location-1", locationType: "Manual" },
+      { locationGuid: "location-online", locationType: "Online" },
+    ];
     mockActiveTellers.teller1 = "Alice";
     mockActiveTellers.teller2 = "Bob";
     mockSearchablePeople = [
@@ -327,6 +337,35 @@ describe("InlineBallotEntry", () => {
     expect(mockCreateBallot).not.toHaveBeenCalled();
     expect(mockShowErrorMessage).toHaveBeenCalledWith("Location is required");
     expect(wrapper.emitted("ballot-start-blocked")?.[0]).toEqual(["location"]);
+  });
+
+  it("does not start another ballot when the selected location is Online", async () => {
+    mockLocationStore.selectedLocationGuid = "location-online";
+
+    const wrapper = mount(InlineBallotEntry, {
+      props: {
+        electionGuid: "election-123",
+        ballot: createMockBallot(),
+        requiredVotes: 9,
+      },
+      ...mountOptions,
+    });
+
+    await flushPromises();
+
+    const addBallotButton = wrapper
+      .findAllComponents(ElButton)
+      .find((button) => button.text().includes("Start another ballot"));
+    await addBallotButton!.trigger("click");
+    await flushPromises();
+
+    expect(mockCreateBallot).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).toHaveBeenCalledWith(
+      "Cannot start a ballot at the Online location",
+    );
+    expect(wrapper.emitted("ballot-start-blocked")?.[0]).toEqual([
+      "onlineLocation",
+    ]);
   });
 
   it("does not start another ballot when the main teller is unset", async () => {

--- a/frontend/src/components/ballots/__tests__/InlineBallotEntry.spec.ts
+++ b/frontend/src/components/ballots/__tests__/InlineBallotEntry.spec.ts
@@ -339,7 +339,7 @@ describe("InlineBallotEntry", () => {
     expect(wrapper.emitted("ballot-start-blocked")?.[0]).toEqual(["location"]);
   });
 
-  it("does not start another ballot when the selected location is Online", async () => {
+  it("disables Start another ballot when the selected location is Online", async () => {
     mockLocationStore.selectedLocationGuid = "location-online";
 
     const wrapper = mount(InlineBallotEntry, {
@@ -356,16 +356,15 @@ describe("InlineBallotEntry", () => {
     const addBallotButton = wrapper
       .findAllComponents(ElButton)
       .find((button) => button.text().includes("Start another ballot"));
-    await addBallotButton!.trigger("click");
-    await flushPromises();
-
-    expect(mockCreateBallot).not.toHaveBeenCalled();
-    expect(mockShowErrorMessage).toHaveBeenCalledWith(
+    expect(addBallotButton).toBeDefined();
+    expect(addBallotButton!.props("disabled")).toBe(true);
+    expect(addBallotButton!.attributes("title")).toBe(
       "Cannot start a ballot at the Online location",
     );
-    expect(wrapper.emitted("ballot-start-blocked")?.[0]).toEqual([
-      "onlineLocation",
-    ]);
+
+    await addBallotButton!.trigger("click");
+    await flushPromises();
+    expect(mockCreateBallot).not.toHaveBeenCalled();
   });
 
   it("does not start another ballot when the main teller is unset", async () => {

--- a/frontend/src/components/locations/LocationForm.vue
+++ b/frontend/src/components/locations/LocationForm.vue
@@ -2,7 +2,8 @@
 import { useApiErrorHandler } from "@/composables/useApiErrorHandler";
 import { useNotifications } from "@/composables/useNotifications";
 import { type FormInstance, type FormRules, ElMessageBox } from "element-plus";
-import { reactive, ref, watch } from "vue";
+import { computed, reactive, ref, watch } from "vue";
+import { isOnlineLocationType } from "@/utils/ballotStartRequirements";
 import { useI18n } from "vue-i18n";
 import { useLocationStore } from "../../stores/locationStore";
 import type {
@@ -32,6 +33,11 @@ const { handleApiError } = useApiErrorHandler();
 const formRef = ref<FormInstance>();
 const submitting = ref(false);
 const deleting = ref(false);
+const canDelete = computed(
+  () =>
+    Boolean(props.showDelete) &&
+    !isOnlineLocationType(props.location?.locationType),
+);
 
 const form = reactive({
   name: "",
@@ -269,7 +275,7 @@ function handleCancel() {
       }}</el-button>
     </div>
 
-    <div v-if="isEditMode() && showDelete" class="location-form-delete">
+    <div v-if="isEditMode() && canDelete" class="location-form-delete">
       <el-button type="danger" :loading="deleting" @click="handleDelete">
         {{ $t("locations.form.delete") }}
       </el-button>

--- a/frontend/src/locales/en/ballots.json
+++ b/frontend/src/locales/en/ballots.json
@@ -71,6 +71,7 @@
   "ballots.loadError": "Failed to load ballots",
   "ballots.location": "Location",
   "ballots.locationRequired": "Location is required",
+  "ballots.onlineLocationNotAllowed": "Cannot start a ballot at the Online location",
   "ballots.tellerRequired": "Teller is required",
   "ballots.management": "Enter Ballots",
   "ballots.markNeedsReview": "Mark as Needs Review",

--- a/frontend/src/locales/en/locations.json
+++ b/frontend/src/locales/en/locations.json
@@ -31,6 +31,7 @@
   "locations.form.updated": "Location updated successfully",
   "locations.locationSelected": "Location selected successfully",
   "locations.selectLocation": "Select Location",
+  "locations.typeOnline": "Online",
   "locations.tallyStatus": "Tally Status",
   "locations.form.edit": "Edit",
   "locations.form.delete": "Delete",

--- a/frontend/src/pages/ballots/BallotManagementPage.vue
+++ b/frontend/src/pages/ballots/BallotManagementPage.vue
@@ -15,6 +15,7 @@ import {
 import {
   BALLOT_START_BLOCK_MESSAGE_KEY,
   getBallotStartBlockReason,
+  isOnlineLocationType,
   locationTypeForGuid,
   type BallotStartBlockReason,
 } from "@/utils/ballotStartRequirements";
@@ -68,6 +69,17 @@ const { flashing: tellerFlashing, flash: flashTeller } =
 
 const hasKeyboardTeller = computed(() =>
   Boolean(activeTellers.value.teller1.trim()),
+);
+
+const selectedLocationType = computed(() =>
+  locationTypeForGuid(
+    locationStore.locations,
+    locationStore.selectedLocationGuid,
+  ),
+);
+
+const isOnlineLocationSelected = computed(() =>
+  isOnlineLocationType(selectedLocationType.value),
 );
 
 const showLocationColumn = computed(() => locationStore.locations.length > 1);
@@ -286,10 +298,7 @@ async function handleAddBallot() {
   const reason = getBallotStartBlockReason({
     computerCode: computerCode.value,
     locationGuid: locationStore.selectedLocationGuid,
-    locationType: locationTypeForGuid(
-      locationStore.locations,
-      locationStore.selectedLocationGuid,
-    ),
+    locationType: selectedLocationType.value,
     teller1: activeTellers.value.teller1,
   });
   if (reason) {
@@ -355,6 +364,12 @@ function handleLocationChange(locationGuid: string | null) {
             <el-button
               type="primary"
               :loading="creatingBallot"
+              :disabled="isOnlineLocationSelected"
+              :title="
+                isOnlineLocationSelected
+                  ? $t('ballots.onlineLocationNotAllowed')
+                  : undefined
+              "
               @click="handleAddBallot"
             >
               <el-icon>

--- a/frontend/src/pages/ballots/BallotManagementPage.vue
+++ b/frontend/src/pages/ballots/BallotManagementPage.vue
@@ -15,6 +15,7 @@ import {
 import {
   BALLOT_START_BLOCK_MESSAGE_KEY,
   getBallotStartBlockReason,
+  locationTypeForGuid,
   type BallotStartBlockReason,
 } from "@/utils/ballotStartRequirements";
 import {
@@ -268,7 +269,7 @@ function handleBallotCreatedFromEntry(ballotGuid: string) {
 }
 
 function flashStartBlockField(reason: BallotStartBlockReason) {
-  if (reason === "location") {
+  if (reason === "location" || reason === "onlineLocation") {
     void flashLocation();
   } else if (reason === "teller") {
     void flashTeller();
@@ -284,6 +285,10 @@ async function handleAddBallot() {
   const reason = getBallotStartBlockReason({
     computerCode: computerCode.value,
     locationGuid: locationStore.selectedLocationGuid,
+    locationType: locationTypeForGuid(
+      locationStore.locations,
+      locationStore.selectedLocationGuid,
+    ),
     teller1: activeTellers.value.teller1,
   });
   if (reason) {

--- a/frontend/src/pages/ballots/BallotManagementPage.vue
+++ b/frontend/src/pages/ballots/BallotManagementPage.vue
@@ -18,6 +18,7 @@ import {
   locationTypeForGuid,
   type BallotStartBlockReason,
 } from "@/utils/ballotStartRequirements";
+import { formatLocationLabel } from "@/utils/locationDisplay";
 import {
   ballotGuidFromRouteParams,
   electionBallotsPath,
@@ -389,7 +390,7 @@ function handleLocationChange(locationGuid: string | null) {
               <el-option
                 v-for="location in locationStore.sortedLocations"
                 :key="location.locationGuid"
-                :label="location.name"
+                :label="formatLocationLabel($t, location)"
                 :value="location.locationGuid"
               />
             </el-select>

--- a/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
+++ b/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
@@ -134,6 +134,7 @@ describe("BallotManagementPage", () => {
           locationSelected: "Location selected",
           selectLocation: "Select location",
           currentLocation: "Current location",
+          typeOnline: "Online",
         },
       },
     },

--- a/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
+++ b/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
@@ -156,8 +156,9 @@ describe("BallotManagementPage", () => {
           },
           ElTableColumn: true,
           ElButton: {
+            props: ["disabled", "loading", "title"],
             template:
-              '<button class="el-button" @click="$emit(\'click\')"><slot></slot></button>',
+              '<button class="el-button" :disabled="disabled" :title="title" @click="!disabled && $emit(\'click\')"><slot></slot></button>',
           },
           ElTag: {
             template: '<span class="el-tag"><slot></slot></span>',
@@ -335,30 +336,24 @@ describe("BallotManagementPage", () => {
     vi.useRealTimers();
   });
 
-  it("does not start a ballot when the selected location is Online and flashes the location select", async () => {
-    vi.useFakeTimers();
+  it("disables Add Ballot when the selected location is Online", async () => {
     locationStore.selectedLocationGuid = "loc-online";
     const wrapper = mountPage();
     await flushPromises();
 
-    await clickAddBallot(wrapper);
-
-    expect(ballotStore.createBallot).not.toHaveBeenCalled();
-    expect(mockShowErrorMessage).toHaveBeenCalledWith(
+    const addButton = wrapper
+      .findAll(".el-button")
+      .find((button) => button.text().includes("Add Ballot"));
+    expect(addButton).toBeDefined();
+    expect(addButton!.attributes("disabled")).toBeDefined();
+    expect(addButton!.attributes("title")).toBe(
       "Cannot start a ballot at the Online location",
     );
-    expect(wrapper.find(".location-select").classes()).toContain(
-      "required-field-flash",
-    );
 
-    vi.advanceTimersByTime(REQUIRED_FIELD_FLASH_MS);
+    await addButton!.trigger("click");
     await flushPromises();
-    expect(wrapper.find(".location-select").classes()).not.toContain(
-      "required-field-flash",
-    );
-
-    wrapper.unmount();
-    vi.useRealTimers();
+    expect(ballotStore.createBallot).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).not.toHaveBeenCalled();
   });
 
   it("does not start a ballot when the main teller is unset and flashes the teller select", async () => {

--- a/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
+++ b/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
@@ -122,6 +122,8 @@ describe("BallotManagementPage", () => {
           computerCodeRequired:
             "Set this computer's code before creating a ballot",
           locationRequired: "Location is required",
+          onlineLocationNotAllowed:
+            "Cannot start a ballot at the Online location",
           tellerRequired: "Teller is required",
           "statusValue.Ok": "Ok",
         },
@@ -209,12 +211,21 @@ describe("BallotManagementPage", () => {
         name: "Main Hall",
         electionGuid: "test-election-guid",
         sortOrder: 1,
+        locationType: "Manual",
       },
       {
         locationGuid: "loc-2",
         name: "Side Room",
         electionGuid: "test-election-guid",
         sortOrder: 2,
+        locationType: "Manual",
+      },
+      {
+        locationGuid: "loc-online",
+        name: "Online",
+        electionGuid: "test-election-guid",
+        sortOrder: 999,
+        locationType: "Online",
       },
     ];
     locationStore.selectedLocationGuid = "loc-1";
@@ -271,7 +282,14 @@ describe("BallotManagementPage", () => {
 
     await clickAddBallot(wrapper);
 
-    expect(ballotStore.createBallot).toHaveBeenCalled();
+    expect(ballotStore.createBallot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        electionGuid: "test-election-guid",
+        computerCode: "AA",
+        locationGuid: "loc-1",
+        teller1: "Alice",
+      }),
+    );
     const panel = wrapper.findComponent({ name: "BallotEntryPanel" });
     expect(panel.exists()).toBe(true);
     expect(panel.props("showMetadata")).toBe(true);
@@ -302,6 +320,32 @@ describe("BallotManagementPage", () => {
 
     expect(ballotStore.createBallot).not.toHaveBeenCalled();
     expect(mockShowErrorMessage).toHaveBeenCalledWith("Location is required");
+    expect(wrapper.find(".location-select").classes()).toContain(
+      "required-field-flash",
+    );
+
+    vi.advanceTimersByTime(REQUIRED_FIELD_FLASH_MS);
+    await flushPromises();
+    expect(wrapper.find(".location-select").classes()).not.toContain(
+      "required-field-flash",
+    );
+
+    wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  it("does not start a ballot when the selected location is Online and flashes the location select", async () => {
+    vi.useFakeTimers();
+    locationStore.selectedLocationGuid = "loc-online";
+    const wrapper = mountPage();
+    await flushPromises();
+
+    await clickAddBallot(wrapper);
+
+    expect(ballotStore.createBallot).not.toHaveBeenCalled();
+    expect(mockShowErrorMessage).toHaveBeenCalledWith(
+      "Cannot start a ballot at the Online location",
+    );
     expect(wrapper.find(".location-select").classes()).toContain(
       "required-field-flash",
     );

--- a/frontend/src/pages/frontdesk/FrontDeskPage.vue
+++ b/frontend/src/pages/frontdesk/FrontDeskPage.vue
@@ -15,6 +15,7 @@ import {
   type ActiveTellers,
 } from "@/utils/activeTellerStorage";
 import { formatNumber } from "@/utils/formatNumber";
+import { formatLocationLabel } from "@/utils/locationDisplay";
 import { sortRegistrationHistoryNewestFirst } from "@/utils/formatRegistrationHistory";
 import { Location, Search } from "@element-plus/icons-vue";
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
@@ -475,7 +476,7 @@ onUnmounted(async () => {
               <el-option
                 v-for="location in locationStore.sortedLocations"
                 :key="location.locationGuid"
-                :label="location.name"
+                :label="formatLocationLabel($t, location)"
                 :value="location.locationGuid"
               />
             </el-select>

--- a/frontend/src/pages/locations/LocationsListPage.vue
+++ b/frontend/src/pages/locations/LocationsListPage.vue
@@ -7,6 +7,7 @@ import { useRoute } from "vue-router";
 import LocationForm from "../../components/locations/LocationForm.vue";
 import { useLocationStore } from "../../stores/locationStore";
 import type { LocationDto } from "../../types";
+import { formatLocationLabel } from "@/utils/locationDisplay";
 
 const route = useRoute();
 const locationStore = useLocationStore();
@@ -33,7 +34,9 @@ const locationDrawerTitle = computed(() => {
   if (!editingLocation.value) {
     return t("locations.form.titleEdit");
   }
-  return t("locations.editDrawerTitle", { name: editingLocation.value.name });
+  return t("locations.editDrawerTitle", {
+    name: formatLocationLabel(t, editingLocation.value),
+  });
 });
 
 onMounted(async () => {
@@ -144,7 +147,7 @@ function getStatusType(status: string) {
           >
             <template #default="scope">
               <el-button type="primary" link @click="handleEdit(scope.row)">
-                {{ scope.row.name }}
+                {{ formatLocationLabel($t, scope.row) }}
               </el-button>
             </template>
           </el-table-column>

--- a/frontend/src/utils/__tests__/ballotStartRequirements.test.ts
+++ b/frontend/src/utils/__tests__/ballotStartRequirements.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   BALLOT_START_BLOCK_MESSAGE_KEY,
   getBallotStartBlockReason,
+  locationTypeForGuid,
 } from "../ballotStartRequirements";
 
 describe("getBallotStartBlockReason", () => {
@@ -13,6 +14,15 @@ describe("getBallotStartBlockReason", () => {
 
   it("allows a ballot to start when computer, location, and teller 1 are set", () => {
     expect(getBallotStartBlockReason(ready)).toBeNull();
+  });
+
+  it("allows a ballot to start at a manual location", () => {
+    expect(
+      getBallotStartBlockReason({
+        ...ready,
+        locationType: "Manual",
+      }),
+    ).toBeNull();
   });
 
   it("does not require teller 2", () => {
@@ -45,6 +55,21 @@ describe("getBallotStartBlockReason", () => {
     );
   });
 
+  it("blocks when the selected location is Online", () => {
+    expect(
+      getBallotStartBlockReason({
+        ...ready,
+        locationType: "Online",
+      }),
+    ).toBe("onlineLocation");
+    expect(
+      getBallotStartBlockReason({
+        ...ready,
+        locationType: "online",
+      }),
+    ).toBe("onlineLocation");
+  });
+
   it("blocks when the main teller is unset", () => {
     expect(getBallotStartBlockReason({ ...ready, teller1: "" })).toBe("teller");
     expect(getBallotStartBlockReason({ ...ready, teller1: "  " })).toBe(
@@ -75,9 +100,23 @@ describe("getBallotStartBlockReason", () => {
     ).toBe("location");
   });
 
+  it("checks Online location before teller when a location is set", () => {
+    expect(
+      getBallotStartBlockReason({
+        computerCode: "AA",
+        locationGuid: "loc-online",
+        locationType: "Online",
+        teller1: "",
+      }),
+    ).toBe("onlineLocation");
+  });
+
   it("maps each block reason to the matching i18n key", () => {
     expect(BALLOT_START_BLOCK_MESSAGE_KEY.location).toBe(
       "ballots.locationRequired",
+    );
+    expect(BALLOT_START_BLOCK_MESSAGE_KEY.onlineLocation).toBe(
+      "ballots.onlineLocationNotAllowed",
     );
     expect(BALLOT_START_BLOCK_MESSAGE_KEY.teller).toBe(
       "ballots.tellerRequired",
@@ -85,5 +124,16 @@ describe("getBallotStartBlockReason", () => {
     expect(BALLOT_START_BLOCK_MESSAGE_KEY.computerCode).toBe(
       "ballots.computerCodeRequired",
     );
+  });
+
+  it("looks up location type by guid", () => {
+    const locations = [
+      { locationGuid: "loc-1", locationType: "Manual" },
+      { locationGuid: "loc-online", locationType: "Online" },
+    ];
+    expect(locationTypeForGuid(locations, "loc-1")).toBe("Manual");
+    expect(locationTypeForGuid(locations, "loc-online")).toBe("Online");
+    expect(locationTypeForGuid(locations, "missing")).toBeNull();
+    expect(locationTypeForGuid(locations, null)).toBeNull();
   });
 });

--- a/frontend/src/utils/__tests__/locationDisplay.test.ts
+++ b/frontend/src/utils/__tests__/locationDisplay.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { formatLocationLabel } from "../locationDisplay";
+
+describe("formatLocationLabel", () => {
+  const t = (key: string) => (key === "locations.typeOnline" ? "Online" : key);
+
+  it("uses i18n for an Online-typed location regardless of name", () => {
+    expect(
+      formatLocationLabel(t, { name: "Hall A", locationType: "Online" }),
+    ).toBe("Online");
+  });
+
+  it("uses the stored name for a paper location", () => {
+    expect(
+      formatLocationLabel(t, { name: "Main Hall", locationType: "Manual" }),
+    ).toBe("Main Hall");
+  });
+});

--- a/frontend/src/utils/ballotStartRequirements.ts
+++ b/frontend/src/utils/ballotStartRequirements.ts
@@ -1,4 +1,8 @@
-export type BallotStartBlockReason = "computerCode" | "location" | "teller";
+export type BallotStartBlockReason =
+  | "computerCode"
+  | "location"
+  | "onlineLocation"
+  | "teller";
 
 export const BALLOT_START_BLOCK_MESSAGE_KEY: Record<
   BallotStartBlockReason,
@@ -6,16 +10,19 @@ export const BALLOT_START_BLOCK_MESSAGE_KEY: Record<
 > = {
   computerCode: "ballots.computerCodeRequired",
   location: "ballots.locationRequired",
+  onlineLocation: "ballots.onlineLocationNotAllowed",
   teller: "ballots.tellerRequired",
 };
 
 /**
- * A new paper ballot must not start without a computer code, location, and
- * main teller (teller 1). Teller 2 is optional.
+ * A new paper/teller ballot must not start without a computer code, a
+ * non-Online location, and main teller (teller 1). Teller 2 is optional.
+ * The Online location is reserved for voter-initiated ballots.
  */
 export function getBallotStartBlockReason(input: {
   computerCode?: string | null;
   locationGuid?: string | null;
+  locationType?: string | null;
   teller1?: string | null;
 }): BallotStartBlockReason | null {
   if (!input.computerCode?.trim()) {
@@ -24,8 +31,33 @@ export function getBallotStartBlockReason(input: {
   if (!input.locationGuid?.trim()) {
     return "location";
   }
+  if (isOnlineLocationType(input.locationType)) {
+    return "onlineLocation";
+  }
   if (!input.teller1?.trim()) {
     return "teller";
   }
   return null;
+}
+
+export function isOnlineLocationType(
+  locationType?: string | null,
+): boolean {
+  return locationType?.trim().toLowerCase() === "online";
+}
+
+export function locationTypeForGuid(
+  locations: ReadonlyArray<{
+    locationGuid: string;
+    locationType?: string | null;
+  }>,
+  locationGuid: string | null | undefined,
+): string | null {
+  if (!locationGuid) {
+    return null;
+  }
+  return (
+    locations.find((location) => location.locationGuid === locationGuid)
+      ?.locationType ?? null
+  );
 }

--- a/frontend/src/utils/ballotStartRequirements.ts
+++ b/frontend/src/utils/ballotStartRequirements.ts
@@ -17,7 +17,8 @@ export const BALLOT_START_BLOCK_MESSAGE_KEY: Record<
 /**
  * A new paper/teller ballot must not start without a computer code, a
  * non-Online location, and main teller (teller 1). Teller 2 is optional.
- * The Online location is reserved for voter-initiated ballots.
+ * The reserved location is identified by LocationType, not by its display name
+ * (names are translated; "Online" is not a stable key).
  */
 export function getBallotStartBlockReason(input: {
   computerCode?: string | null;
@@ -40,6 +41,7 @@ export function getBallotStartBlockReason(input: {
   return null;
 }
 
+/** True when LocationType is Online (API enum), not when the location is named "Online". */
 export function isOnlineLocationType(
   locationType?: string | null,
 ): boolean {

--- a/frontend/src/utils/locationDisplay.ts
+++ b/frontend/src/utils/locationDisplay.ts
@@ -1,0 +1,15 @@
+import { isOnlineLocationType } from "@/utils/ballotStartRequirements";
+
+/** Label for a location. Online-typed rows use i18n; names are not identifiers. */
+export function formatLocationLabel(
+  t: (key: string) => string,
+  location: {
+    name?: string | null;
+    locationType?: string | null;
+  },
+): string {
+  if (isOnlineLocationType(location.locationType)) {
+    return t("locations.typeOnline");
+  }
+  return location.name?.trim() || "";
+}


### PR DESCRIPTION
Related: #287 (issue stays open).

Next slice of ballot entry issues: new teller ballots must use the location currently set in the browser.

UI verification is deferred to Glen on UAT. This PR is covered by unit tests only. No Playwright/browser tools.

## What this does
- `CreateBallot` now requires and uses `locationGuid` from the browser instead of `Locations.FirstOrDefault` for the election (that unordered pick could be Online).
- Starting a paper/teller ballot is blocked when the selected location is Online. Online is reserved for voter-initiated ballots.
- OpenAPI spec and generated client now include `locationGuid` on `CreateBallotDto`.
- `dotnet run -- --exit-after-start` writes the OpenAPI spec in Development and then stops.

## What I verified
The frontend already sent `locationGuid`. The backend DTO had no `LocationGuid`, so create ignored the selected location. Requesting Main Hall while an Online location exists first now stores the ballot at Main Hall. Create at Online is rejected on the server; the list and “Start another ballot” paths block first.

`dotnet run -- --exit-after-start` logs “Startup completed. Stopping.” and exits 0 after the spec write.

## Out of scope (still on #287)
- Making Teller 1/2 on an open ballot into session-global editors
- Teller-name list, SignalR distribution, admin delete on the Tellers page

## Tests
- `CreateBallotAsync` uses the requested location when an Online location exists first
- `CreateBallotAsync` rejects Online, missing, and other-election locations
- `CreateBallotDto` requires a location GUID
- `getBallotStartBlockReason` blocks Online (after computer/location unset, before teller)
- Ballot list: create sends the selected location; Online selection blocks and flashes the location select
- Inline “Start another ballot”: same Online block