### PR TITLE
Make Teller 1/2 on an open ballot session-global inputs

### DIFF
--- a/context/election-state.md
+++ b/context/election-state.md
@@ -34,3 +34,18 @@ Implementation:
 - Secondary: sidebar watch + router `beforeEach`
 - Stage source: MainHub `statusChanged` → `electionStore.currentStage`
 - Main hub membership must stay for the whole election session (`electionStore`); ballots/people pages only join/leave FrontDesk (see `context/realtime.md`)
+
+## Session Teller 1/2 on an open ballot
+
+**Status:** active  
+**Evidence:** confirmed (issue #287)
+
+Teller 1 and Teller 2 shown while a ballot is open are the same browser-session inputs as on the ballot listing (localStorage via `useActiveTellers`). Changing them on the ballot updates those session globals; they are not editors of that ballot’s stored `teller1`/`teller2` fields.
+
+**Rejected alternative:** treat the ballot metadata names as per-ballot fields to save on that record. The listing already uses session-global tellers (who is at this keyboard now). Opening a ballot already stamps the current session tellers onto the record; the names on screen need to stay that same session setting so the teller can change them without closing the ballot.
+
+Location stays read-only on the open ballot in this slice. Adding a name to the election-wide teller list, SignalR to other computers, and admin delete on the Tellers page are a later #287 slice.
+
+Implementation:
+- `useActiveTellers` — shared reactive session state over `activeTellerStorage`
+- `ActiveTellerSelector` on the listing and as the Teller 1/2 cells in `BallotEntryPanel`

--- a/frontend/src/components/ballots/BallotEntryPanel.vue
+++ b/frontend/src/components/ballots/BallotEntryPanel.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { useNotifications } from "@/composables/useNotifications";
-import { getActiveTellerPayload } from "@/utils/activeTellerStorage";
+import ActiveTellerSelector from "@/components/tellers/ActiveTellerSelector.vue";
+import {
+  getActiveTellerPayload,
+  type ActiveTellers,
+} from "@/utils/activeTellerStorage";
 import type { BallotStartBlockReason } from "@/utils/ballotStartRequirements";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
@@ -17,6 +21,7 @@ const emit = defineEmits<{
   "ballot-created": [ballotGuid: string];
   "ballot-deleted": [ballotGuid: string];
   "ballot-start-blocked": [reason: BallotStartBlockReason];
+  "tellers-changed": [tellers: ActiveTellers];
 }>();
 
 const props = withDefaults(
@@ -27,12 +32,14 @@ const props = withDefaults(
     manageBallotSignalR?: boolean;
     managePeopleSignalR?: boolean;
     hasKeyboardTeller?: boolean;
+    highlightTeller1?: boolean;
   }>(),
   {
     showMetadata: true,
     manageBallotSignalR: true,
     managePeopleSignalR: true,
     hasKeyboardTeller: true,
+    highlightTeller1: false,
   },
 );
 
@@ -217,10 +224,19 @@ async function handleVotesReordered(voteRowIds: number[]) {
             {{ formatComputerCodeLabel($t, ballot.computerCode) }}
           </el-descriptions-item>
           <el-descriptions-item :label="$t('ballots.teller1')">
-            {{ ballot.teller1 || "-" }}
+            <ActiveTellerSelector
+              field="teller1"
+              :election-guid="electionGuid"
+              :highlight-teller1="highlightTeller1"
+              @tellers-changed="emit('tellers-changed', $event)"
+            />
           </el-descriptions-item>
           <el-descriptions-item :label="$t('ballots.teller2')">
-            {{ ballot.teller2 || "-" }}
+            <ActiveTellerSelector
+              field="teller2"
+              :election-guid="electionGuid"
+              @tellers-changed="emit('tellers-changed', $event)"
+            />
           </el-descriptions-item>
         </el-descriptions>
       </div>

--- a/frontend/src/components/ballots/__tests__/BallotEntryPanel.spec.ts
+++ b/frontend/src/components/ballots/__tests__/BallotEntryPanel.spec.ts
@@ -1,0 +1,240 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getActiveTellers,
+  setActiveTeller1,
+  setActiveTeller2,
+} from "@/utils/activeTellerStorage";
+import { useActiveTellers } from "@/composables/useActiveTellers";
+import type { BallotDto } from "@/types/Ballot";
+import type { ElectionDto } from "@/types";
+import BallotEntryPanel from "../BallotEntryPanel.vue";
+
+const mockBallot: BallotDto = {
+  ballotGuid: "ballot-1",
+  locationGuid: "loc-1",
+  locationName: "Main Hall",
+  computerCode: "AA",
+  ballotCode: "A1",
+  ballotNumAtComputer: 1,
+  statusCode: "Ok",
+  teller1: "StoredOnBallot",
+  teller2: "AlsoStored",
+  voteCount: 0,
+  votes: [],
+};
+
+const mockElection = {
+  electionGuid: "elec-1",
+  numberToElect: 9,
+} as ElectionDto;
+
+const mockBallotStore = {
+  currentBallot: mockBallot as BallotDto | null,
+  fetchBallotById: vi.fn(),
+  updateBallot: vi.fn(),
+  initializeSignalR: vi.fn(),
+  joinElection: vi.fn(),
+  leaveElection: vi.fn(),
+  createVote: vi.fn(),
+  updateVote: vi.fn(),
+  deleteVote: vi.fn(),
+  reorderVotes: vi.fn(),
+};
+
+const mockElectionStore = {
+  currentElection: mockElection,
+  fetchElectionById: vi.fn(),
+};
+
+const mockPeopleStore = {
+  initializeSignalR: vi.fn(),
+  joinElection: vi.fn(),
+  leaveElection: vi.fn(),
+  onPersonUpdated: vi.fn(() => () => undefined),
+};
+
+vi.mock("@/stores/ballotStore", () => ({
+  useBallotStore: () => mockBallotStore,
+}));
+
+vi.mock("@/stores/electionStore", () => ({
+  useElectionStore: () => mockElectionStore,
+}));
+
+vi.mock("@/stores/peopleStore", () => ({
+  usePeopleStore: () => mockPeopleStore,
+}));
+
+vi.mock("@/composables/useNotifications", () => ({
+  useNotifications: () => ({
+    showSuccessMessage: vi.fn(),
+    showErrorMessage: vi.fn(),
+    showInfoMessage: vi.fn(),
+  }),
+}));
+
+vi.mock("../InlineBallotEntry.vue", () => ({
+  default: {
+    name: "InlineBallotEntry",
+    template: '<div data-testid="inline-ballot-entry"></div>',
+    props: ["electionGuid", "ballot", "requiredVotes", "hasKeyboardTeller"],
+  },
+}));
+
+const { selectorChanges } = vi.hoisted(() => ({
+  selectorChanges: {
+    teller1: "",
+    teller2: "",
+  },
+}));
+
+vi.mock("@/components/tellers/ActiveTellerSelector.vue", async () => {
+  const { setActiveTeller1, setActiveTeller2 } = await import(
+    "@/utils/activeTellerStorage"
+  );
+  const { useActiveTellers } = await import("@/composables/useActiveTellers");
+  const { defineComponent, h } = await import("vue");
+  return {
+    default: defineComponent({
+      name: "ActiveTellerSelector",
+      props: {
+        electionGuid: { type: String, required: true },
+        field: { type: String, default: "all" },
+        highlightTeller1: { type: Boolean, default: false },
+      },
+      emits: ["tellersChanged"],
+      setup(props, { emit }) {
+        const { setTeller1, setTeller2, tellers } = useActiveTellers();
+        function apply() {
+          if (props.field === "teller2") {
+            setActiveTeller2(selectorChanges.teller2);
+            setTeller2(selectorChanges.teller2);
+          } else {
+            setActiveTeller1(selectorChanges.teller1);
+            setTeller1(selectorChanges.teller1);
+          }
+          emit("tellersChanged", { ...tellers.value });
+        }
+        return () =>
+          h(
+            "button",
+            {
+              type: "button",
+              class: `active-teller-selector-stub field-${props.field}`,
+              "data-highlight": String(props.highlightTeller1),
+              onClick: apply,
+            },
+            props.field,
+          );
+      },
+    }),
+  };
+});
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  messages: {
+    en: {
+      ballots: {
+        location: "Location",
+        computer: "Computer",
+        teller1: "Teller 1",
+        teller2: "Teller 2",
+        loadError: "Failed to load",
+      },
+    },
+  },
+});
+
+function mountPanel() {
+  return mount(BallotEntryPanel, {
+    props: {
+      electionGuid: "elec-1",
+      ballotGuid: "ballot-1",
+      highlightTeller1: true,
+    },
+    global: {
+      plugins: [i18n, createPinia()],
+      stubs: {
+        ElSkeleton: { template: '<div class="el-skeleton"></div>' },
+        ElDescriptions: { template: "<div class='el-descriptions'><slot /></div>" },
+        ElDescriptionsItem: {
+          props: ["label"],
+          template:
+            '<div class="el-descriptions-item"><span class="item-label">{{ label }}</span><slot /></div>',
+        },
+      },
+    },
+  });
+}
+
+describe("BallotEntryPanel session tellers", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+    selectorChanges.teller1 = "Pat";
+    selectorChanges.teller2 = "Sam";
+    mockBallotStore.currentBallot = { ...mockBallot };
+    mockBallotStore.fetchBallotById.mockResolvedValue(mockBallot);
+    mockBallotStore.updateBallot.mockResolvedValue(mockBallot);
+    mockBallotStore.initializeSignalR.mockResolvedValue(undefined);
+    mockBallotStore.joinElection.mockResolvedValue(undefined);
+    mockBallotStore.leaveElection.mockResolvedValue(undefined);
+    mockElectionStore.fetchElectionById.mockResolvedValue(mockElection);
+    mockPeopleStore.initializeSignalR.mockResolvedValue(undefined);
+    mockPeopleStore.joinElection.mockResolvedValue(undefined);
+    mockPeopleStore.leaveElection.mockResolvedValue(undefined);
+    useActiveTellers().refreshActiveTellers();
+  });
+
+  it("shows Teller 1 and Teller 2 as session inputs, not the stored ballot names", async () => {
+    setActiveTeller1("SessionOne");
+    setActiveTeller2("SessionTwo");
+    useActiveTellers().refreshActiveTellers();
+
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain("StoredOnBallot");
+    expect(wrapper.text()).not.toContain("AlsoStored");
+    expect(wrapper.find(".field-teller1").exists()).toBe(true);
+    expect(wrapper.find(".field-teller2").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Location");
+    expect(wrapper.text()).toContain("Main Hall");
+  });
+
+  it("changing Teller 1 on the open ballot sets the listing session global", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    await wrapper.find(".field-teller1").trigger("click");
+    await flushPromises();
+
+    expect(getActiveTellers().teller1).toBe("Pat");
+    expect(useActiveTellers().tellers.value.teller1).toBe("Pat");
+  });
+
+  it("changing Teller 2 on the open ballot sets the listing session global", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    await wrapper.find(".field-teller2").trigger("click");
+    await flushPromises();
+
+    expect(getActiveTellers().teller2).toBe("Sam");
+    expect(useActiveTellers().tellers.value.teller2).toBe("Sam");
+  });
+
+  it("forwards the teller-required highlight to Teller 1", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    expect(wrapper.find(".field-teller1").attributes("data-highlight")).toBe(
+      "true",
+    );
+  });
+});

--- a/frontend/src/components/ballots/__tests__/BallotEntryPanel.spec.ts
+++ b/frontend/src/components/ballots/__tests__/BallotEntryPanel.spec.ts
@@ -92,9 +92,8 @@ const { selectorChanges } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/components/tellers/ActiveTellerSelector.vue", async () => {
-  const { setActiveTeller1, setActiveTeller2 } = await import(
-    "@/utils/activeTellerStorage"
-  );
+  const { setActiveTeller1, setActiveTeller2 } =
+    await import("@/utils/activeTellerStorage");
   const { useActiveTellers } = await import("@/composables/useActiveTellers");
   const { defineComponent, h } = await import("vue");
   return {
@@ -161,7 +160,9 @@ function mountPanel() {
       plugins: [i18n, createPinia()],
       stubs: {
         ElSkeleton: { template: '<div class="el-skeleton"></div>' },
-        ElDescriptions: { template: "<div class='el-descriptions'><slot /></div>" },
+        ElDescriptions: {
+          template: "<div class='el-descriptions'><slot /></div>",
+        },
         ElDescriptionsItem: {
           props: ["label"],
           template:

--- a/frontend/src/components/tellers/ActiveTellerSelector.vue
+++ b/frontend/src/components/tellers/ActiveTellerSelector.vue
@@ -1,21 +1,21 @@
 <script setup lang="ts">
+import { useActiveTellers } from "@/composables/useActiveTellers";
 import { useTellerStore } from "@/stores/tellerStore";
-import {
-  getActiveTellers,
-  setActiveTeller1,
-  setActiveTeller2,
-  type ActiveTellers,
-} from "@/utils/activeTellerStorage";
+import type { ActiveTellers } from "@/utils/activeTellerStorage";
 import { User } from "@element-plus/icons-vue";
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
     electionGuid: string;
     highlightTeller1?: boolean;
+    /** Which session teller inputs to show. Default is both (listing toolbar). */
+    field?: "all" | "teller1" | "teller2";
+    showIcon?: boolean;
   }>(),
   {
     highlightTeller1: false,
+    field: "all",
   },
 );
 
@@ -24,9 +24,19 @@ const emit = defineEmits<{
 }>();
 
 const tellerStore = useTellerStore();
+const { tellers, setTeller1, setTeller2, refreshActiveTellers } =
+  useActiveTellers();
 
-const teller1 = ref<string | undefined>(undefined);
-const teller2 = ref<string | undefined>(undefined);
+const showIcon = computed(() => props.showIcon ?? props.field === "all");
+const showTeller1 = computed(
+  () => props.field === "all" || props.field === "teller1",
+);
+const showTeller2 = computed(
+  () => props.field === "all" || props.field === "teller2",
+);
+
+const teller1 = computed(() => toSelectValue(tellers.value.teller1));
+const teller2 = computed(() => toSelectValue(tellers.value.teller2));
 
 const tellerOptions = computed(() =>
   tellerStore.tellers
@@ -67,14 +77,13 @@ function toSelectValue(name: string): string | undefined {
 
 function emitTellersChanged() {
   emit("tellersChanged", {
-    teller1: teller1.value ?? "",
-    teller2: teller2.value ?? "",
+    teller1: tellers.value.teller1,
+    teller2: tellers.value.teller2,
   });
 }
 
 async function handleTeller1Change(value: string | undefined) {
-  teller1.value = toSelectValue(value ?? "");
-  setActiveTeller1(value ?? "");
+  setTeller1(value ?? "");
   emitTellersChanged();
   if (value) {
     await ensureTellerListed(value);
@@ -82,8 +91,7 @@ async function handleTeller1Change(value: string | undefined) {
 }
 
 async function handleTeller2Change(value: string | undefined) {
-  teller2.value = toSelectValue(value ?? "");
-  setActiveTeller2(value ?? "");
+  setTeller2(value ?? "");
   emitTellersChanged();
   if (value) {
     await ensureTellerListed(value);
@@ -91,9 +99,7 @@ async function handleTeller2Change(value: string | undefined) {
 }
 
 onMounted(async () => {
-  const stored = getActiveTellers();
-  teller1.value = toSelectValue(stored.teller1);
-  teller2.value = toSelectValue(stored.teller2);
+  refreshActiveTellers();
   emitTellersChanged();
   await loadTellers();
 });
@@ -107,8 +113,12 @@ watch(
 </script>
 
 <template>
-  <div class="active-teller-selector">
+  <div
+    class="active-teller-selector"
+    :class="{ 'is-single-field': field !== 'all' }"
+  >
     <el-icon
+      v-if="showIcon"
       class="teller-icon"
       aria-hidden="true"
       :title="$t('teller.active.hint')"
@@ -116,7 +126,8 @@ watch(
       <User />
     </el-icon>
     <el-select
-      v-model="teller1"
+      v-if="showTeller1"
+      :model-value="teller1"
       filterable
       allow-create
       clearable
@@ -134,12 +145,13 @@ watch(
       />
     </el-select>
     <el-select
-      v-model="teller2"
+      v-if="showTeller2"
+      :model-value="teller2"
       filterable
       allow-create
       clearable
       :placeholder="$t('teller.active.teller2Placeholder')"
-      class="teller-select"
+      class="teller-select teller2-select"
       @change="handleTeller2Change"
     >
       <el-option value="" disabled :label="$t('teller.active.typeToAdd')" />
@@ -167,6 +179,15 @@ watch(
   .teller-icon {
     color: var(--el-color-primary);
     font-size: 16px;
+  }
+
+  &.is-single-field {
+    display: flex;
+    width: 100%;
+
+    .teller-select {
+      width: 100%;
+    }
   }
 }
 </style>

--- a/frontend/src/components/tellers/__tests__/ActiveTellerSelector.spec.ts
+++ b/frontend/src/components/tellers/__tests__/ActiveTellerSelector.spec.ts
@@ -1,0 +1,102 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getActiveTellers } from "@/utils/activeTellerStorage";
+import { useActiveTellers } from "@/composables/useActiveTellers";
+import ActiveTellerSelector from "../ActiveTellerSelector.vue";
+
+const mockFetchTellers = vi.fn();
+const mockCreateTeller = vi.fn();
+
+vi.mock("@/stores/tellerStore", () => ({
+  useTellerStore: () => ({
+    tellers: [],
+    fetchTellers: mockFetchTellers,
+    createTeller: mockCreateTeller,
+  }),
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  messages: {
+    en: {
+      teller: {
+        active: {
+          typeToAdd: "Type to add",
+          teller1Placeholder: "Teller at keyboard",
+          teller2Placeholder: "Second teller (optional)",
+          hint: "Hint",
+        },
+      },
+    },
+  },
+});
+
+function mountSelector(
+  props: {
+    field?: "all" | "teller1" | "teller2";
+    highlightTeller1?: boolean;
+  } = {},
+) {
+  return mount(ActiveTellerSelector, {
+    props: {
+      electionGuid: "elec-1",
+      ...props,
+    },
+    global: {
+      plugins: [i18n, createPinia()],
+      stubs: {
+        ElIcon: true,
+        ElOption: true,
+        ElSelect: {
+          props: ["modelValue", "placeholder"],
+          emits: ["change"],
+          template:
+            '<button type="button" class="el-select-stub" :data-placeholder="placeholder" @click="$emit(\'change\', \'Pat\')">{{ modelValue }}</button>',
+        },
+      },
+    },
+  });
+}
+
+describe("ActiveTellerSelector", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+    mockFetchTellers.mockReset().mockResolvedValue(undefined);
+    mockCreateTeller.mockReset().mockResolvedValue(undefined);
+    useActiveTellers().refreshActiveTellers();
+  });
+
+  it("writes Teller 1 to the browser-session globals", async () => {
+    const wrapper = mountSelector();
+    await flushPromises();
+
+    await wrapper.find(".teller1-select").trigger("click");
+    await flushPromises();
+
+    expect(getActiveTellers().teller1).toBe("Pat");
+    expect(useActiveTellers().tellers.value.teller1).toBe("Pat");
+  });
+
+  it("writes Teller 2 to the same session globals as the listing", async () => {
+    const wrapper = mountSelector();
+    await flushPromises();
+
+    await wrapper.find(".teller2-select").trigger("click");
+    await flushPromises();
+
+    expect(getActiveTellers().teller2).toBe("Pat");
+    expect(useActiveTellers().tellers.value.teller2).toBe("Pat");
+  });
+
+  it("can show only Teller 1, matching a ballot metadata cell", async () => {
+    const wrapper = mountSelector({ field: "teller1" });
+    await flushPromises();
+
+    expect(wrapper.find(".teller1-select").exists()).toBe(true);
+    expect(wrapper.find(".teller2-select").exists()).toBe(false);
+  });
+});

--- a/frontend/src/composables/__tests__/useActiveTellers.spec.ts
+++ b/frontend/src/composables/__tests__/useActiveTellers.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getActiveTellers,
+  setActiveTeller1,
+  setActiveTeller2,
+} from "@/utils/activeTellerStorage";
+import { useActiveTellers } from "../useActiveTellers";
+
+describe("useActiveTellers", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useActiveTellers().refreshActiveTellers();
+  });
+
+  it("writes Teller 1/2 to the same session storage as the listing", () => {
+    const session = useActiveTellers();
+    session.setTeller1("Pat");
+    session.setTeller2("Sam");
+
+    expect(getActiveTellers()).toEqual({ teller1: "Pat", teller2: "Sam" });
+    expect(session.tellers.value).toEqual({ teller1: "Pat", teller2: "Sam" });
+  });
+
+  it("shares one session object across callers", () => {
+    const listing = useActiveTellers();
+    const openBallot = useActiveTellers();
+
+    listing.setTeller1("Keyboard");
+    openBallot.setTeller2("Assistant");
+
+    expect(listing.tellers.value).toEqual({
+      teller1: "Keyboard",
+      teller2: "Assistant",
+    });
+    expect(openBallot.tellers.value).toBe(listing.tellers.value);
+  });
+
+  it("refreshes from storage when another path wrote the keys", () => {
+    setActiveTeller1("Stored1");
+    setActiveTeller2("Stored2");
+
+    const session = useActiveTellers();
+    session.refreshActiveTellers();
+
+    expect(session.tellers.value).toEqual({
+      teller1: "Stored1",
+      teller2: "Stored2",
+    });
+  });
+});

--- a/frontend/src/composables/useActiveTellers.ts
+++ b/frontend/src/composables/useActiveTellers.ts
@@ -1,0 +1,49 @@
+import {
+  clearActiveTellers,
+  getActiveTellers,
+  setActiveTeller1,
+  setActiveTeller2,
+  type ActiveTellers,
+} from "@/utils/activeTellerStorage";
+import { ref } from "vue";
+
+const sessionTellers = ref<ActiveTellers>(getActiveTellers());
+
+/**
+ * Browser-session Teller 1/2 (localStorage). Shared so the ballot listing
+ * and an open ballot edit the same values.
+ */
+export function useActiveTellers() {
+  function refreshActiveTellers() {
+    sessionTellers.value = getActiveTellers();
+  }
+
+  function setTeller1(name: string) {
+    setActiveTeller1(name);
+    sessionTellers.value = {
+      ...sessionTellers.value,
+      teller1: name,
+    };
+  }
+
+  function setTeller2(name: string) {
+    setActiveTeller2(name);
+    sessionTellers.value = {
+      ...sessionTellers.value,
+      teller2: name,
+    };
+  }
+
+  function clearTellers() {
+    clearActiveTellers();
+    sessionTellers.value = { teller1: "", teller2: "" };
+  }
+
+  return {
+    tellers: sessionTellers,
+    setTeller1,
+    setTeller2,
+    clearTellers,
+    refreshActiveTellers,
+  };
+}

--- a/frontend/src/pages/ballots/BallotEntryPage.vue
+++ b/frontend/src/pages/ballots/BallotEntryPage.vue
@@ -1,16 +1,13 @@
 <script setup lang="ts">
 import ActiveTellerSelector from "@/components/tellers/ActiveTellerSelector.vue";
+import { useActiveTellers } from "@/composables/useActiveTellers";
 import { useRequiredFieldFlash } from "@/composables/useRequiredFieldFlash";
-import {
-  getActiveTellers,
-  type ActiveTellers,
-} from "@/utils/activeTellerStorage";
 import type { BallotStartBlockReason } from "@/utils/ballotStartRequirements";
 import {
   electionBallotEntryPath,
   electionBallotsPath,
 } from "@/utils/ballotRoutes";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import BallotEntryPanel from "../../components/ballots/BallotEntryPanel.vue";
 
@@ -27,16 +24,13 @@ function handleBallotDeleted() {
   router.push(electionBallotsPath(electionGuid));
 }
 
-const activeTellers = ref<ActiveTellers>(getActiveTellers());
+const { tellers: activeTellers, refreshActiveTellers } = useActiveTellers();
+refreshActiveTellers();
 const { flashing: tellerFlashing, flash: flashTeller } =
   useRequiredFieldFlash();
 const hasKeyboardTeller = computed(() =>
   Boolean(activeTellers.value.teller1.trim()),
 );
-
-function onTellersChanged(tellers: ActiveTellers) {
-  activeTellers.value = tellers;
-}
 
 function onBallotStartBlocked(reason: BallotStartBlockReason) {
   if (reason === "teller") {
@@ -53,7 +47,6 @@ function onBallotStartBlocked(reason: BallotStartBlockReason) {
           <ActiveTellerSelector
             :election-guid="electionGuid"
             :highlight-teller1="tellerFlashing"
-            @tellers-changed="onTellersChanged"
           />
         </div>
       </template>
@@ -63,6 +56,7 @@ function onBallotStartBlocked(reason: BallotStartBlockReason) {
         :election-guid="electionGuid"
         :ballot-guid="ballotGuid"
         :has-keyboard-teller="hasKeyboardTeller"
+        :highlight-teller1="tellerFlashing"
         @ballot-created="handleBallotCreated"
         @ballot-deleted="handleBallotDeleted"
         @ballot-start-blocked="onBallotStartBlocked"

--- a/frontend/src/pages/ballots/BallotManagementPage.vue
+++ b/frontend/src/pages/ballots/BallotManagementPage.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
 import BallotViewFilterSelect from "@/components/ballots/BallotViewFilterSelect.vue";
 import ActiveTellerSelector from "@/components/tellers/ActiveTellerSelector.vue";
+import { useActiveTellers } from "@/composables/useActiveTellers";
 import { useApiErrorHandler } from "@/composables/useApiErrorHandler";
 import { useComputerCode } from "@/composables/useComputerCode";
 import { useNotifications } from "@/composables/useNotifications";
 import { useRequiredFieldFlash } from "@/composables/useRequiredFieldFlash";
 
 import type { ComputerDto } from "@/types/Computer";
-import {
-  getActiveTellerPayload,
-  getActiveTellers,
-  type ActiveTellers,
-} from "@/utils/activeTellerStorage";
+import { getActiveTellerPayload } from "@/utils/activeTellerStorage";
 import {
   BALLOT_START_BLOCK_MESSAGE_KEY,
   getBallotStartBlockReason,
@@ -56,7 +53,8 @@ const isNewBallot = ref(false);
 const creatingBallot = ref(false);
 const listLoading = ref(false);
 const refreshing = ref(false);
-const activeTellers = ref<ActiveTellers>(getActiveTellers());
+const { tellers: activeTellers, refreshActiveTellers } = useActiveTellers();
+refreshActiveTellers();
 const selectedViewFilter = ref(
   defaultBallotViewFilter("", locationStore.selectedLocationGuid),
 );
@@ -128,10 +126,6 @@ watch(computerCode, (code) => {
     locationStore.selectedLocationGuid,
   );
 });
-
-function onTellersChanged(tellers: ActiveTellers) {
-  activeTellers.value = tellers;
-}
 
 /** Keep the open ballot bookmarkable and restorable on reload. */
 function syncBallotRoute(ballotGuid: string | null) {
@@ -383,7 +377,6 @@ function handleLocationChange(locationGuid: string | null) {
             :election-guid="electionGuid"
             class="header-tellers"
             :highlight-teller1="tellerFlashing"
-            @tellers-changed="onTellersChanged"
           />
 
           <div
@@ -500,6 +493,7 @@ function handleLocationChange(locationGuid: string | null) {
         :ballot-guid="drawerBallotGuid"
         :manage-ballot-signal-r="false"
         :has-keyboard-teller="hasKeyboardTeller"
+        :highlight-teller1="tellerFlashing"
         @ballot-created="handleBallotCreatedFromEntry"
         @ballot-deleted="handleBallotDeletedFromEntry"
         @ballot-start-blocked="flashStartBlockField"

--- a/frontend/src/pages/ballots/__tests__/BallotEntryPage.spec.ts
+++ b/frontend/src/pages/ballots/__tests__/BallotEntryPage.spec.ts
@@ -21,7 +21,13 @@ vi.mock("@/components/ballots/BallotEntryPanel.vue", () => ({
     name: "BallotEntryPanel",
     template:
       '<div class="ballot-entry-panel-mock" data-testid="ballot-entry-panel"></div>',
-    props: ["electionGuid", "ballotGuid", "showMetadata"],
+    props: [
+      "electionGuid",
+      "ballotGuid",
+      "showMetadata",
+      "highlightTeller1",
+      "hasKeyboardTeller",
+    ],
   },
 }));
 
@@ -63,5 +69,6 @@ describe("BallotEntryPage", () => {
     expect(panel.exists()).toBe(true);
     expect(panel.props("electionGuid")).toBe("test-election-guid");
     expect(panel.props("ballotGuid")).toBe("test-ballot-guid");
+    expect(panel.props("highlightTeller1")).toBe(false);
   });
 });

--- a/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
+++ b/frontend/src/pages/ballots/__tests__/BallotManagementPage.spec.ts
@@ -35,6 +35,7 @@ vi.mock("@/components/ballots/BallotEntryPanel.vue", () => ({
       manageBallotSignalR: { type: Boolean, default: true },
       managePeopleSignalR: { type: Boolean, default: true },
       hasKeyboardTeller: { type: Boolean, default: true },
+      highlightTeller1: { type: Boolean, default: false },
     },
   },
 }));
@@ -310,6 +311,7 @@ describe("BallotManagementPage", () => {
     expect(panel.exists()).toBe(true);
     expect(panel.props("ballotGuid")).toBe("ballot-1");
     expect(panel.props("showMetadata")).toBe(true);
+    expect(panel.props("highlightTeller1")).toBe(false);
   });
 
   it("does not start a ballot when location is unset and flashes the location select", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related: #287 (issue stays open)

Next slice of ballot entry issues: Teller 1 and Teller 2 on an open ballot are inputs that mirror the listing and write the same browser-session globals.

UI verification is deferred to Glen on UAT. This PR is covered by unit tests only. No Playwright/browser tools.

## What this does
- Open-ballot Teller 1/2 are `ActiveTellerSelector` inputs (same control as the listing), not the stored ballot names.
- Changing them updates the same session tellers (`localStorage` via `useActiveTellers`) that the listing uses.
- Location on the ballot stays read-only. Online / location-on-create behavior from #289 is unchanged.

## What I verified
- `npm run check` (vue-tsc + eslint) passed for this change
- Vitest: `useActiveTellers`, `ActiveTellerSelector`, `BallotEntryPanel`, `BallotEntryPage`, `BallotManagementPage`, and `ballotStartRequirements` — 37 passed
- Existing Online-location create blocks remain in the listing and “Start another ballot” tests

Could not exercise the live UI in a browser in this environment.

## Out of scope (still on #287)
- Adding a teller name to an election-wide list, SignalR to other teller computers, clear does not delete, admin delete on the Tellers page
- Location editing on an open ballot
- Dark theme (#285)

## Tests
- `useActiveTellers` shares one session object and writes the same storage keys as the listing
- `ActiveTellerSelector` writes Teller 1/2 to those session globals
- Open ballot shows Teller 1/2 as those inputs; changing them sets the listing session globals
- Listing still blocks create at Online; “Start another ballot” Online block is unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1971ca7c-96bc-4bde-8cc2-a5014b430f2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1971ca7c-96bc-4bde-8cc2-a5014b430f2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

