### PR TITLE
Soften dark theme on the election dashboard setup page

### DIFF
--- a/context/index.md
+++ b/context/index.md
@@ -14,3 +14,4 @@ Lean index of project *why* knowledge. Load a topic file only when the work touc
 - [people-import.md](people-import.md) — three-action import pipeline (not a Next/Previous wizard)
 - [sms-eligibility.md](sms-eligibility.md) — reject reserved/fictional/malformed phones before paid SMS/voice/WhatsApp; OnlineVoter.SmsStatus; ensure phone row on Person write; person detail phone status; Twilio callback auto-learn
 - [test-elections.md](test-elections.md) — duplicate as test copy (`ShowAsTest`); teller test banner; test-only runtime reset
+- [theme.md](theme.md) — dark hairlines, stage chips, and name-link tokens (dashboard/setup slice)

--- a/context/index.md
+++ b/context/index.md
@@ -14,4 +14,4 @@ Lean index of project *why* knowledge. Load a topic file only when the work touc
 - [people-import.md](people-import.md) — three-action import pipeline (not a Next/Previous wizard)
 - [sms-eligibility.md](sms-eligibility.md) — reject reserved/fictional/malformed phones before paid SMS/voice/WhatsApp; OnlineVoter.SmsStatus; ensure phone row on Person write; person detail phone status; Twilio callback auto-learn
 - [test-elections.md](test-elections.md) — duplicate as test copy (`ShowAsTest`); teller test banner; test-only runtime reset
-- [theme.md](theme.md) — dark hairlines, stage chips, and name-link tokens (dashboard/setup slice)
+- [theme.md](theme.md) — dark hairlines, stage chips, current-page chip pair, and name-link tokens (dashboard/setup slice)

--- a/context/theme.md
+++ b/context/theme.md
@@ -1,0 +1,38 @@
+# Theme tokens
+
+## Dark theme hairlines follow the light-mode scale
+
+**Status:** active  
+**Evidence:** inferred  
+**Source:** issue #285 (dashboard/setup screenshots); `tokens-dark.less` previously mapped `--el-border-color-extra-light` to `--color-gray-400`  
+**Revisit when:** another page still has dominating chrome after this token change, or Element Plus starts shipping a first-class dark theme we adopt
+
+Light-mode borders are almost invisible (`--color-gray-200` / `--color-gray-100`). Dark mode had the scale inverted: “lighter” Element Plus border tokens were *brighter* grays, and `.el-card` used raw `--color-gray-200` (`#e5e7eb`) which stays light on navy. Cards and table rules therefore framed every block.
+
+Dark `--color-border` / `--color-border-subtle` are low-opacity primary-200 so hairlines sit on navy instead of reading as white lines. `--el-border-color*` and `--el-table-border-color` point at those tokens. Light `--color-border` is still `--color-gray-200`, so the card rule change is a rename.
+
+**Rejected alternative:** restyle only People Management. The dominating lines come from shared tokens those controls already use; page-local hex would fight the next dashboard screen.
+
+**Rejected alternative:** keep the gray-700→gray-400 dark scale and only dim `.el-card`. Table-v2 row rules use `--el-border-color-lighter`, which would stay loud.
+
+## Election-stage chips use fill tokens, not light-only white
+
+**Status:** active  
+**Evidence:** confirmed  
+**Source:** issue #285; `StageControl.vue` had `#fff` / `#dcdfe6` / `#606266`  
+**Revisit when:** stage chips gain a selected-outline treatment that needs its own token
+
+Unselected stage buttons are `<button class="stage-control__seg">` with CSS fills. Hardcoded white/gray made them look like light-theme leftovers on the navy sidebar. They now use `--el-fill-color-blank`, `--el-border-color`, and `--el-text-color-regular` so dark mode gets gray-900 chips. Selected still paints `--color-stage-*` inline.
+
+**Rejected alternative:** a `--color-stage-chip-*` pair. The Element Plus fill/border tokens already mean “unselected control surface.”
+
+## Names use `--color-text-link`, not `--el-color-primary`
+
+**Status:** active  
+**Evidence:** inferred  
+**Source:** issue #285 names-list contrast; People table uses `el-button type="primary" link`  
+**Revisit when:** primary solid buttons also need a lighter dark fill
+
+`--el-color-primary` is `#2563a8` in both themes. That hue pops on white and goes muddy on `#0e2040` / `#111827`. Brightening `--el-color-primary` in dark would also recolor solid primary actions (Add Person). `--color-text-link` is primary-500 in light (same as today) and primary-300 in dark. `PeopleTable` name buttons set `--el-button-text-color` from that token.
+
+**Rejected alternative:** change dark `--el-color-primary`. Out of scope for this dashboard slice and would shift every primary fill.

--- a/context/theme.md
+++ b/context/theme.md
@@ -9,7 +9,7 @@
 
 Light-mode borders are almost invisible (`--color-gray-200` / `--color-gray-100`). Dark mode had the scale inverted: “lighter” Element Plus border tokens were *brighter* grays, and `.el-card` used raw `--color-gray-200` (`#e5e7eb`) which stays light on navy. Cards and table rules therefore framed every block.
 
-Dark `--color-border` / `--color-border-subtle` are low-opacity primary-200 so hairlines sit on navy instead of reading as white lines. `--el-border-color*` and `--el-table-border-color` point at those tokens. Light `--color-border` is still `--color-gray-200`, so the card rule change is a rename.
+Dark `--color-border` / `--color-border-subtle` are low-opacity primary-200 so hairlines sit on navy instead of reading as white lines. `--el-border-color*` and `--el-table-border-color` point at those tokens. Light `--color-border` is still `--color-gray-200`, so the card rule change is a rename. `--color-sidebar-active` is `#2563a8` so the current page is a real chip, not the same navy as the sidebar border.
 
 **Rejected alternative:** restyle only People Management. The dominating lines come from shared tokens those controls already use; page-local hex would fight the next dashboard screen.
 
@@ -33,6 +33,6 @@ Unselected stage buttons are `<button class="stage-control__seg">` with CSS fill
 **Source:** issue #285 names-list contrast; People table uses `el-button type="primary" link`  
 **Revisit when:** primary solid buttons also need a lighter dark fill
 
-`--el-color-primary` is `#2563a8` in both themes. That hue pops on white and goes muddy on `#0e2040` / `#111827`. Brightening `--el-color-primary` in dark would also recolor solid primary actions (Add Person). `--color-text-link` is primary-500 in light (same as today) and primary-300 in dark. `PeopleTable` name buttons set `--el-button-text-color` from that token.
+`--el-color-primary` is `#2563a8` in both themes. That hue pops on white and goes muddy on `#0e2040` / `#111827`. Brightening `--el-color-primary` in dark would also recolor solid primary actions (Add Person). `--color-text-link` is primary-500 in light (same as today) and primary-200 in dark. `PeopleTable` name buttons set `--el-button-text-color` from that token.
 
 **Rejected alternative:** change dark `--el-color-primary`. Out of scope for this dashboard slice and would shift every primary fill.

--- a/context/theme.md
+++ b/context/theme.md
@@ -9,7 +9,18 @@
 
 Light-mode borders are almost invisible (`--color-gray-200` / `--color-gray-100`). Dark mode had the scale inverted: “lighter” Element Plus border tokens were *brighter* grays, and `.el-card` used raw `--color-gray-200` (`#e5e7eb`) which stays light on navy. Cards and table rules therefore framed every block.
 
-Dark `--color-border` / `--color-border-subtle` are low-opacity primary-200 so hairlines sit on navy instead of reading as white lines. `--el-border-color*` and `--el-table-border-color` point at those tokens. Light `--color-border` is still `--color-gray-200`, so the card rule change is a rename. `--color-sidebar-active` is `#2563a8` so the current page is a real chip, not the same navy as the sidebar border.
+Dark `--color-border` / `--color-border-subtle` are low-opacity primary-200 so hairlines sit on navy instead of reading as white lines. `--el-border-color*` and `--el-table-border-color` point at those tokens. Light `--color-border` is still `--color-gray-200`, so the card rule change is a rename.
+
+## Dark current-page chip is fill plus light text
+
+**Status:** active  
+**Evidence:** inferred  
+**Source:** issue #285 current-menu highlight; PR review of the `#2563a8` + orange pairing  
+**Revisit when:** the dark sidebar palette is retuned
+
+`.stage-group__page.is-active` and Dashboard `.el-menu-item.is-active` both use `--color-sidebar-active` + `--color-sidebar-text-active`. The loud chip is `#2563a8`. Orange `#f47920` on that fill is about 2.2:1 (below WCAG AA 4.5:1 for 14px menu text). Active text is `#eef2f9` (primary-50 / light sidebar background) so the label stays light-on-chip, about 5.4:1, the same idea as light mode’s dark navy on `#d4dff0`.
+
+**Rejected alternative:** keep orange and darken the fill. Orange needs a fill near the old `#14284d` to stay at ~5.4:1. That fill is the weak chip, and it is not distinct enough from `--color-sidebar-hover` (`#1c3a6a`; orange on hover is only ~4.1:1).
 
 **Rejected alternative:** restyle only People Management. The dominating lines come from shared tokens those controls already use; page-local hex would fight the next dashboard screen.
 
@@ -22,7 +33,7 @@ Dark `--color-border` / `--color-border-subtle` are low-opacity primary-200 so h
 **Source:** issue #285; `StageControl.vue` had `#fff` / `#dcdfe6` / `#606266`  
 **Revisit when:** stage chips gain a selected-outline treatment that needs its own token
 
-Unselected stage buttons are `<button class="stage-control__seg">` with CSS fills. Hardcoded white/gray made them look like light-theme leftovers on the navy sidebar. They now use `--el-fill-color-blank`, `--el-border-color`, and `--el-text-color-regular` so dark mode gets gray-900 chips. Selected still paints `--color-stage-*` inline.
+Unselected stage buttons are `<button class="stage-control__seg">` with CSS fills. Hardcoded white/gray made them look like light-theme leftovers on the navy sidebar. Fill and hairline are `--el-fill-color-blank` (white in light, gray-900 in dark) and `--el-border-color`. Unselected text is `--el-text-color-regular` in light; `html.dark .stage-control__seg:not(.is-selected)` sets `--color-sidebar-text` (`#a8bfe1`), not `--el-text-color-regular` (`--color-gray-300`). Selected still paints `--color-stage-*` inline.
 
 **Rejected alternative:** a `--color-stage-chip-*` pair. The Element Plus fill/border tokens already mean “unselected control surface.”
 

--- a/frontend/src/components/nav/StageControl.vue
+++ b/frontend/src/components/nav/StageControl.vue
@@ -78,7 +78,7 @@ async function selectStage(newStage: ElectionStage) {
   align-items: stretch;
   border-radius: 6px;
   overflow: hidden;
-  border: 1px solid #dcdfe6;
+  border: 1px solid var(--el-border-color);
   flex-direction: column;
   gap: 10px;
 
@@ -87,13 +87,13 @@ async function selectStage(newStage: ElectionStage) {
     align-items: center;
     gap: 6px;
     padding: 6px 14px;
-    background: #fff;
+    background: var(--el-fill-color-blank);
     border: none;
-    border-bottom: 1px solid #dcdfe6;
+    border-bottom: 1px solid var(--el-border-color);
     cursor: pointer;
     font-size: 13px;
     font-weight: 500;
-    color: #606266;
+    color: var(--el-text-color-regular);
     transition:
       background 0.15s,
       color 0.15s;
@@ -103,7 +103,7 @@ async function selectStage(newStage: ElectionStage) {
     }
 
     &:hover:not(.is-selected) {
-      background: #f5f7fa;
+      background: var(--el-fill-color-light);
     }
 
     &.is-selected {

--- a/frontend/src/components/nav/StageControl.vue
+++ b/frontend/src/components/nav/StageControl.vue
@@ -116,4 +116,8 @@ async function selectStage(newStage: ElectionStage) {
     }
   }
 }
+
+html.dark .stage-control__seg:not(.is-selected) {
+  color: var(--color-sidebar-text);
+}
 </style>

--- a/frontend/src/components/nav/__tests__/StageControl.test.ts
+++ b/frontend/src/components/nav/__tests__/StageControl.test.ts
@@ -164,6 +164,9 @@ describe("StageControl", () => {
       expect(source).toContain("background: var(--el-fill-color-blank)");
       expect(source).toContain("border: 1px solid var(--el-border-color)");
       expect(source).toContain("color: var(--el-text-color-regular)");
+      expect(source).toContain(
+        "html.dark .stage-control__seg:not(.is-selected)",
+      );
       expect(source).not.toMatch(/background:\s*#fff\b/);
       expect(source).not.toMatch(/background:\s*#ffffff\b/i);
     });

--- a/frontend/src/components/nav/__tests__/StageControl.test.ts
+++ b/frontend/src/components/nav/__tests__/StageControl.test.ts
@@ -120,6 +120,55 @@ describe("StageControl", () => {
     });
   });
 
+  describe("unselected stage styling", () => {
+    it("leaves unselected stages without an inline fill (theme tokens style them)", () => {
+      const wrapper = mount(StageControl, {
+        props: { electionGuid: "test-guid", stage: "GatheringBallots" },
+        global: { stubs: globalStubs },
+      });
+      const radios = wrapper.findAll('[role="radio"]');
+      const unselected = radios.filter(
+        (r) => r.attributes("aria-checked") !== "true",
+      );
+      expect(unselected.length).toBe(3);
+      for (const btn of unselected) {
+        const style = btn.attributes("style") ?? "";
+        expect(style).not.toMatch(/background/i);
+        expect(style).not.toMatch(/#fff|#ffffff|white/i);
+      }
+    });
+
+    it("applies the selected-stage fill only on the current stage", () => {
+      const wrapper = mount(StageControl, {
+        props: { electionGuid: "test-guid", stage: "GatheringBallots" },
+        global: { stubs: globalStubs },
+      });
+      const selected = wrapper
+        .findAll('[role="radio"]')
+        .find((r) => r.attributes("aria-checked") === "true");
+      expect(selected).toBeDefined();
+      expect(selected!.attributes("style")).toContain("--color-stage-gather");
+    });
+  });
+
+  describe("theme tokens (no light-only chip colors)", () => {
+    it("styles unselected chips with fill/border tokens, not hardcoded white", async () => {
+      const { default: fs } = await import("node:fs");
+      const { default: path } = await import("node:path");
+      const { fileURLToPath } = await import("node:url");
+      const dir = path.dirname(fileURLToPath(import.meta.url));
+      const source = fs.readFileSync(
+        path.resolve(dir, "../StageControl.vue"),
+        "utf8",
+      );
+      expect(source).toContain("background: var(--el-fill-color-blank)");
+      expect(source).toContain("border: 1px solid var(--el-border-color)");
+      expect(source).toContain("color: var(--el-text-color-regular)");
+      expect(source).not.toMatch(/background:\s*#fff\b/);
+      expect(source).not.toMatch(/background:\s*#ffffff\b/i);
+    });
+  });
+
   describe("reactive updates", () => {
     it("updates aria-checked when stage prop changes", async () => {
       const wrapper = mount(StageControl, {

--- a/frontend/src/components/nav/__tests__/StageGroupedSidebarMenu.test.ts
+++ b/frontend/src/components/nav/__tests__/StageGroupedSidebarMenu.test.ts
@@ -293,6 +293,24 @@ describe("StageGroupedSidebarMenu", () => {
     });
   });
 
+  describe("current page highlight", () => {
+    it("marks the matching page with is-active", () => {
+      const peoplePage = STAGE_PAGES.SettingUp.find((p) => p.key === "people");
+      expect(peoplePage).toBeDefined();
+      mockRoutePath.mockReturnValue(peoplePage!.routePath("test-id"));
+
+      const wrapper = mountMenu({
+        isGuestTeller: false,
+        currentStage: "SettingUp",
+        electionGuid: "test-id",
+      });
+
+      const active = wrapper.findAll(".stage-group__page.is-active");
+      expect(active).toHaveLength(1);
+      expect(active[0]!.text()).toContain(peoplePage!.i18nKey);
+    });
+  });
+
   describe("page navigation", () => {
     it("calls router.push when a page item is clicked (admin)", async () => {
       const wrapper = mountMenu({

--- a/frontend/src/components/people/PeopleTable.vue
+++ b/frontend/src/components/people/PeopleTable.vue
@@ -31,6 +31,7 @@ const columns = computed<Column<any>[]>(() => [
         {
           type: "primary",
           link: true,
+          class: "people-table__name",
           onClick: () => emit("edit", rowData),
         },
         { default: () => rowData.fullName },
@@ -97,5 +98,12 @@ const columns = computed<Column<any>[]>(() => [
 .people-table {
   width: 100%;
   min-height: 200px;
+
+  .people-table__name {
+    --el-button-text-color: var(--color-text-link);
+    --el-button-hover-text-color: var(--color-text-link-hover);
+    --el-button-hover-link-text-color: var(--color-text-link-hover);
+    font-weight: var(--font-weight-medium);
+  }
 }
 </style>

--- a/frontend/src/components/people/__tests__/PeopleTable.test.ts
+++ b/frontend/src/components/people/__tests__/PeopleTable.test.ts
@@ -1,0 +1,67 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { h } from "vue";
+import type { PersonListDto } from "../../../types";
+import PeopleTable from "../PeopleTable.vue";
+
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const samplePerson: PersonListDto = {
+  personGuid: "p-1",
+  fullName: "Afonso [Little], Pedro [Glen]",
+  email: "pedro@example.com",
+  phone: "555-0100",
+  area: "A",
+};
+
+const TableStub = {
+  props: ["columns", "data"],
+  setup(props: { columns: Array<{ cellRenderer?: Function }>; data: PersonListDto[] }) {
+    return () =>
+      h(
+        "div",
+        { class: "table-stub" },
+        props.columns.map((col, index) =>
+          col.cellRenderer
+            ? h("div", { key: index }, [col.cellRenderer({ rowData: props.data[0] })])
+            : null,
+        ),
+      );
+  },
+};
+
+const AutoResizerStub = {
+  template: "<div><slot :height=\"400\" :width=\"800\" /></div>",
+};
+
+describe("PeopleTable", () => {
+  it("renders names as primary link buttons that use the link token class", () => {
+    const wrapper = mount(PeopleTable, {
+      props: {
+        people: [samplePerson],
+        loading: false,
+        tableHeight: 400,
+      },
+      global: {
+        stubs: {
+          ElAutoResizer: AutoResizerStub,
+          ElTableV2: TableStub,
+          ElButton: {
+            props: ["type", "link", "class"],
+            template:
+              '<button class="el-button" :class="$attrs.class || class"><slot /></button>',
+          },
+          ElIcon: { template: "<span />" },
+        },
+      },
+    });
+
+    const nameButton = wrapper.find(".people-table__name");
+    expect(nameButton.exists()).toBe(true);
+    expect(nameButton.text()).toBe(samplePerson.fullName);
+  });
+});

--- a/frontend/src/components/people/__tests__/PeopleTable.test.ts
+++ b/frontend/src/components/people/__tests__/PeopleTable.test.ts
@@ -1,4 +1,5 @@
 import { mount } from "@vue/test-utils";
+import { ElButton } from "element-plus";
 import { describe, expect, it, vi } from "vitest";
 import { h } from "vue";
 import type { PersonListDto } from "../../../types";
@@ -19,23 +20,43 @@ const samplePerson: PersonListDto = {
 };
 
 const TableStub = {
+  name: "ElTableV2",
   props: ["columns", "data"],
-  setup(props: { columns: Array<{ cellRenderer?: Function }>; data: PersonListDto[] }) {
-    return () =>
-      h(
+  setup(props: {
+    columns: Array<{
+      cellRenderer?: (args: { rowData: PersonListDto }) => unknown;
+    }>;
+    data: PersonListDto[];
+  }) {
+    return () => {
+      const row = props.data[0];
+      return h(
         "div",
         { class: "table-stub" },
-        props.columns.map((col, index) =>
-          col.cellRenderer
-            ? h("div", { key: index }, [col.cellRenderer({ rowData: props.data[0] })])
-            : null,
-        ),
+        props.columns
+          .filter((col) => col.cellRenderer)
+          .map((col, index) =>
+            h("div", { key: index }, [col.cellRenderer!({ rowData: row })]),
+          ),
       );
+    };
   },
 };
 
 const AutoResizerStub = {
-  template: "<div><slot :height=\"400\" :width=\"800\" /></div>",
+  name: "ElAutoResizer",
+  setup(
+    _props: unknown,
+    {
+      slots,
+    }: {
+      slots: {
+        default?: (props: { height: number; width: number }) => unknown;
+      };
+    },
+  ) {
+    return () => h("div", slots.default?.({ height: 400, width: 800 }));
+  },
 };
 
 describe("PeopleTable", () => {
@@ -47,14 +68,11 @@ describe("PeopleTable", () => {
         tableHeight: 400,
       },
       global: {
+        components: { ElButton },
+        directives: { loading: () => undefined },
         stubs: {
           ElAutoResizer: AutoResizerStub,
           ElTableV2: TableStub,
-          ElButton: {
-            props: ["type", "link", "class"],
-            template:
-              '<button class="el-button" :class="$attrs.class || class"><slot /></button>',
-          },
           ElIcon: { template: "<span />" },
         },
       },

--- a/frontend/src/styles/__tests__/darkThemeTokens.test.ts
+++ b/frontend/src/styles/__tests__/darkThemeTokens.test.ts
@@ -39,7 +39,7 @@ describe("dark theme tokens (dashboard/setup polish)", () => {
   });
 
   it("makes the current sidebar item stronger than hover/border", () => {
-    expect(tokenValue(dark, "--color-sidebar-active")).toBe("#1e4f8c");
+    expect(tokenValue(dark, "--color-sidebar-active")).toBe("#2563a8");
     expect(tokenValue(dark, "--color-sidebar-active")).not.toBe(
       tokenValue(dark, "--color-sidebar-border"),
     );
@@ -53,7 +53,7 @@ describe("dark theme tokens (dashboard/setup polish)", () => {
       "var(--color-primary-500)",
     );
     expect(tokenValue(dark, "--color-text-link")).toBe(
-      "var(--color-primary-300)",
+      "var(--color-primary-200)",
     );
   });
 });

--- a/frontend/src/styles/__tests__/darkThemeTokens.test.ts
+++ b/frontend/src/styles/__tests__/darkThemeTokens.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dark = readFileSync(resolve(here, "../tokens-dark.less"), "utf8");
+const light = readFileSync(resolve(here, "../tokens.less"), "utf8");
+const elementPlus = readFileSync(resolve(here, "../element-plus.less"), "utf8");
+
+function tokenValue(source: string, name: string): string {
+  const match = source.match(new RegExp(`${name}:\\s*([^;]+);`));
+  if (!match?.[1]) {
+    throw new Error(`Token ${name} not found`);
+  }
+  return match[1].trim();
+}
+
+describe("dark theme tokens (dashboard/setup polish)", () => {
+  it("keeps light-mode borders on the previous gray-200 card hairline", () => {
+    expect(tokenValue(light, "--color-border")).toBe("var(--color-gray-200)");
+    expect(elementPlus).toContain("border: 1px solid var(--color-border)");
+    expect(elementPlus).not.toContain("border: 1px solid var(--color-gray-200)");
+  });
+
+  it("uses low-contrast navy hairlines in dark mode instead of inverted gray-400/500", () => {
+    expect(tokenValue(dark, "--color-border")).toMatch(/rgba\(\s*168,\s*191,\s*225/i);
+    expect(tokenValue(dark, "--el-border-color")).toBe("var(--color-border)");
+    expect(tokenValue(dark, "--el-border-color-extra-light")).not.toBe(
+      "var(--color-gray-400)",
+    );
+    expect(dark).not.toMatch(
+      /--el-border-color-extra-light:\s*var\(--color-gray-400\)/,
+    );
+  });
+
+  it("makes the current sidebar item stronger than hover/border", () => {
+    expect(tokenValue(dark, "--color-sidebar-active")).toBe("#1e4f8c");
+    expect(tokenValue(dark, "--color-sidebar-active")).not.toBe(
+      tokenValue(dark, "--color-sidebar-border"),
+    );
+    expect(tokenValue(dark, "--color-sidebar-active")).not.toBe(
+      tokenValue(dark, "--color-sidebar-hover"),
+    );
+  });
+
+  it("brightens link/name text in dark while light stays primary-500", () => {
+    expect(tokenValue(light, "--color-text-link")).toBe("var(--color-primary-500)");
+    expect(tokenValue(dark, "--color-text-link")).toBe("var(--color-primary-300)");
+  });
+});

--- a/frontend/src/styles/__tests__/darkThemeTokens.test.ts
+++ b/frontend/src/styles/__tests__/darkThemeTokens.test.ts
@@ -16,6 +16,29 @@ function tokenValue(source: string, name: string): string {
   return match[1].trim();
 }
 
+function hexChannelToLinear(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(hex: string): number {
+  if (!/^#[0-9a-fA-F]{6}$/.test(hex)) {
+    throw new Error(`Expected #rrggbb, got ${hex}`);
+  }
+  const n = Number.parseInt(hex.slice(1), 16);
+  const r = hexChannelToLinear((n >> 16) & 255);
+  const g = hexChannelToLinear((n >> 8) & 255);
+  const b = hexChannelToLinear(n & 255);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const a = relativeLuminance(foreground);
+  const b = relativeLuminance(background);
+  const [hi, lo] = a > b ? [a, b] : [b, a];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
 describe("dark theme tokens (dashboard/setup polish)", () => {
   it("keeps light-mode borders on the previous gray-200 card hairline", () => {
     expect(tokenValue(light, "--color-border")).toBe("var(--color-gray-200)");
@@ -38,14 +61,14 @@ describe("dark theme tokens (dashboard/setup polish)", () => {
     );
   });
 
-  it("makes the current sidebar item stronger than hover/border", () => {
-    expect(tokenValue(dark, "--color-sidebar-active")).toBe("#2563a8");
-    expect(tokenValue(dark, "--color-sidebar-active")).not.toBe(
-      tokenValue(dark, "--color-sidebar-border"),
-    );
-    expect(tokenValue(dark, "--color-sidebar-active")).not.toBe(
-      tokenValue(dark, "--color-sidebar-hover"),
-    );
+  it("pairs the current-page chip fill with light text that meets WCAG AA", () => {
+    const activeFill = tokenValue(dark, "--color-sidebar-active");
+    const activeText = tokenValue(dark, "--color-sidebar-text-active");
+    expect(activeFill).toBe("#2563a8");
+    expect(activeText).toBe("#eef2f9");
+    expect(activeFill).not.toBe(tokenValue(dark, "--color-sidebar-border"));
+    expect(activeFill).not.toBe(tokenValue(dark, "--color-sidebar-hover"));
+    expect(contrastRatio(activeText, activeFill)).toBeGreaterThanOrEqual(4.5);
   });
 
   it("brightens link/name text in dark while light stays primary-500", () => {

--- a/frontend/src/styles/__tests__/darkThemeTokens.test.ts
+++ b/frontend/src/styles/__tests__/darkThemeTokens.test.ts
@@ -20,11 +20,15 @@ describe("dark theme tokens (dashboard/setup polish)", () => {
   it("keeps light-mode borders on the previous gray-200 card hairline", () => {
     expect(tokenValue(light, "--color-border")).toBe("var(--color-gray-200)");
     expect(elementPlus).toContain("border: 1px solid var(--color-border)");
-    expect(elementPlus).not.toContain("border: 1px solid var(--color-gray-200)");
+    expect(elementPlus).not.toContain(
+      "border: 1px solid var(--color-gray-200)",
+    );
   });
 
   it("uses low-contrast navy hairlines in dark mode instead of inverted gray-400/500", () => {
-    expect(tokenValue(dark, "--color-border")).toMatch(/rgba\(\s*168,\s*191,\s*225/i);
+    expect(tokenValue(dark, "--color-border")).toMatch(
+      /rgba\(\s*168,\s*191,\s*225/i,
+    );
     expect(tokenValue(dark, "--el-border-color")).toBe("var(--color-border)");
     expect(tokenValue(dark, "--el-border-color-extra-light")).not.toBe(
       "var(--color-gray-400)",
@@ -45,7 +49,11 @@ describe("dark theme tokens (dashboard/setup polish)", () => {
   });
 
   it("brightens link/name text in dark while light stays primary-500", () => {
-    expect(tokenValue(light, "--color-text-link")).toBe("var(--color-primary-500)");
-    expect(tokenValue(dark, "--color-text-link")).toBe("var(--color-primary-300)");
+    expect(tokenValue(light, "--color-text-link")).toBe(
+      "var(--color-primary-500)",
+    );
+    expect(tokenValue(dark, "--color-text-link")).toBe(
+      "var(--color-primary-300)",
+    );
   });
 });

--- a/frontend/src/styles/element-plus.less
+++ b/frontend/src/styles/element-plus.less
@@ -111,7 +111,7 @@
 .el-card {
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
-  border: 1px solid var(--color-gray-200);
+  border: 1px solid var(--color-border);
   transition: var(--transition-normal);
 
   &:hover {

--- a/frontend/src/styles/tokens-dark.less
+++ b/frontend/src/styles/tokens-dark.less
@@ -13,13 +13,13 @@
   --color-text-secondary: var(--color-gray-300);
   --color-text-tertiary: var(--color-gray-400);
   /* Brighter than --el-color-primary so names/links read on navy, like primary-500 on white */
-  --color-text-link: var(--color-primary-300);
-  --color-text-link-hover: var(--color-primary-200);
+  --color-text-link: var(--color-primary-200);
+  --color-text-link-hover: var(--color-primary-100);
 
   /* Soft hairlines: extra-light is the least visible, matching the light-theme scale.
      The previous mapping inverted that (extra-light was gray-400) so borders dominated. */
-  --color-border: rgba(168, 191, 225, 0.14);
-  --color-border-subtle: rgba(168, 191, 225, 0.08);
+  --color-border: rgba(168, 191, 225, 0.1);
+  --color-border-subtle: rgba(168, 191, 225, 0.06);
 
   /* Election stage dark theme */
   --color-stage-setup: #4f8fcc;
@@ -36,7 +36,7 @@
   --color-sidebar-border: #14284d;
   --color-sidebar-hover: #1c3a6a;
   /* Stronger than hover (was #14284d, same as border and barely above bg) */
-  --color-sidebar-active: #1e4f8c;
+  --color-sidebar-active: #2563a8;
 
   /* Front Desk layout dark theme */
   --color-frontdesk-sidebar-bg: #0a1528;

--- a/frontend/src/styles/tokens-dark.less
+++ b/frontend/src/styles/tokens-dark.less
@@ -32,7 +32,8 @@
   /* Sidebar dark theme */
   --color-sidebar-bg: #0e2040;
   --color-sidebar-text: #a8bfe1;
-  --color-sidebar-text-active: #f47920;
+  /* Light-on-chip pair with --color-sidebar-active; orange #f47920 is ~2.2:1 on #2563a8 */
+  --color-sidebar-text-active: #eef2f9;
   --color-sidebar-border: #14284d;
   --color-sidebar-hover: #1c3a6a;
   /* Stronger than hover (was #14284d, same as border and barely above bg) */

--- a/frontend/src/styles/tokens-dark.less
+++ b/frontend/src/styles/tokens-dark.less
@@ -12,6 +12,14 @@
   --color-text-primary: var(--color-gray-50);
   --color-text-secondary: var(--color-gray-300);
   --color-text-tertiary: var(--color-gray-400);
+  /* Brighter than --el-color-primary so names/links read on navy, like primary-500 on white */
+  --color-text-link: var(--color-primary-300);
+  --color-text-link-hover: var(--color-primary-200);
+
+  /* Soft hairlines: extra-light is the least visible, matching the light-theme scale.
+     The previous mapping inverted that (extra-light was gray-400) so borders dominated. */
+  --color-border: rgba(168, 191, 225, 0.14);
+  --color-border-subtle: rgba(168, 191, 225, 0.08);
 
   /* Election stage dark theme */
   --color-stage-setup: #4f8fcc;
@@ -27,7 +35,8 @@
   --color-sidebar-text-active: #f47920;
   --color-sidebar-border: #14284d;
   --color-sidebar-hover: #1c3a6a;
-  --color-sidebar-active: #14284d;
+  /* Stronger than hover (was #14284d, same as border and barely above bg) */
+  --color-sidebar-active: #1e4f8c;
 
   /* Front Desk layout dark theme */
   --color-frontdesk-sidebar-bg: #0a1528;
@@ -87,10 +96,11 @@
   --el-text-color-disabled: var(--color-gray-600);
   --el-input-text-color: var(--color-gray-50);
 
-  --el-border-color: var(--color-gray-700);
-  --el-border-color-light: var(--color-gray-600);
-  --el-border-color-lighter: var(--color-gray-500);
-  --el-border-color-extra-light: var(--color-gray-400);
+  --el-border-color: var(--color-border);
+  --el-border-color-light: var(--color-border-subtle);
+  --el-border-color-lighter: var(--color-border-subtle);
+  --el-border-color-extra-light: rgba(168, 191, 225, 0.05);
+  --el-table-border-color: var(--color-border-subtle);
 
   --el-fill-color-blank: var(--color-gray-900);
   --el-fill-color-light: var(--color-gray-800);

--- a/frontend/src/styles/tokens.less
+++ b/frontend/src/styles/tokens.less
@@ -157,6 +157,13 @@
   --color-text-secondary: var(--color-gray-600);
   --color-text-tertiary: var(--color-gray-500);
   --color-text-inverse: #ffffff;
+  /* Link emphasis (people names, primary text links). Same hue as --el-color-primary in light. */
+  --color-text-link: var(--color-primary-500);
+  --color-text-link-hover: var(--color-primary-700);
+
+  /* Hairline borders — light-mode gray-200 matches the previous .el-card rule */
+  --color-border: var(--color-gray-200);
+  --color-border-subtle: var(--color-gray-100);
 
   /* Spacing */
   --spacing-1: 0.25rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related: #285 (issue stays open)

Dark mode on the election dashboard / People Management (setup) page was harder to use than light mode: hairlines framed every block, unselected election-stage chips stayed white, names in the list looked muted, and the current sidebar item barely showed.

This slice only adjusts the shared tokens those controls already use, plus the two components that had light-only hex.

### What changed
- **Borders:** Dark `--el-border-color*` and a new `--color-border` use low-opacity navy hairlines instead of inverted gray-400/500. `.el-card` now reads `--color-border` (still gray-200 in light).
- **Stage chips:** `StageControl` unselected fill is `--el-fill-color-blank` (gray-900 in dark). Unselected text is `--el-text-color-regular` in light and `--color-sidebar-text` in dark.
- **Names:** `--color-text-link` is primary-500 in light (unchanged) and primary-200 in dark. People table name buttons consume that token.
- **Current menu item:** Dark `--color-sidebar-active` is `#2563a8` (a real chip, distinct from hover/border). Active text is `#eef2f9`, not orange — orange on that fill is ~2.2:1. Light-on-chip is ~5.4:1 (WCAG AA) for both the election sidebar and Dashboard `el-menu`.

Light mode is the reference. Token defaults keep the previous light hairline and name color.

### Tests
Vitest + jsdom only (no Playwright): StageControl, StageGroupedSidebarMenu current-page class, PeopleTable name class, and a dark-token contract test that asserts the active fill/text pair stays at least 4.5:1.

Other pages may still need work after this slice. I could not log into a live People Management screen in this environment, so please flip the theme on that page when reviewing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd15386c-62cb-473f-b494-206c4ccb5c88?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd15386c-62cb-473f-b494-206c4ccb5c88&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

