### PR TITLE
Election teller name list via SignalR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ There are 9 hubs under `backend/Hubs/`. **Do not assume a single `election-{guid
 
 Group name patterns (constructed via `GetGroupName` statics in each hub + used for broadcasts in `SignalRNotificationService.cs`):
 
-- `Main{electionGuid}` — MainHub (election updates, statusChanged, electionClosed). Also creates `Main{ guid }Known` / `Main{ guid }Guest` variants.
+- `Main{electionGuid}` — MainHub (election updates, statusChanged, electionClosed, tellersChanged). Also creates `Main{ guid }Known` / `Main{ guid }Guest` variants.
 - `Analyze{electionGuid}` — AnalyzeHub (tallyProgress / tallyComplete).
 - `FrontDesk{electionGuid}` — FrontDeskHub (PersonAdded/Updated/Deleted, PersonCheckedIn, PersonFlagsUpdated, VoterCountUpdated, PersonVoteCountUpdated, updateBallots, reloadPage, updateOnlineElection). See `context/realtime.md`.
 - `BallotImport{electionGuid}` — BallotImportHub (importProgress, importError, importComplete; camelCase; via SignalRNotificationService).

--- a/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/SignalRNotificationServiceTests.cs
@@ -220,6 +220,45 @@ public class SignalRNotificationServiceTests
     }
 
     [Fact]
+    public async Task SendTellerUpdateAsync_sends_tellersChanged_to_base_Main_group()
+    {
+        var (service, mainClients, frontDeskClients, _, _, _, _, _, groupProxies) = CreateService();
+        var update = new TellerUpdateDto
+        {
+            ElectionGuid = _electionGuid,
+            RowId = 7,
+            Name = "Pat",
+            Action = "added"
+        };
+        var expectedGroup = MainHub.GetGroupName(_electionGuid);
+
+        await service.SendTellerUpdateAsync(update);
+
+        mainClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        mainClients.Verify(c => c.Group(expectedGroup + "Known"), Times.Never);
+        mainClients.Verify(c => c.Group(expectedGroup + "Guest"), Times.Never);
+        frontDeskClients.Verify(c => c.Group(It.IsAny<string>()), Times.Never);
+
+        Assert.True(groupProxies.TryGetValue(expectedGroup, out var proxy));
+        proxy!.Verify(
+            p => p.SendCoreAsync(
+                "tellersChanged",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var invocation = proxy.Invocations.Single(i =>
+            i.Method.Name == nameof(IClientProxy.SendCoreAsync)
+            && Equals(i.Arguments[0], "tellersChanged"));
+        var capturedArgs = Assert.IsType<object?[]>(invocation.Arguments[1]);
+        Assert.Single(capturedArgs);
+        var dto = Assert.IsType<TellerUpdateDto>(capturedArgs[0]);
+        Assert.Equal(7, dto.RowId);
+        Assert.Equal("Pat", dto.Name);
+        Assert.Equal("added", dto.Action);
+    }
+
+    [Fact]
     public async Task NotifyVoterCountUpdatedAsync_sends_VoterCountUpdated_to_FrontDesk_group()
     {
         var (service, _, frontDeskClients, _, _, _, _, _, groupProxies) = CreateService();

--- a/Backend.Tests/UnitTests/Services/TellerServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/TellerServiceTests.cs
@@ -1,0 +1,143 @@
+using Backend.DTOs.SignalR;
+using Backend.DTOs.Tellers;
+using Backend.Entities;
+using Backend.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Backend.Tests.UnitTests.Services;
+
+public class TellerServiceTests : ServiceTestBase
+{
+    private static readonly Guid ElectionGuid = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private readonly Mock<ISignalRNotificationService> _signalRMock;
+    private readonly TellerService _service;
+
+    public TellerServiceTests()
+    {
+        _signalRMock = new Mock<ISignalRNotificationService>();
+        _service = new TellerService(
+            Context,
+            Mock.Of<ILogger<TellerService>>(),
+            _signalRMock.Object);
+        SeedElection();
+    }
+
+    [Fact]
+    public async Task CreateTellerAsync_persists_name_and_notifies_added()
+    {
+        var created = await _service.CreateTellerAsync(new CreateTellerDto
+        {
+            ElectionGuid = ElectionGuid,
+            Name = "Pat"
+        });
+
+        Assert.Equal("Pat", created.Name);
+        Assert.Equal(ElectionGuid, created.ElectionGuid);
+        Assert.True(created.RowId > 0);
+
+        var listed = await _service.GetTellersByElectionAsync(ElectionGuid);
+        Assert.Single(listed.Items);
+        Assert.Equal("Pat", listed.Items[0].Name);
+
+        _signalRMock.Verify(
+            s => s.SendTellerUpdateAsync(It.Is<TellerUpdateDto>(u =>
+                u.ElectionGuid == ElectionGuid
+                && u.RowId == created.RowId
+                && u.Name == "Pat"
+                && u.Action == "added")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetTellersByElectionAsync_returns_names_alphabetically()
+    {
+        await _service.CreateTellerAsync(new CreateTellerDto { ElectionGuid = ElectionGuid, Name = "Zoe" });
+        await _service.CreateTellerAsync(new CreateTellerDto { ElectionGuid = ElectionGuid, Name = "Ann" });
+        await _service.CreateTellerAsync(new CreateTellerDto { ElectionGuid = ElectionGuid, Name = "Mia" });
+
+        var listed = await _service.GetTellersByElectionAsync(ElectionGuid);
+
+        Assert.Equal(new[] { "Ann", "Mia", "Zoe" }, listed.Items.Select(t => t.Name));
+    }
+
+    [Fact]
+    public async Task CreateTellerAsync_does_not_remove_existing_name()
+    {
+        var first = await _service.CreateTellerAsync(new CreateTellerDto
+        {
+            ElectionGuid = ElectionGuid,
+            Name = "Pat"
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreateTellerAsync(new CreateTellerDto
+            {
+                ElectionGuid = ElectionGuid,
+                Name = "Pat"
+            }));
+
+        var stillThere = await _service.GetTellerByIdAsync(first.RowId);
+        Assert.NotNull(stillThere);
+        Assert.Equal("Pat", stillThere!.Name);
+    }
+
+    [Fact]
+    public async Task DeleteTellerAsync_removes_name_and_notifies_deleted()
+    {
+        var created = await _service.CreateTellerAsync(new CreateTellerDto
+        {
+            ElectionGuid = ElectionGuid,
+            Name = "Sam"
+        });
+        _signalRMock.Invocations.Clear();
+
+        var deleted = await _service.DeleteTellerAsync(created.RowId);
+
+        Assert.True(deleted);
+        Assert.Null(await _service.GetTellerByIdAsync(created.RowId));
+
+        _signalRMock.Verify(
+            s => s.SendTellerUpdateAsync(It.Is<TellerUpdateDto>(u =>
+                u.ElectionGuid == ElectionGuid
+                && u.RowId == created.RowId
+                && u.Name == "Sam"
+                && u.Action == "deleted")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTellerAsync_notifies_updated()
+    {
+        var created = await _service.CreateTellerAsync(new CreateTellerDto
+        {
+            ElectionGuid = ElectionGuid,
+            Name = "Old"
+        });
+        _signalRMock.Invocations.Clear();
+
+        var updated = await _service.UpdateTellerAsync(created.RowId, new UpdateTellerDto { Name = "New" });
+
+        Assert.NotNull(updated);
+        Assert.Equal("New", updated!.Name);
+        _signalRMock.Verify(
+            s => s.SendTellerUpdateAsync(It.Is<TellerUpdateDto>(u =>
+                u.RowId == created.RowId && u.Name == "New" && u.Action == "updated")),
+            Times.Once);
+    }
+
+    private void SeedElection()
+    {
+        Context.Elections.Add(new Election
+        {
+            RowId = 1,
+            ElectionGuid = ElectionGuid,
+            Name = "Test Election",
+            NumberToElect = 3,
+            ElectionType = "Loc",
+            RowVersion = new byte[8]
+        });
+        Context.SaveChanges();
+    }
+}

--- a/backend/DTOs/SignalR/TellerUpdateDto.cs
+++ b/backend/DTOs/SignalR/TellerUpdateDto.cs
@@ -1,0 +1,27 @@
+namespace Backend.DTOs.SignalR;
+
+/// <summary>
+/// Election-scoped teller name list change for MainHub <c>tellersChanged</c>.
+/// </summary>
+public class TellerUpdateDto
+{
+    /// <summary>
+    /// Election whose teller name list changed.
+    /// </summary>
+    public Guid ElectionGuid { get; set; }
+
+    /// <summary>
+    /// Teller row id.
+    /// </summary>
+    public int RowId { get; set; }
+
+    /// <summary>
+    /// Teller display name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The action performed: <c>added</c>, <c>updated</c>, or <c>deleted</c>.
+    /// </summary>
+    public string Action { get; set; } = string.Empty;
+}

--- a/backend/Services/ISignalRNotificationService.cs
+++ b/backend/Services/ISignalRNotificationService.cs
@@ -156,6 +156,13 @@ public interface ISignalRNotificationService
     /// </summary>
     /// <param name="electionGuid">The election whose open sessions should refresh.</param>
     Task RequestFrontDeskReloadAsync(Guid electionGuid);
+
+    /// <summary>
+    /// Sends a teller name-list change to all teller computers on MainHub
+    /// (event <c>tellersChanged</c>, base group <c>Main{electionGuid}</c>).
+    /// </summary>
+    /// <param name="update">The teller add/update/delete payload.</param>
+    Task SendTellerUpdateAsync(TellerUpdateDto update);
 }
 
 

--- a/backend/Services/SignalRNotificationService.cs
+++ b/backend/Services/SignalRNotificationService.cs
@@ -508,6 +508,31 @@ public class SignalRNotificationService : ISignalRNotificationService
         }
     }
 
+    /// <summary>
+    /// Broadcasts a teller name-list change to every joined teller computer.
+    /// Uses the MainHub base group (session-wide membership) and camelCase
+    /// <c>tellersChanged</c>, matching other MainHub SPA listeners.
+    /// </summary>
+    public async Task SendTellerUpdateAsync(TellerUpdateDto update)
+    {
+        try
+        {
+            var groupName = MainHub.GetGroupName(update.ElectionGuid);
+            await _mainHubContext.Clients.Group(groupName).SendAsync("tellersChanged", update);
+            _logger.LogInformation(
+                "Sent tellersChanged ({Action}) notification to group {GroupName}",
+                update.Action,
+                groupName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error sending tellersChanged notification for election {ElectionGuid}",
+                update.ElectionGuid);
+        }
+    }
+
     private static List<string> DistinctNonEmpty(params string?[] values)
     {
         var result = new List<string>();

--- a/backend/Services/TellerService.cs
+++ b/backend/Services/TellerService.cs
@@ -1,5 +1,6 @@
 using Backend.Context;
 using Backend.Entities;
+using Backend.DTOs.SignalR;
 using Backend.DTOs.Tellers;
 using Backend.Helpers;
 using Backend.Models;
@@ -14,14 +15,19 @@ public class TellerService : ITellerService
 {
     private readonly MainDbContext _context;
     private readonly ILogger<TellerService> _logger;
+    private readonly ISignalRNotificationService _signalRNotificationService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TellerService"/> class.
     /// </summary>
-    public TellerService(MainDbContext context, ILogger<TellerService> logger)
+    public TellerService(
+        MainDbContext context,
+        ILogger<TellerService> logger,
+        ISignalRNotificationService signalRNotificationService)
     {
         _context = context;
         _logger = logger;
+        _signalRNotificationService = signalRNotificationService;
     }
 
     /// <inheritdoc />
@@ -93,6 +99,8 @@ public class TellerService : ITellerService
 
         _logger.LogInformation("Successfully created teller {RowId}: {TellerName}", teller.RowId, teller.Name);
 
+        await NotifyTellerChangedAsync(tellerDto, "added");
+
         return tellerDto;
     }
 
@@ -123,6 +131,8 @@ public class TellerService : ITellerService
 
         _logger.LogInformation("Successfully updated teller {RowId}: {TellerName}", teller.RowId, teller.Name);
 
+        await NotifyTellerChangedAsync(tellerDto, "updated");
+
         return tellerDto;
     }
 
@@ -141,10 +151,20 @@ public class TellerService : ITellerService
             return false;
         }
 
+        var electionGuid = teller.ElectionGuid;
+        var name = teller.Name;
+
         _context.Tellers.Remove(teller);
         await _context.SaveChangesAsync();
 
-        _logger.LogInformation("Successfully deleted teller {RowId}: {TellerName}", rowId, teller.Name);
+        _logger.LogInformation("Successfully deleted teller {RowId}: {TellerName}", rowId, name);
+
+        await NotifyTellerChangedAsync(new TellerDto
+        {
+            RowId = rowId,
+            ElectionGuid = electionGuid,
+            Name = name
+        }, "deleted");
 
         return true;
     }
@@ -161,5 +181,16 @@ public class TellerService : ITellerService
         }
 
         return !await query.AnyAsync();
+    }
+
+    private async Task NotifyTellerChangedAsync(TellerDto teller, string action)
+    {
+        await _signalRNotificationService.SendTellerUpdateAsync(new TellerUpdateDto
+        {
+            ElectionGuid = teller.ElectionGuid,
+            RowId = teller.RowId,
+            Name = teller.Name,
+            Action = action
+        });
     }
 }

--- a/context/election-state.md
+++ b/context/election-state.md
@@ -35,6 +35,15 @@ Implementation:
 - Stage source: MainHub `statusChanged` → `electionStore.currentStage`
 - Main hub membership must stay for the whole election session (`electionStore`); ballots/people pages only join/leave FrontDesk (see `context/realtime.md`)
 
+## Teller 1/2 names vs the election teller list
+
+**Status:** active  
+**Evidence:** confirmed (issue #287)
+
+Teller 1 and Teller 2 on the ballot listing and an open ballot are **browser-session** selections (shipped in #290). The **election teller list** is separate: typing a name adds it to `Teller` for that election; both dropdowns show that list alphabetically; SignalR `tellersChanged` (MainHub) updates other teller computers; clearing a dropdown does not remove the name. Only the admin Tellers page deletes a name.
+
+**Rejected alternative:** treat clear as delete. Rejected — operators reuse the same names across computers and ballots; clear only means “this workstation is not attributing that person right now.”
+
 ## Session Teller 1/2 on an open ballot
 
 **Status:** active  

--- a/context/realtime.md
+++ b/context/realtime.md
@@ -11,7 +11,7 @@ Do **not** assume a single `election-{guid}` convention for all realtime traffic
 
 | Pattern                                                     | Hub / use                                               |
 | ----------------------------------------------------------- | ------------------------------------------------------- |
-| `Main{electionGuid}` (+ `…Known` / `…Guest`)                | MainHub — shared status on **base**; role events on suffix |
+| `Main{electionGuid}` (+ `…Known` / `…Guest`)                | MainHub — shared status + teller name list on **base**; role events on suffix |
 | `Analyze{electionGuid}`                                     | AnalyzeHub — tally progress/complete                    |
 | `FrontDesk{electionGuid}`                                   | FrontDeskHub — people, ballots, online election, reload |
 | `BallotImport{electionGuid}` / `PeopleImport{electionGuid}` | import hubs (election-scoped)                           |
@@ -33,6 +33,23 @@ Frontend: `frontend/src/services/signalrService.ts` (`connectTo*Hub`, `joinElect
 - Shared election status (name, stage) is broadcast as **`statusChanged`** to the **base** group only — one payload, no double delivery.
 - Role-specific events use suffix groups (guest **`electionClosed`** → `Main{guid}Guest` only).
 - Server producers use `IHubContext<MainHub>` via `SignalRNotificationService` (and computer-assignment close-out), not client-callable hub methods.
+
+## Election teller name list (MainHub `tellersChanged`)
+
+**Status:** active  
+**Evidence:** confirmed (issue #287)  
+**Source:** issue #287 (teller-name list slice); Teller 1/2 already persist via `Teller` + Tellers page  
+**Revisit when:** teller names need FrontDesk-only fan-out, or the list grows large enough that a thin refetch is required
+
+Entering a name in Teller 1 or Teller 2 creates (or no-ops) a row on the existing election `Teller` table. Clearing the dropdown only clears this browser session’s selection (`useActiveTellers` / localStorage). It does **not** delete the election name. Admin delete stays on the existing Tellers page (`TellersListPage` + `TellerForm`).
+
+Live distribution uses MainHub **base** group `Main{electionGuid}` and camelCase **`tellersChanged`** (`TellerUpdateDto`: `electionGuid`, `rowId`, `name`, `action` = added / updated / deleted). `tellerStore` patches the in-memory list (idempotent, alphabetical). Both Teller 1/2 dropdowns read that same list.
+
+**Rejected alternative:** FrontDeskHub (PersonAdded-style events). Rejected — Tellers page and other teller computers already have session-wide MainHub membership; FrontDesk is page-owned and is left on ballots/people unmount. A FrontDesk-only event would miss the admin Tellers page unless that page also joined FrontDesk.
+
+**Rejected alternative:** a second “active teller names” table or admin screen. Rejected — the election already has `Teller` + the Tellers page for add/rename/delete.
+
+**Reason:** every teller computer that has joined the election is already in `Main{guid}`; one event keeps listing, open-ballot, front desk, and the Tellers page in sync without a new hub or page.
 
 **Rejected alternative:** leave server event as `ElectionUpdated` while FE listens for `statusChanged` (broken live updates). **Rejected alternative:** keep unused hub methods `StatusChanged` / `ElectionClosed` / `CloseOutGuestTellers` as the documented push path — they were never called by services and were client-invokable.
 

--- a/frontend/src/components/tellers/ActiveTellerSelector.vue
+++ b/frontend/src/components/tellers/ActiveTellerSelector.vue
@@ -68,6 +68,12 @@ async function ensureTellerListed(name: string) {
     });
   } catch {
     // Duplicate or validation errors are acceptable when racing other clients.
+    // Refresh so a name created on another computer still appears locally.
+    try {
+      await loadTellers();
+    } catch {
+      // Keep the typed session value even if the list cannot refresh.
+    }
   }
 }
 

--- a/frontend/src/components/tellers/__tests__/ActiveTellerSelector.spec.ts
+++ b/frontend/src/components/tellers/__tests__/ActiveTellerSelector.spec.ts
@@ -4,18 +4,29 @@ import { createI18n } from "vue-i18n";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getActiveTellers } from "@/utils/activeTellerStorage";
 import { useActiveTellers } from "@/composables/useActiveTellers";
+import { useTellerStore } from "@/stores/tellerStore";
+import type { Teller } from "@/types/teller";
 import ActiveTellerSelector from "../ActiveTellerSelector.vue";
 
-const mockFetchTellers = vi.fn();
-const mockCreateTeller = vi.fn();
-
-vi.mock("@/stores/tellerStore", () => ({
-  useTellerStore: () => ({
-    tellers: [],
-    fetchTellers: mockFetchTellers,
-    createTeller: mockCreateTeller,
-  }),
+vi.mock("@/services/tellerService", () => ({
+  tellerService: {
+    getTellersByElection: vi.fn(),
+    createTeller: vi.fn(),
+    deleteTeller: vi.fn(),
+    getTellerById: vi.fn(),
+    updateTeller: vi.fn(),
+  },
 }));
+
+vi.mock("@/services/signalrService", () => ({
+  signalrService: {
+    connectToMainHub: vi.fn().mockResolvedValue({
+      on: vi.fn(),
+    }),
+  },
+}));
+
+import { tellerService } from "@/services/tellerService";
 
 const i18n = createI18n({
   legacy: false,
@@ -34,47 +45,80 @@ const i18n = createI18n({
   },
 });
 
+function listedTeller(name: string, rowId: number): Teller {
+  return {
+    rowId,
+    electionGuid: "elec-1",
+    name,
+  };
+}
+
 function mountSelector(
   props: {
     field?: "all" | "teller1" | "teller2";
     highlightTeller1?: boolean;
   } = {},
 ) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
   return mount(ActiveTellerSelector, {
     props: {
       electionGuid: "elec-1",
       ...props,
     },
     global: {
-      plugins: [i18n, createPinia()],
+      plugins: [i18n, pinia],
       stubs: {
         ElIcon: true,
-        ElOption: true,
+        ElOption: {
+          props: ["label", "value"],
+          template: '<div class="el-option-stub">{{ label }}</div>',
+        },
         ElSelect: {
           props: ["modelValue", "placeholder"],
           emits: ["change"],
-          template:
-            '<button type="button" class="el-select-stub" :data-placeholder="placeholder" @click="$emit(\'change\', \'Pat\')">{{ modelValue }}</button>',
+          template: `
+            <div class="el-select-stub" :data-placeholder="placeholder">
+              <slot />
+              <button type="button" class="emit-named" @click="$emit('change', 'Pat')">set</button>
+              <button type="button" class="emit-clear" @click="$emit('change', undefined)">clear</button>
+            </div>
+          `,
         },
       },
     },
   });
 }
 
+function optionLabels(wrapper: ReturnType<typeof mount>, selectClass: string) {
+  return wrapper
+    .findAll(`${selectClass} .el-option-stub`)
+    .map((node) => node.text())
+    .filter((label) => label && label !== "Type to add");
+}
+
 describe("ActiveTellerSelector", () => {
   beforeEach(() => {
     localStorage.clear();
     setActivePinia(createPinia());
-    mockFetchTellers.mockReset().mockResolvedValue(undefined);
-    mockCreateTeller.mockReset().mockResolvedValue(undefined);
     useActiveTellers().refreshActiveTellers();
+    vi.mocked(tellerService.getTellersByElection).mockResolvedValue({
+      items: [],
+      totalCount: 0,
+      pageNumber: 1,
+      pageSize: 200,
+    });
+    vi.mocked(tellerService.createTeller).mockResolvedValue(
+      listedTeller("Pat", 11),
+    );
+    vi.mocked(tellerService.deleteTeller).mockResolvedValue(true);
   });
 
   it("writes Teller 1 to the browser-session globals", async () => {
     const wrapper = mountSelector();
     await flushPromises();
 
-    await wrapper.find(".teller1-select").trigger("click");
+    await wrapper.find(".teller1-select .emit-named").trigger("click");
     await flushPromises();
 
     expect(getActiveTellers().teller1).toBe("Pat");
@@ -85,7 +129,7 @@ describe("ActiveTellerSelector", () => {
     const wrapper = mountSelector();
     await flushPromises();
 
-    await wrapper.find(".teller2-select").trigger("click");
+    await wrapper.find(".teller2-select .emit-named").trigger("click");
     await flushPromises();
 
     expect(getActiveTellers().teller2).toBe("Pat");
@@ -98,5 +142,73 @@ describe("ActiveTellerSelector", () => {
 
     expect(wrapper.find(".teller1-select").exists()).toBe(true);
     expect(wrapper.find(".teller2-select").exists()).toBe(false);
+  });
+
+  it("adds an entered name to the election list and both dropdowns, alphabetically", async () => {
+    vi.mocked(tellerService.getTellersByElection).mockResolvedValue({
+      items: [listedTeller("Zoe", 1)],
+      totalCount: 1,
+      pageNumber: 1,
+      pageSize: 200,
+    });
+
+    const wrapper = mountSelector();
+    await flushPromises();
+
+    await wrapper.find(".teller1-select .emit-named").trigger("click");
+    await flushPromises();
+
+    expect(tellerService.createTeller).toHaveBeenCalledWith("elec-1", {
+      electionGuid: "elec-1",
+      name: "Pat",
+    });
+    expect(optionLabels(wrapper, ".teller1-select")).toEqual(["Pat", "Zoe"]);
+    expect(optionLabels(wrapper, ".teller2-select")).toEqual(["Pat", "Zoe"]);
+  });
+
+  it("does not delete the election name when the dropdown is cleared", async () => {
+    vi.mocked(tellerService.getTellersByElection).mockResolvedValue({
+      items: [listedTeller("Pat", 11)],
+      totalCount: 1,
+      pageNumber: 1,
+      pageSize: 200,
+    });
+
+    const wrapper = mountSelector();
+    await flushPromises();
+
+    await wrapper.find(".teller1-select .emit-named").trigger("click");
+    await flushPromises();
+    await wrapper.find(".teller1-select .emit-clear").trigger("click");
+    await flushPromises();
+
+    expect(getActiveTellers().teller1).toBe("");
+    expect(tellerService.deleteTeller).not.toHaveBeenCalled();
+    expect(useTellerStore().tellers.map((t) => t.name)).toEqual(["Pat"]);
+    expect(optionLabels(wrapper, ".teller1-select")).toEqual(["Pat"]);
+    expect(optionLabels(wrapper, ".teller2-select")).toEqual(["Pat"]);
+  });
+
+  it("shows a SignalR-added name in both dropdowns alphabetically", async () => {
+    vi.mocked(tellerService.getTellersByElection).mockResolvedValue({
+      items: [listedTeller("Zoe", 1)],
+      totalCount: 1,
+      pageNumber: 1,
+      pageSize: 200,
+    });
+
+    const wrapper = mountSelector();
+    await flushPromises();
+
+    useTellerStore().applyTellerUpdate({
+      electionGuid: "elec-1",
+      rowId: 8,
+      name: "Ann",
+      action: "added",
+    });
+    await flushPromises();
+
+    expect(optionLabels(wrapper, ".teller1-select")).toEqual(["Ann", "Zoe"]);
+    expect(optionLabels(wrapper, ".teller2-select")).toEqual(["Ann", "Zoe"]);
   });
 });

--- a/frontend/src/components/tellers/__tests__/TellerForm.spec.ts
+++ b/frontend/src/components/tellers/__tests__/TellerForm.spec.ts
@@ -1,0 +1,122 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Teller } from "@/types/teller";
+import TellerForm from "../TellerForm.vue";
+
+const mockDeleteTeller = vi.fn();
+const mockConfirm = vi.fn();
+
+vi.mock("@/stores/tellerStore", () => ({
+  useTellerStore: () => ({
+    deleteTeller: mockDeleteTeller,
+    createTeller: vi.fn(),
+    updateTeller: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/useNotifications", () => ({
+  useNotifications: () => ({
+    showSuccessMessage: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/useApiErrorHandler", () => ({
+  useApiErrorHandler: () => ({
+    handleApiError: vi.fn(),
+  }),
+}));
+
+vi.mock("element-plus", async () => {
+  const actual = await vi.importActual<typeof import("element-plus")>(
+    "element-plus",
+  );
+  return {
+    ...actual,
+    ElMessageBox: {
+      confirm: (...args: unknown[]) => mockConfirm(...args),
+    },
+  };
+});
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  messages: {
+    en: {
+      teller: {
+        form: {
+          name: "Teller Name",
+          namePlaceholder: "Enter teller name",
+          nameRequired: "required",
+          nameMaxLength: "too long",
+          save: "Save",
+          create: "Create",
+          cancel: "Cancel",
+          delete: "Delete",
+          saved: "saved",
+        },
+        confirm: {
+          deleteTellerTitle: "Warning",
+          deleteTellerMessage: 'Are you sure you want to delete teller "{name}"?',
+          delete: "Delete",
+          cancel: "Cancel",
+        },
+        success: {
+          tellerDeleted: "Teller deleted successfully",
+        },
+      },
+    },
+  },
+});
+
+const existing: Teller = {
+  rowId: 4,
+  electionGuid: "elec-1",
+  name: "Pat",
+};
+
+describe("TellerForm", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockDeleteTeller.mockReset().mockResolvedValue(undefined);
+    mockConfirm.mockReset().mockResolvedValue(true);
+  });
+
+  it("deletes a teller name from the election list on the Tellers page", async () => {
+    const wrapper = mount(TellerForm, {
+      props: {
+        electionGuid: "elec-1",
+        teller: existing,
+        isEdit: true,
+        showDelete: true,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ElForm: { template: "<form><slot /></form>" },
+          ElFormItem: { template: "<div><slot /></div>" },
+          ElInput: true,
+          ElButton: {
+            props: ["type"],
+            template:
+              '<button type="button" :data-type="type" @click="$emit(\'click\')"><slot /></button>',
+          },
+        },
+      },
+    });
+
+    const deleteButton = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Delete"));
+    expect(deleteButton).toBeTruthy();
+
+    await deleteButton!.trigger("click");
+    await flushPromises();
+
+    expect(mockConfirm).toHaveBeenCalled();
+    expect(mockDeleteTeller).toHaveBeenCalledWith("elec-1", 4);
+    expect(wrapper.emitted("deleted")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/tellers/__tests__/TellerForm.spec.ts
+++ b/frontend/src/components/tellers/__tests__/TellerForm.spec.ts
@@ -29,9 +29,8 @@ vi.mock("@/composables/useApiErrorHandler", () => ({
 }));
 
 vi.mock("element-plus", async () => {
-  const actual = await vi.importActual<typeof import("element-plus")>(
-    "element-plus",
-  );
+  const actual =
+    await vi.importActual<typeof import("element-plus")>("element-plus");
   return {
     ...actual,
     ElMessageBox: {
@@ -59,7 +58,8 @@ const i18n = createI18n({
         },
         confirm: {
           deleteTellerTitle: "Warning",
-          deleteTellerMessage: 'Are you sure you want to delete teller "{name}"?',
+          deleteTellerMessage:
+            'Are you sure you want to delete teller "{name}"?',
           delete: "Delete",
           cancel: "Cancel",
         },

--- a/frontend/src/pages/tellers/__tests__/TellersListPage.spec.ts
+++ b/frontend/src/pages/tellers/__tests__/TellersListPage.spec.ts
@@ -77,19 +77,24 @@ describe("TellersListPage", () => {
           ElTableColumn: {
             template: `
               <div>
-                <div v-for="row in [{ name: 'Ann', rowId: 1 }, { name: 'Pat', rowId: 2 }]" :key="row.rowId">
+                <div
+                  v-for="row in [{ name: 'Ann', rowId: 1 }, { name: 'Pat', rowId: 2 }]"
+                  :key="row.rowId"
+                >
                   <slot name="default" :row="row" />
                 </div>
               </div>
             `,
           },
           ElButton: {
-            template: '<button type="button" @click="$emit(\'click\')"><slot /></button>',
+            template:
+              '<button type="button" @click="$emit(\'click\')"><slot /></button>',
           },
           ElIcon: true,
           ElDrawer: {
             props: ["modelValue"],
-            template: '<div v-if="modelValue" class="drawer-stub"><slot /></div>',
+            template:
+              '<div v-if="modelValue" class="drawer-stub"><slot /></div>',
           },
           ElPagination: true,
         },

--- a/frontend/src/pages/tellers/__tests__/TellersListPage.spec.ts
+++ b/frontend/src/pages/tellers/__tests__/TellersListPage.spec.ts
@@ -1,0 +1,117 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Teller } from "@/types/teller";
+import TellersListPage from "../TellersListPage.vue";
+
+const mockFetchTellers = vi.fn();
+const mockTellers: Teller[] = [
+  { rowId: 1, electionGuid: "elec-1", name: "Ann" },
+  { rowId: 2, electionGuid: "elec-1", name: "Pat" },
+];
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ params: { id: "elec-1" } }),
+}));
+
+vi.mock("@/stores/tellerStore", () => ({
+  useTellerStore: () => ({
+    tellers: mockTellers,
+    loading: false,
+    totalCount: 2,
+    currentPage: 1,
+    pageSize: 50,
+    fetchTellers: mockFetchTellers,
+  }),
+}));
+
+vi.mock("@/composables/useApiErrorHandler", () => ({
+  useApiErrorHandler: () => ({
+    handleApiError: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/tellers/TellerForm.vue", () => ({
+  default: {
+    name: "TellerForm",
+    props: ["electionGuid", "teller", "isEdit", "showDelete"],
+    template:
+      '<div class="teller-form-stub" :data-show-delete="showDelete" :data-name="teller?.name"></div>',
+  },
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  messages: {
+    en: {
+      teller: {
+        form: {
+          titleAdd: "Add Teller",
+          titleEdit: "Edit Teller",
+          name: "Teller Name",
+        },
+        editDrawerTitle: "Edit {name}",
+      },
+    },
+  },
+});
+
+describe("TellersListPage", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockFetchTellers.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("lists election teller names and opens the existing delete form", async () => {
+    const wrapper = mount(TellersListPage, {
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ElCard: { template: "<div><slot name='header' /><slot /></div>" },
+          ElTable: {
+            props: ["data"],
+            template: '<div class="el-table-stub"><slot /></div>',
+          },
+          ElTableColumn: {
+            template: `
+              <div>
+                <div v-for="row in [{ name: 'Ann', rowId: 1 }, { name: 'Pat', rowId: 2 }]" :key="row.rowId">
+                  <slot name="default" :row="row" />
+                </div>
+              </div>
+            `,
+          },
+          ElButton: {
+            template: '<button type="button" @click="$emit(\'click\')"><slot /></button>',
+          },
+          ElIcon: true,
+          ElDrawer: {
+            props: ["modelValue"],
+            template: '<div v-if="modelValue" class="drawer-stub"><slot /></div>',
+          },
+          ElPagination: true,
+        },
+      },
+    });
+    await flushPromises();
+
+    expect(mockFetchTellers).toHaveBeenCalledWith("elec-1", 1, 50);
+    expect(wrapper.text()).toContain("Ann");
+    expect(wrapper.text()).toContain("Pat");
+
+    const nameButtons = wrapper
+      .findAll("button")
+      .filter((button) => button.text() === "Ann");
+    expect(nameButtons.length).toBeGreaterThan(0);
+    await nameButtons[0]!.trigger("click");
+    await flushPromises();
+
+    const form = wrapper.findComponent({ name: "TellerForm" });
+    expect(form.exists()).toBe(true);
+    expect(form.props("showDelete")).toBe(true);
+    expect(form.props("isEdit")).toBe(true);
+    expect(form.props("teller")).toMatchObject({ name: "Ann", rowId: 1 });
+  });
+});

--- a/frontend/src/stores/tellerStore.test.ts
+++ b/frontend/src/stores/tellerStore.test.ts
@@ -1,0 +1,155 @@
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Teller } from "@/types/teller";
+
+vi.mock("@/services/tellerService", () => ({
+  tellerService: {
+    getTellersByElection: vi.fn(),
+    getTellerById: vi.fn(),
+    createTeller: vi.fn(),
+    updateTeller: vi.fn(),
+    deleteTeller: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/signalrService", () => ({
+  signalrService: {
+    connectToMainHub: vi.fn(),
+  },
+}));
+
+import { tellerService } from "@/services/tellerService";
+import { signalrService } from "@/services/signalrService";
+import { useTellerStore } from "./tellerStore";
+
+const electionGuid = "elec-1";
+
+function teller(overrides: Partial<Teller> = {}): Teller {
+  return {
+    rowId: 1,
+    electionGuid,
+    name: "Pat",
+    ...overrides,
+  };
+}
+
+describe("tellerStore", () => {
+  let store: ReturnType<typeof useTellerStore>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    store = useTellerStore();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("createTeller adds the name and keeps the list alphabetical", async () => {
+    store.tellers = [teller({ rowId: 2, name: "Zoe" })];
+    store.totalCount = 1;
+    vi.mocked(tellerService.createTeller).mockResolvedValue(
+      teller({ rowId: 3, name: "Ann" }),
+    );
+
+    await store.createTeller(electionGuid, {
+      electionGuid,
+      name: "Ann",
+    });
+
+    expect(store.tellers.map((t) => t.name)).toEqual(["Ann", "Zoe"]);
+    expect(store.totalCount).toBe(2);
+  });
+
+  it("deleteTeller removes the name from the election list", async () => {
+    store.tellers = [
+      teller({ rowId: 1, name: "Ann" }),
+      teller({ rowId: 2, name: "Pat" }),
+    ];
+    store.totalCount = 2;
+    vi.mocked(tellerService.deleteTeller).mockResolvedValue(true);
+
+    await store.deleteTeller(electionGuid, 1);
+
+    expect(store.tellers.map((t) => t.name)).toEqual(["Pat"]);
+    expect(tellerService.deleteTeller).toHaveBeenCalledWith(electionGuid, 1);
+  });
+
+  it("registers tellersChanged on MainHub and applies added names alphabetically", async () => {
+    const handlers = new Map<string, (data: unknown) => void>();
+    vi.mocked(signalrService.connectToMainHub).mockResolvedValue({
+      on: vi.fn((event: string, handler: (data: unknown) => void) => {
+        handlers.set(event, handler);
+      }),
+    } as never);
+    vi.mocked(tellerService.getTellersByElection).mockResolvedValue({
+      items: [teller({ rowId: 1, name: "Zoe" })],
+      totalCount: 1,
+      pageNumber: 1,
+      pageSize: 50,
+    });
+
+    await store.fetchTellers(electionGuid);
+
+    expect(handlers.has("tellersChanged")).toBe(true);
+
+    handlers.get("tellersChanged")!({
+      electionGuid,
+      rowId: 4,
+      name: "Ann",
+      action: "added",
+    });
+
+    expect(store.tellers.map((t) => t.name)).toEqual(["Ann", "Zoe"]);
+  });
+
+  it("tellersChanged deleted removes the name without a refetch", async () => {
+    store.listedElectionGuid = electionGuid;
+    store.tellers = [
+      teller({ rowId: 1, name: "Ann" }),
+      teller({ rowId: 2, name: "Pat" }),
+    ];
+    store.totalCount = 2;
+
+    store.applyTellerUpdate({
+      electionGuid,
+      rowId: 1,
+      name: "Ann",
+      action: "deleted",
+    });
+
+    expect(store.tellers.map((t) => t.name)).toEqual(["Pat"]);
+    expect(store.totalCount).toBe(1);
+  });
+
+  it("ignores tellersChanged for another election", () => {
+    store.listedElectionGuid = electionGuid;
+    store.tellers = [teller()];
+
+    store.applyTellerUpdate({
+      electionGuid: "other-election",
+      rowId: 9,
+      name: "Chris",
+      action: "added",
+    });
+
+    expect(store.tellers.map((t) => t.name)).toEqual(["Pat"]);
+  });
+
+  it("tellersChanged added is idempotent when the creating client already has the row", () => {
+    store.listedElectionGuid = electionGuid;
+    store.tellers = [teller({ rowId: 5, name: "Pat" })];
+    store.totalCount = 1;
+
+    store.applyTellerUpdate({
+      electionGuid,
+      rowId: 5,
+      name: "Pat",
+      action: "added",
+    });
+
+    expect(store.tellers).toHaveLength(1);
+    expect(store.totalCount).toBe(1);
+  });
+});

--- a/frontend/src/stores/tellerStore.ts
+++ b/frontend/src/stores/tellerStore.ts
@@ -1,7 +1,15 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 import { tellerService } from "@/services/tellerService";
+import { signalrService } from "@/services/signalrService";
 import type { Teller, CreateTellerDto, UpdateTellerDto } from "@/types/teller";
+
+export interface TellerUpdateEvent {
+  electionGuid: string;
+  rowId: number;
+  name: string;
+  action: string;
+}
 
 export const useTellerStore = defineStore("teller", () => {
   const tellers = ref<Teller[]>([]);
@@ -11,20 +19,111 @@ export const useTellerStore = defineStore("teller", () => {
   const totalCount = ref(0);
   const currentPage = ref(1);
   const pageSize = ref(50);
+  const listedElectionGuid = ref<string | null>(null);
+  const signalrInitialized = ref(false);
+
+  function sortTellers() {
+    tellers.value.sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+    );
+  }
+
+  function upsertTeller(teller: Teller) {
+    const byId = tellers.value.findIndex((t) => t.rowId === teller.rowId);
+    if (byId !== -1) {
+      tellers.value[byId] = teller;
+    } else {
+      const byName = tellers.value.findIndex(
+        (t) => t.name.toLowerCase() === teller.name.toLowerCase(),
+      );
+      if (byName !== -1) {
+        tellers.value[byName] = teller;
+      } else {
+        tellers.value.push(teller);
+        totalCount.value++;
+      }
+    }
+    sortTellers();
+  }
+
+  function normalizeTellerUpdate(data: unknown): TellerUpdateEvent | null {
+    if (!data || typeof data !== "object") {
+      return null;
+    }
+    const raw = data as Record<string, unknown>;
+    const electionGuid = String(raw.electionGuid ?? raw.ElectionGuid ?? "");
+    const rowId = Number(raw.rowId ?? raw.RowId);
+    const name = String(raw.name ?? raw.Name ?? "");
+    const action = String(raw.action ?? raw.Action ?? "").toLowerCase();
+    if (!electionGuid || !Number.isFinite(rowId)) {
+      return null;
+    }
+    return { electionGuid, rowId, name, action };
+  }
+
+  function applyTellerUpdate(update: TellerUpdateEvent) {
+    if (
+      !listedElectionGuid.value ||
+      update.electionGuid.toLowerCase() !==
+        listedElectionGuid.value.toLowerCase()
+    ) {
+      return;
+    }
+
+    if (update.action === "deleted") {
+      const existed = tellers.value.some((t) => t.rowId === update.rowId);
+      tellers.value = tellers.value.filter((t) => t.rowId !== update.rowId);
+      if (existed) {
+        totalCount.value = Math.max(0, totalCount.value - 1);
+      }
+      if (currentTeller.value?.rowId === update.rowId) {
+        currentTeller.value = null;
+      }
+      return;
+    }
+
+    upsertTeller({
+      rowId: update.rowId,
+      electionGuid: update.electionGuid,
+      name: update.name,
+    });
+  }
+
+  async function initializeSignalR() {
+    if (signalrInitialized.value) {
+      return;
+    }
+
+    try {
+      const connection = await signalrService.connectToMainHub();
+      connection.on("tellersChanged", (data: unknown) => {
+        const update = normalizeTellerUpdate(data);
+        if (update) {
+          applyTellerUpdate(update);
+        }
+      });
+      signalrInitialized.value = true;
+    } catch (e) {
+      console.error("Failed to initialize SignalR for teller store:", e);
+    }
+  }
 
   async function fetchTellers(electionGuid: string, page = 1, size = 50) {
     loading.value = true;
     error.value = null;
+    listedElectionGuid.value = electionGuid;
     try {
       const response = await tellerService.getTellersByElection(
         electionGuid,
         page,
         size,
       );
-      tellers.value = response.items;
+      tellers.value = [...response.items];
+      sortTellers();
       totalCount.value = response.totalCount;
       currentPage.value = response.pageNumber;
       pageSize.value = response.pageSize;
+      await initializeSignalR();
     } catch (err: any) {
       error.value = err.message || "Failed to fetch tellers";
       throw err;
@@ -54,13 +153,14 @@ export const useTellerStore = defineStore("teller", () => {
   ) {
     loading.value = true;
     error.value = null;
+    listedElectionGuid.value = electionGuid;
     try {
       const newTeller = await tellerService.createTeller(
         electionGuid,
         tellerData,
       );
-      tellers.value.push(newTeller);
-      totalCount.value++;
+      upsertTeller(newTeller);
+      await initializeSignalR();
       return newTeller;
     } catch (err: any) {
       error.value = err.message || "Failed to create teller";
@@ -83,10 +183,7 @@ export const useTellerStore = defineStore("teller", () => {
         rowId,
         tellerData,
       );
-      const index = tellers.value.findIndex((t) => t.rowId === rowId);
-      if (index !== -1) {
-        tellers.value[index] = updatedTeller;
-      }
+      upsertTeller(updatedTeller);
       if (currentTeller.value?.rowId === rowId) {
         currentTeller.value = updatedTeller;
       }
@@ -104,8 +201,11 @@ export const useTellerStore = defineStore("teller", () => {
     error.value = null;
     try {
       await tellerService.deleteTeller(electionGuid, rowId);
+      const existed = tellers.value.some((t) => t.rowId === rowId);
       tellers.value = tellers.value.filter((t) => t.rowId !== rowId);
-      totalCount.value--;
+      if (existed) {
+        totalCount.value = Math.max(0, totalCount.value - 1);
+      }
       if (currentTeller.value?.rowId === rowId) {
         currentTeller.value = null;
       }
@@ -129,6 +229,7 @@ export const useTellerStore = defineStore("teller", () => {
     totalCount.value = 0;
     currentPage.value = 1;
     pageSize.value = 50;
+    listedElectionGuid.value = null;
   }
 
   return {
@@ -139,11 +240,14 @@ export const useTellerStore = defineStore("teller", () => {
     totalCount,
     currentPage,
     pageSize,
+    listedElectionGuid,
     fetchTellers,
     fetchTellerById,
     createTeller,
     updateTeller,
     deleteTeller,
+    applyTellerUpdate,
+    initializeSignalR,
     clearError,
     $reset,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Entering a name in Teller 1 or Teller 2 adds it to this election’s existing teller list. Clearing the dropdown only clears the browser-session selection; the name stays on the list until an admin deletes it on the Tellers page. Both dropdowns show the names alphabetically, and `tellersChanged` on MainHub updates other teller computers.

Uses the existing `Teller` entity, Tellers API, and Tellers page. No new admin page, no Azure SQL, no Playwright.

Unit tests: TellerService + `tellersChanged` SignalR contract; tellerStore apply/subscribe; ActiveTellerSelector enter/clear/both-dropdowns/SignalR; Tellers page delete form.

Related: #287 (issue stays open)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce5f94ab-a2b8-4e3b-96ce-6c8825af3111?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce5f94ab-a2b8-4e3b-96ce-6c8825af3111&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

