### PR TITLE
Online location: type badge, sort-only edit, i18n display name

### DIFF
--- a/Backend.Tests/UnitTests/Helpers/LocationDisplayHelperTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/LocationDisplayHelperTests.cs
@@ -1,0 +1,54 @@
+using Backend.Entities;
+using Backend.Enumerations;
+using Backend.Helpers;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class LocationDisplayHelperTests
+{
+    [Fact]
+    public void FormatName_UsesLocalizer_ForOnlineTypeRegardlessOfStoredName()
+    {
+        var location = new Location
+        {
+            Name = "Hall A",
+            LocationTypeCode = nameof(LocationType.Online)
+        };
+
+        var label = LocationDisplayHelper.FormatName(location, _ => "Online");
+
+        Assert.Equal("Online", label);
+    }
+
+    [Fact]
+    public void FormatName_UsesStoredName_ForPaperLocation()
+    {
+        var location = new Location
+        {
+            Name = "Main Hall",
+            LocationTypeCode = nameof(LocationType.Manual)
+        };
+
+        var label = LocationDisplayHelper.FormatName(location, _ => "Online");
+
+        Assert.Equal("Main Hall", label);
+    }
+
+    [Fact]
+    public void IsOnlineLocation_UsesTypeNotName()
+    {
+        var namedOnline = new Location
+        {
+            Name = "Online",
+            LocationTypeCode = nameof(LocationType.Manual)
+        };
+        var typedOnline = new Location
+        {
+            Name = "Hall A",
+            LocationTypeCode = nameof(LocationType.Online)
+        };
+
+        Assert.False(LocationDisplayHelper.IsOnlineLocation(namedOnline));
+        Assert.True(LocationDisplayHelper.IsOnlineLocation(typedOnline));
+    }
+}

--- a/Backend.Tests/UnitTests/ReportServiceTests.cs
+++ b/Backend.Tests/UnitTests/ReportServiceTests.cs
@@ -1,5 +1,8 @@
+using Microsoft.Extensions.Localization;
+using Moq;
 using Backend.Entities;
 using Backend.Enumerations;
+using Backend.Helpers;
 using Backend.Services;
 
 using LocationTypeEnum = Backend.Enumerations.LocationType;
@@ -13,7 +16,11 @@ public class ReportServiceTests : ServiceTestBase, IAsyncLifetime
 
     public ReportServiceTests()
     {
-        _service = new ReportService(Context);
+        var localizer = new Mock<IStringLocalizer<ReportService>>();
+        localizer
+            .Setup(l => l[LocationDisplayHelper.TypeOnlineKey])
+            .Returns(new LocalizedString(LocationDisplayHelper.TypeOnlineKey, "Online"));
+        _service = new ReportService(Context, localizer.Object);
     }
 
     public async Task InitializeAsync()

--- a/Backend.Tests/UnitTests/Services/LocationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/LocationServiceTests.cs
@@ -100,6 +100,68 @@ public class LocationServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task UpdateLocationAsync_Paper_WithoutName_DoesNotClearStoredName()
+    {
+        var locationGuid = Guid.NewGuid();
+        Context.Locations.Add(new Location
+        {
+            LocationGuid = locationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Hall A",
+            ContactInfo = "keep me",
+            SortOrder = 1,
+            LocationTypeCode = nameof(LocationType.Manual),
+            LocationTallyStatus = LocationTallyStatus.NotStarted,
+            BallotsCollected = 0
+        });
+        await Context.SaveChangesAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.UpdateLocationAsync(locationGuid, new UpdateLocationDto
+            {
+                Name = null,
+                SortOrder = 5
+            }));
+
+        Assert.Contains("name is required", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        var stored = Context.Locations.Single(l => l.LocationGuid == locationGuid);
+        Assert.Equal("Hall A", stored.Name);
+        Assert.Equal("keep me", stored.ContactInfo);
+        Assert.Equal(1, stored.SortOrder);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UpdateLocationAsync_Paper_WhitespaceName_DoesNotClearStoredName(string emptyName)
+    {
+        var locationGuid = Guid.NewGuid();
+        Context.Locations.Add(new Location
+        {
+            LocationGuid = locationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Hall A",
+            SortOrder = 1,
+            LocationTypeCode = nameof(LocationType.Manual),
+            LocationTallyStatus = LocationTallyStatus.NotStarted,
+            BallotsCollected = 0
+        });
+        await Context.SaveChangesAsync();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.UpdateLocationAsync(locationGuid, new UpdateLocationDto
+            {
+                Name = emptyName,
+                SortOrder = 5
+            }));
+
+        var stored = Context.Locations.Single(l => l.LocationGuid == locationGuid);
+        Assert.Equal("Hall A", stored.Name);
+        Assert.Equal(1, stored.SortOrder);
+    }
+
+    [Fact]
     public async Task CreateLocationAsync_DoesNotCreateOnlineType_EvenWhenNamedOnline()
     {
         var created = await _service.CreateLocationAsync(new CreateLocationDto

--- a/Backend.Tests/UnitTests/Services/LocationServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/LocationServiceTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Backend.DTOs.Locations;
+using Backend.Entities;
+using Backend.Enumerations;
+using Backend.Services;
+
+namespace Backend.Tests.UnitTests.Services;
+
+public class LocationServiceTests : ServiceTestBase
+{
+    private readonly LocationService _service;
+    private static readonly Guid ElectionGuid = Guid.NewGuid();
+
+    public LocationServiceTests()
+    {
+        _service = new LocationService(Context, new Mock<ILogger<LocationService>>().Object);
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = ElectionGuid,
+            Name = "Test",
+            NumberToElect = 3,
+            ElectionType = "Loc",
+            RowVersion = new byte[8]
+        });
+        Context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task UpdateLocationAsync_Online_IgnoresNameContactAndCoordinates_AppliesSortOrder()
+    {
+        var locationGuid = Guid.NewGuid();
+        Context.Locations.Add(new Location
+        {
+            LocationGuid = locationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Online",
+            ContactInfo = null,
+            Long = null,
+            Lat = null,
+            SortOrder = 999,
+            LocationTypeCode = nameof(LocationType.Online),
+            LocationTallyStatus = LocationTallyStatus.NotStarted,
+            BallotsCollected = 0
+        });
+        await Context.SaveChangesAsync();
+
+        var updated = await _service.UpdateLocationAsync(locationGuid, new UpdateLocationDto
+        {
+            Name = "Renamed in Persian",
+            ContactInfo = "do not store",
+            Longitude = "-122.4",
+            Latitude = "37.7",
+            SortOrder = 12
+        });
+
+        Assert.NotNull(updated);
+        Assert.Equal("Online", updated.Name);
+        Assert.Null(updated.ContactInfo);
+        Assert.Null(updated.Longitude);
+        Assert.Null(updated.Latitude);
+        Assert.Equal(12, updated.SortOrder);
+
+        var stored = Context.Locations.Single(l => l.LocationGuid == locationGuid);
+        Assert.Equal("Online", stored.Name);
+        Assert.Null(stored.ContactInfo);
+        Assert.Null(stored.Long);
+        Assert.Null(stored.Lat);
+        Assert.Equal(12, stored.SortOrder);
+        Assert.Equal(nameof(LocationType.Online), stored.LocationTypeCode);
+    }
+
+    [Fact]
+    public async Task UpdateLocationAsync_Paper_AppliesNameAndContact()
+    {
+        var locationGuid = Guid.NewGuid();
+        Context.Locations.Add(new Location
+        {
+            LocationGuid = locationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Hall A",
+            SortOrder = 1,
+            LocationTypeCode = nameof(LocationType.Manual),
+            LocationTallyStatus = LocationTallyStatus.NotStarted,
+            BallotsCollected = 0
+        });
+        await Context.SaveChangesAsync();
+
+        var updated = await _service.UpdateLocationAsync(locationGuid, new UpdateLocationDto
+        {
+            Name = "Main Hall",
+            ContactInfo = "555-0100",
+            SortOrder = 2
+        });
+
+        Assert.NotNull(updated);
+        Assert.Equal("Main Hall", updated.Name);
+        Assert.Equal("555-0100", updated.ContactInfo);
+        Assert.Equal(2, updated.SortOrder);
+    }
+
+    [Fact]
+    public async Task CreateLocationAsync_DoesNotCreateOnlineType_EvenWhenNamedOnline()
+    {
+        var created = await _service.CreateLocationAsync(new CreateLocationDto
+        {
+            ElectionGuid = ElectionGuid,
+            Name = "Online",
+            SortOrder = 1
+        });
+
+        Assert.Null(created.LocationType);
+        var stored = Context.Locations.Single(l => l.LocationGuid == created.LocationGuid);
+        Assert.Null(stored.LocationTypeCode);
+        Assert.NotEqual(LocationType.Online, stored.LocationTypeEnum);
+    }
+
+    [Fact]
+    public async Task DeleteLocationAsync_Online_Throws()
+    {
+        var locationGuid = Guid.NewGuid();
+        Context.Locations.Add(new Location
+        {
+            LocationGuid = locationGuid,
+            ElectionGuid = ElectionGuid,
+            Name = "Online",
+            LocationTypeCode = nameof(LocationType.Online),
+            LocationTallyStatus = LocationTallyStatus.NotStarted,
+            BallotsCollected = 0
+        });
+        await Context.SaveChangesAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.DeleteLocationAsync(locationGuid));
+
+        Assert.Contains("cannot be deleted", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(Context.Locations.Where(l => l.LocationGuid == locationGuid));
+    }
+}

--- a/Backend.Tests/UnitTests/TallyServiceTests.cs
+++ b/Backend.Tests/UnitTests/TallyServiceTests.cs
@@ -33,6 +33,9 @@ public class TallyServiceTests : ServiceTestBase
         _localizerMock.Setup(l => l["tally.section.elected"]).Returns(new LocalizedString("tally.section.elected", "E"));
         _localizerMock.Setup(l => l["tally.section.extra"]).Returns(new LocalizedString("tally.section.extra", "X"));
         _localizerMock.Setup(l => l["tally.section.other"]).Returns(new LocalizedString("tally.section.other", "O"));
+        _localizerMock
+            .Setup(l => l[LocationDisplayHelper.TypeOnlineKey])
+            .Returns(new LocalizedString(LocationDisplayHelper.TypeOnlineKey, "Online"));
         
         _service = new TallyService(
             Context,

--- a/backend/DTOs/Locations/UpdateLocationDto.cs
+++ b/backend/DTOs/Locations/UpdateLocationDto.cs
@@ -6,9 +6,9 @@
 public class UpdateLocationDto
 {
     /// <summary>
-    /// The name of the location.
+    /// The name of the location. Omitted for the reserved Online location.
     /// </summary>
-    public string Name { get; set; } = null!;
+    public string? Name { get; set; }
 
     /// <summary>
     /// Contact information for the location.

--- a/backend/Helpers/LocationDisplayHelper.cs
+++ b/backend/Helpers/LocationDisplayHelper.cs
@@ -1,0 +1,35 @@
+using Backend.Entities;
+using Backend.Enumerations;
+
+namespace Backend.Helpers;
+
+/// <summary>
+/// Display name for a location. The reserved Online row is identified by
+/// <see cref="LocationType.Online"/>, never by the stored name.
+/// </summary>
+public static class LocationDisplayHelper
+{
+    public const string TypeOnlineKey = "locations.typeOnline";
+
+    public static bool IsOnlineLocationType(string? locationTypeCode) =>
+        string.Equals(locationTypeCode, nameof(LocationType.Online), StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsOnlineLocation(Location location) =>
+        IsOnlineLocationType(location.LocationTypeCode);
+
+    public static string FormatName(
+        string? storedName,
+        string? locationTypeCode,
+        Func<string, string> localize)
+    {
+        if (IsOnlineLocationType(locationTypeCode))
+        {
+            return localize(TypeOnlineKey);
+        }
+
+        return storedName?.Trim() ?? string.Empty;
+    }
+
+    public static string FormatName(Location location, Func<string, string> localize) =>
+        FormatName(location.Name, location.LocationTypeCode, localize);
+}

--- a/backend/Services/LocationService.cs
+++ b/backend/Services/LocationService.cs
@@ -100,6 +100,9 @@ public class LocationService : ILocationService
         location.LocationGuid = Guid.NewGuid();
         location.LocationTallyStatus = LocationTallyStatus.NotStarted;
         location.BallotsCollected = 0;
+        // Teller-created rows are never the reserved Online type. That row is
+        // added only by OnlineLocationHelper when online voting is enabled.
+        location.LocationTypeCode = null;
 
         _context.Locations.Add(location);
         await _context.SaveChangesAsync();
@@ -131,7 +134,17 @@ public class LocationService : ILocationService
             return null;
         }
 
-        updateDto.CopyMatchingPropertiesTo(location, ignoreNulls: false);
+        if (LocationDisplayHelper.IsOnlineLocation(location))
+        {
+            // Name, contact, and coordinates are not identity and are not
+            // editable. Only sort order may change.
+            location.SortOrder = updateDto.SortOrder;
+        }
+        else
+        {
+            updateDto.CopyMatchingPropertiesTo(location, ignoreNulls: false);
+        }
+
         await _context.SaveChangesAsync();
 
         var locationDto = MapToLocationDto(location);

--- a/backend/Services/LocationService.cs
+++ b/backend/Services/LocationService.cs
@@ -142,6 +142,13 @@ public class LocationService : ILocationService
         }
         else
         {
+            // Validator cannot see LocationType. Paper/imported rows still
+            // require a name; omitting it would clear Location.Name on copy.
+            if (string.IsNullOrWhiteSpace(updateDto.Name))
+            {
+                throw new InvalidOperationException("Location name is required");
+            }
+
             updateDto.CopyMatchingPropertiesTo(location, ignoreNulls: false);
         }
 

--- a/backend/Services/ReportService.Ballots.cs
+++ b/backend/Services/ReportService.Ballots.cs
@@ -46,7 +46,7 @@ public partial class ReportService
 
         var ballotItems = ballots.Select(b =>
         {
-            var locName = hasMultipleLocations ? b.Location.Name : "";
+            var locName = hasMultipleLocations ? FormatLocationName(b.Location) : "";
             var votes = b.Votes
                 .OrderBy(v => isSingleName ? (v.Person?.FullNameFl ?? "") : v.PositionOnBallot.ToString("0000"))
                 .Select(v => new BallotVoteDto
@@ -213,7 +213,7 @@ public partial class ReportService
             Ballots = g.Select(x =>
             {
                 var b = x.Ballot;
-                var locName = hasMultipleLocations ? b.Location.Name : "";
+                var locName = hasMultipleLocations ? FormatLocationName(b.Location) : "";
                 return new BallotReportItemDto
                 {
                     BallotCode = b.BallotCode ?? "",
@@ -265,7 +265,7 @@ public partial class ReportService
             Ballots = ballots.Select(b => new BallotSummaryItemDto
             {
                 BallotCode = b.BallotCode ?? "",
-                Location = hasMultipleLocations ? b.Location.Name : "",
+                Location = hasMultipleLocations ? FormatLocationName(b.Location) : "",
                 LocationId = b.Location.RowId,
                 BallotId = b.RowId,
                 StatusCode = b.StatusCode.ToString(),

--- a/backend/Services/ReportService.Voters.cs
+++ b/backend/Services/ReportService.Voters.cs
@@ -174,7 +174,7 @@ public partial class ReportService
 
         var locationRows = locations
             .GroupJoin(people, l => l.LocationGuid, p => p.VotingLocationGuid ?? Guid.Empty,
-                (l, pList) => BuildLocationRow(l.Name, pList.ToList()))
+                (l, pList) => BuildLocationRow(FormatLocationName(l), pList.ToList()))
             .OrderBy(r => r.LocationName)
             .ToList();
 
@@ -222,7 +222,7 @@ public partial class ReportService
         var locationGroups = people
             .Where(p => p.VotingLocationGuid.HasValue)
             .Join(locations, p => p.VotingLocationGuid, l => l.LocationGuid, (p, l) => new { l, p })
-            .GroupBy(x => x.l.Name)
+            .GroupBy(x => FormatLocationName(x.l))
             .OrderBy(g => g.Key)
             .Select(g => new LocationAreaGroupDto
             {

--- a/backend/Services/ReportService.cs
+++ b/backend/Services/ReportService.cs
@@ -2,13 +2,16 @@ using Backend.Context;
 using Backend.Entities;
 using Backend.Enumerations;
 using Backend.DTOs.Reports;
+using Backend.Helpers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
 
 namespace Backend.Services;
 
 public partial class ReportService : IReportService
 {
     private readonly MainDbContext _context;
+    private readonly IStringLocalizer<ReportService> _localizer;
 
     private static readonly Dictionary<string, string> VotingMethodNames = new()
     {
@@ -24,10 +27,24 @@ public partial class ReportService : IReportService
         ["3"] = "Custom 3"
     };
 
-    public ReportService(MainDbContext context)
+    public ReportService(MainDbContext context, IStringLocalizer<ReportService> localizer)
     {
         _context = context;
+        _localizer = localizer;
     }
+
+    private string FormatLocationName(string? storedName, string? locationTypeCode)
+    {
+        if (LocationDisplayHelper.IsOnlineLocationType(locationTypeCode))
+        {
+            return _localizer[LocationDisplayHelper.TypeOnlineKey];
+        }
+
+        return storedName?.Trim() ?? string.Empty;
+    }
+
+    private string FormatLocationName(Location location) =>
+        FormatLocationName(location.Name, location.LocationTypeCode);
 
     private async Task<Election> GetElectionAsync(Guid electionGuid)
     {

--- a/backend/Services/TallyService.Monitor.cs
+++ b/backend/Services/TallyService.Monitor.cs
@@ -32,6 +32,7 @@ public partial class TallyService
                 b.DateUpdated,
                 b.DateCreated,
                 LocationName = b.Location.Name,
+                LocationTypeCode = b.Location.LocationTypeCode,
             })
             .ToListAsync();
 
@@ -44,14 +45,25 @@ public partial class TallyService
                     var latest = g
                         .OrderByDescending(b => b.DateUpdated ?? b.DateCreated ?? DateTimeOffset.MinValue)
                         .First();
-                    return (Count: g.Count(), LastKnownLocationName: latest.LocationName ?? UnknownLocationName);
+                    return (
+                        Count: g.Count(),
+                        LastKnownLocationName: FormatLocationName(latest.LocationName, latest.LocationTypeCode));
                 });
 
-        var assignedLocationsByCode = await _context.Computers
+        var assignedLocationRows = await _context.Computers
             .AsNoTracking()
             .Where(c => c.ElectionGuid == electionGuid)
-            .Select(c => new { c.ComputerCode, LocationName = c.Location.Name })
-            .ToDictionaryAsync(c => c.ComputerCode, c => c.LocationName ?? UnknownLocationName);
+            .Select(c => new
+            {
+                c.ComputerCode,
+                LocationName = c.Location.Name,
+                LocationTypeCode = c.Location.LocationTypeCode,
+            })
+            .ToListAsync();
+
+        var assignedLocationsByCode = assignedLocationRows.ToDictionary(
+            c => c.ComputerCode,
+            c => FormatLocationName(c.LocationName, c.LocationTypeCode));
 
         var computers = _computerAssignmentService.GetActiveComputers(electionGuid)
             .Select(active =>
@@ -73,18 +85,29 @@ public partial class TallyService
             .ToList();
 
         // Get location information
-        var locations = await _context.Locations
+        var locationRows = await _context.Locations
             .Where(l => l.ElectionGuid == electionGuid)
-            .Select(l => new LocationInfoDto
+            .Select(l => new
             {
-                LocationGuid = l.LocationGuid,
-                LocationName = l.Name ?? UnknownLocationName,
+                l.LocationGuid,
+                l.Name,
+                l.LocationTypeCode,
                 BallotCount = l.Ballots.Count(b => b.StatusCode == BallotStatus.Ok),
                 VoteCount = l.Ballots.Sum(b => b.Votes.Count),
                 VoterCount = _context.People.Count(p => p.ElectionGuid == electionGuid && p.VotingLocationGuid == l.LocationGuid && p.CanVote == true),
                 Status = l.Ballots.Any() ? "Active" : "No Ballots"
             })
             .ToListAsync();
+
+        var locations = locationRows.Select(l => new LocationInfoDto
+        {
+            LocationGuid = l.LocationGuid,
+            LocationName = FormatLocationName(l.Name, l.LocationTypeCode),
+            BallotCount = l.BallotCount,
+            VoteCount = l.VoteCount,
+            VoterCount = l.VoterCount,
+            Status = l.Status
+        }).ToList();
 
         var onlineCounts = await CountOnlineBallotStatusesAsync(electionGuid);
 

--- a/backend/Services/TallyService.Presentation.cs
+++ b/backend/Services/TallyService.Presentation.cs
@@ -206,7 +206,7 @@ public partial class TallyService
                 ? (decimal)locationBallotCount / locationVoterCount * 100
                 : 0;
 
-            turnoutByLocation[location.Name ?? UnknownFallbackValue] = turnout;
+            turnoutByLocation[FormatLocationName(location)] = turnout;
         }
         return turnoutByLocation;
     }
@@ -326,7 +326,7 @@ public partial class TallyService
 
             locationStatistics.Add(new LocationStatisticsDto
             {
-                LocationName = location.Name ?? UnknownFallbackValue,
+                LocationName = FormatLocationName(location),
                 RegisteredVoters = locationVoters,
                 BallotsCast = locationBallots,
                 ValidBallots = locationBallots,

--- a/backend/Services/TallyService.Reports.cs
+++ b/backend/Services/TallyService.Reports.cs
@@ -139,33 +139,34 @@ public partial class TallyService
 
     private async Task<List<BallotReportDto>> GetBallotReportDataAsync(Guid electionGuid)
     {
-        return await _context.Ballots
+        var ballots = await _context.Ballots
             .Include(b => b.Location)
             .Include(b => b.Votes)
             .ThenInclude(v => v.Person)
             .Where(b => b.Location.ElectionGuid == electionGuid)
             .OrderBy(b => b.Location.Name)
             .ThenBy(b => b.BallotNumAtComputer)
-            .Select(b => new BallotReportDto
-            {
-                BallotGuid = b.BallotGuid,
-                LocationName = b.Location.Name ?? UnknownFallbackValue,
-                Status = b.StatusCode,
-                Votes = b.Votes
-                    .OrderBy(v => v.PositionOnBallot)
-                    .Select(v => new VoteReportDto
-                    {
-                        FullName = v.Person != null ? v.Person.FullNameFl ?? UnknownFallbackValue : UnknownFallbackValue,
-                        Position = v.PositionOnBallot
-                    })
-                    .ToList()
-            })
             .ToListAsync();
+
+        return ballots.Select(b => new BallotReportDto
+        {
+            BallotGuid = b.BallotGuid,
+            LocationName = FormatLocationName(b.Location),
+            Status = b.StatusCode,
+            Votes = b.Votes
+                .OrderBy(v => v.PositionOnBallot)
+                .Select(v => new VoteReportDto
+                {
+                    FullName = v.Person != null ? v.Person.FullNameFl ?? UnknownFallbackValue : UnknownFallbackValue,
+                    Position = v.PositionOnBallot
+                })
+                .ToList()
+        }).ToList();
     }
 
     private async Task<List<VoterReportDto>> GetVoterReportDataAsync(Guid electionGuid)
     {
-        return await _context.People
+        var rows = await _context.People
             .Where(p => p.ElectionGuid == electionGuid)
             .GroupJoin(
                 _context.Locations,
@@ -175,33 +176,56 @@ public partial class TallyService
             )
             .SelectMany(
                 x => x.Locations.DefaultIfEmpty(),
-                (x, location) => new VoterReportDto
+                (x, location) => new
                 {
-                    PersonGuid = x.Person.PersonGuid,
-                    FullName = x.Person.FullNameFl ?? UnknownFallbackValue,
-                    LocationName = location != null ? location.Name ?? UnknownFallbackValue : UnknownFallbackValue,
-                    Voted = x.Person.HasOnlineBallot == true, // Simplified - in real implementation, check if ballot exists
-                    VoteTime = null // Would need to track vote timestamps
+                    x.Person.PersonGuid,
+                    FullName = x.Person.FullNameFl,
+                    LocationName = location != null ? location.Name : null,
+                    LocationTypeCode = location != null ? location.LocationTypeCode : null,
+                    Voted = x.Person.HasOnlineBallot == true,
                 }
             )
+            .ToListAsync();
+
+        return rows
+            .Select(row => new VoterReportDto
+            {
+                PersonGuid = row.PersonGuid,
+                FullName = row.FullName ?? UnknownFallbackValue,
+                LocationName = row.LocationName == null && row.LocationTypeCode == null
+                    ? UnknownFallbackValue
+                    : FormatLocationName(row.LocationName, row.LocationTypeCode),
+                Voted = row.Voted,
+                VoteTime = null
+            })
             .OrderBy(v => v.LocationName)
             .ThenBy(v => v.FullName)
-            .ToListAsync();
+            .ToList();
     }
 
     private async Task<List<LocationReportDto>> GetLocationReportDataAsync(Guid electionGuid)
     {
-        return await _context.Locations
+        var rows = await _context.Locations
             .Where(l => l.ElectionGuid == electionGuid)
-            .Select(l => new LocationReportDto
+            .Select(l => new
             {
-                LocationName = l.Name ?? UnknownFallbackValue,
+                l.Name,
+                l.LocationTypeCode,
                 TotalVoters = _context.People.Count(p => p.ElectionGuid == electionGuid && p.VotingLocationGuid == l.LocationGuid && p.CanVote == true),
                 Voted = _context.People.Count(p => p.ElectionGuid == electionGuid && p.VotingLocationGuid == l.LocationGuid && p.HasOnlineBallot == true),
                 BallotsEntered = l.Ballots.Count(b => b.StatusCode == BallotStatus.Ok),
                 TotalVotes = l.Ballots.Sum(b => b.Votes.Count)
             })
             .ToListAsync();
+
+        return rows.Select(l => new LocationReportDto
+        {
+            LocationName = FormatLocationName(l.Name, l.LocationTypeCode),
+            TotalVoters = l.TotalVoters,
+            Voted = l.Voted,
+            BallotsEntered = l.BallotsEntered,
+            TotalVotes = l.TotalVotes
+        }).ToList();
     }
 
     private async Task<ElectionReportDto> GetSummaryReportDataAsync(Guid electionGuid)

--- a/backend/Services/TallyService.cs
+++ b/backend/Services/TallyService.cs
@@ -19,6 +19,19 @@ public partial class TallyService : ITallyService
     private const string UnknownElectionName = "Unknown Election";
     private const string UnknownLocationName = "Unknown Location";
 
+    private string FormatLocationName(string? storedName, string? locationTypeCode)
+    {
+        if (Backend.Helpers.LocationDisplayHelper.IsOnlineLocationType(locationTypeCode))
+        {
+            return _localizer[Backend.Helpers.LocationDisplayHelper.TypeOnlineKey];
+        }
+
+        return string.IsNullOrWhiteSpace(storedName) ? UnknownLocationName : storedName.Trim();
+    }
+
+    private string FormatLocationName(Backend.Entities.Location location) =>
+        FormatLocationName(location.Name, location.LocationTypeCode);
+
     // Section constants - localized
     private string SectionElected => _localizer["tally.section.elected"];
     private string SectionExtra => _localizer["tally.section.extra"];

--- a/backend/Validators/UpdateLocationDtoValidator.cs
+++ b/backend/Validators/UpdateLocationDtoValidator.cs
@@ -14,8 +14,9 @@ public class UpdateLocationDtoValidator : AbstractValidator<UpdateLocationDto>
     /// </summary>
     public UpdateLocationDtoValidator()
     {
-        // Name is omitted when updating the reserved Online location (sort
-        // order only). Paper locations still send a name from the form.
+        // Online sort-only updates omit Name. Non-Online updates must still
+        // send a name; LocationService rejects empty Name on that path
+        // because this validator has no location type.
         RuleFor(x => x.Name)
             .MaximumLength(50)
             .When(x => !string.IsNullOrEmpty(x.Name))

--- a/backend/Validators/UpdateLocationDtoValidator.cs
+++ b/backend/Validators/UpdateLocationDtoValidator.cs
@@ -14,10 +14,11 @@ public class UpdateLocationDtoValidator : AbstractValidator<UpdateLocationDto>
     /// </summary>
     public UpdateLocationDtoValidator()
     {
+        // Name is omitted when updating the reserved Online location (sort
+        // order only). Paper locations still send a name from the form.
         RuleFor(x => x.Name)
-            .NotEmpty()
-            .WithMessage("Location name is required")
             .MaximumLength(50)
+            .When(x => !string.IsNullOrEmpty(x.Name))
             .WithMessage("Location name cannot exceed 50 characters");
 
         RuleFor(x => x.ContactInfo)

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -138,6 +138,21 @@ The typed Online location is added when setup enables online voting, and removed
 
 **Rejected alternative:** create the location only on the first voter ballot. Tellers would not see it in the location list until a vote arrived, and disabling unused online voting would leave an empty reserved location behind.
 
+## Online location display name and edit surface
+
+**Status:** active  
+**Evidence:** confirmed (issue #287; Glen, 4 Sep 2026)
+
+The reserved Online row is shown with the current-language label (`locations.typeOnline` / `formatLocationLabel`). The stored `Name` is a fallback for reports and logs, not the identity and not what tellers edit.
+
+On the Locations page the true Online row is marked by type (badge + row treatment). A paper location whose name happens to be “Online” is not that row.
+
+Editing that row may change sort order only. Name is read-only (the i18n label). Contact, latitude, and longitude are not offered. The API ignores those fields on an Online-typed update and still refuses delete. Teller create never assigns `LocationType.Online`; `OnlineLocationHelper` is the only creator.
+
+**Rejected alternative:** treat a location named “Online” as reserved, or POST the translated label as the stored name. Names are user-facing and translated; writing the current language back would change the stored fallback and still would not identify the row.
+
+**Reason:** tellers need to see which row is the voter-only location, in their language, without being able to rename or dress it up as a paper station.
+
 ## Online and imported ballot codes
 
 **Status:** active  

--- a/frontend/src/components/ballots/BallotEntryPanel.vue
+++ b/frontend/src/components/ballots/BallotEntryPanel.vue
@@ -16,6 +16,8 @@ import { useElectionStore } from "../../stores/electionStore";
 import { usePeopleStore } from "../../stores/peopleStore";
 import type { CreateVoteDto, VoteDto } from "../../types";
 import { formatComputerCodeLabel } from "@/utils/ballotDisplayCode";
+import { formatLocationLabelForGuid } from "@/utils/locationDisplay";
+import { useLocationStore } from "../../stores/locationStore";
 
 const emit = defineEmits<{
   "ballot-created": [ballotGuid: string];
@@ -47,6 +49,7 @@ const { t } = useI18n();
 const ballotStore = useBallotStore();
 const electionStore = useElectionStore();
 const peopleStore = usePeopleStore();
+const locationStore = useLocationStore();
 const { showSuccessMessage, showErrorMessage, showInfoMessage } =
   useNotifications();
 
@@ -54,6 +57,14 @@ const panelLoading = ref(false);
 const voteResyncKey = ref(0);
 const ballot = computed(() => ballotStore.currentBallot);
 const election = computed(() => electionStore.currentElection);
+const ballotLocationLabel = computed(() =>
+  formatLocationLabelForGuid(
+    t,
+    locationStore.locations,
+    ballot.value?.locationGuid,
+    ballot.value?.locationName,
+  ),
+);
 
 function hasCachedPanelData(): boolean {
   return (
@@ -218,7 +229,7 @@ async function handleVotesReordered(voteRowIds: number[]) {
       <div v-if="showMetadata" class="ballot-info">
         <el-descriptions :column="2" border>
           <el-descriptions-item :label="$t('ballots.location')">
-            {{ ballot.locationName }}
+            {{ ballotLocationLabel }}
           </el-descriptions-item>
           <el-descriptions-item :label="$t('ballots.computer')">
             {{ formatComputerCodeLabel($t, ballot.computerCode) }}

--- a/frontend/src/components/ballots/BallotViewFilterSelect.vue
+++ b/frontend/src/components/ballots/BallotViewFilterSelect.vue
@@ -57,9 +57,12 @@ function locationNameForGuid(locationGuid: string): string {
   return (
     filterGroups.value.find((group) => group.locationGuid === locationGuid)
       ?.locationName ??
-    props.locations.find((location) => location.locationGuid === locationGuid)
-      ?.name ??
-    locationGuid
+    formatLocationLabel(
+      t,
+      props.locations.find(
+        (location) => location.locationGuid === locationGuid,
+      ) ?? { name: locationGuid },
+    )
   );
 }
 

--- a/frontend/src/components/ballots/BallotVotesDialog.vue
+++ b/frontend/src/components/ballots/BallotVotesDialog.vue
@@ -9,6 +9,8 @@ import type { BallotDto, VoteDto } from "../../types";
 import VoteFormDialog from "./VoteFormDialog.vue";
 import { useApiErrorHandler } from "@/composables/useApiErrorHandler";
 import { formatBallotDisplayCode } from "@/utils/ballotDisplayCode";
+import { formatLocationLabelForGuid } from "@/utils/locationDisplay";
+import { useLocationStore } from "../../stores/locationStore";
 const { handleApiError } = useApiErrorHandler();
 
 const props = defineProps<{
@@ -23,6 +25,15 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const ballotStore = useBallotStore();
+const locationStore = useLocationStore();
+const ballotLocationLabel = computed(() =>
+  formatLocationLabelForGuid(
+    t,
+    locationStore.locations,
+    props.ballot?.locationGuid,
+    props.ballot?.locationName,
+  ),
+);
 const { showSuccessMessage } = useNotifications();
 
 const showAddVote = ref(false);
@@ -96,7 +107,7 @@ function getVoteStatusType(status: string) {
       <div class="ballot-info">
         <el-descriptions :column="2" border size="small">
           <el-descriptions-item :label="$t('ballots.location')">
-            {{ ballot.locationName }}
+            {{ ballotLocationLabel }}
           </el-descriptions-item>
           <el-descriptions-item :label="$t('ballots.status')">
             <el-tag :type="getStatusType(ballot.statusCode)">

--- a/frontend/src/components/locations/LocationForm.vue
+++ b/frontend/src/components/locations/LocationForm.vue
@@ -41,7 +41,9 @@ const canDelete = computed(
   () => Boolean(props.showDelete) && !isOnlineLocation.value,
 );
 const onlineDisplayName = computed(() =>
-  props.location ? formatLocationLabel(t, props.location) : t("locations.typeOnline"),
+  props.location
+    ? formatLocationLabel(t, props.location)
+    : t("locations.typeOnline"),
 );
 
 const form = reactive({
@@ -233,6 +235,7 @@ function handleCancel() {
         <el-form-item
           :label="$t('locations.form.contactInfo')"
           prop="contactInfo"
+          data-testid="location-contact"
         >
           <el-input
             v-model="form.contactInfo"
@@ -242,7 +245,11 @@ function handleCancel() {
           />
         </el-form-item>
 
-        <el-form-item :label="$t('locations.form.longitude')" prop="longitude">
+        <el-form-item
+          :label="$t('locations.form.longitude')"
+          prop="longitude"
+          data-testid="location-longitude"
+        >
           <el-input
             v-model="form.longitude"
             :placeholder="$t('locations.form.longitudePlaceholder')"
@@ -254,7 +261,11 @@ function handleCancel() {
           </div>
         </el-form-item>
 
-        <el-form-item :label="$t('locations.form.latitude')" prop="latitude">
+        <el-form-item
+          :label="$t('locations.form.latitude')"
+          prop="latitude"
+          data-testid="location-latitude"
+        >
           <el-input
             v-model="form.latitude"
             :placeholder="$t('locations.form.latitudePlaceholder')"
@@ -267,7 +278,11 @@ function handleCancel() {
         </el-form-item>
       </template>
 
-      <el-form-item :label="$t('locations.form.sortOrder')" prop="sortOrder">
+      <el-form-item
+        :label="$t('locations.form.sortOrder')"
+        prop="sortOrder"
+        data-testid="location-sort-order"
+      >
         <el-input-number
           v-model="form.sortOrder"
           :min="0"

--- a/frontend/src/components/locations/LocationForm.vue
+++ b/frontend/src/components/locations/LocationForm.vue
@@ -4,6 +4,7 @@ import { useNotifications } from "@/composables/useNotifications";
 import { type FormInstance, type FormRules, ElMessageBox } from "element-plus";
 import { computed, reactive, ref, watch } from "vue";
 import { isOnlineLocationType } from "@/utils/ballotStartRequirements";
+import { formatLocationLabel } from "@/utils/locationDisplay";
 import { useI18n } from "vue-i18n";
 import { useLocationStore } from "../../stores/locationStore";
 import type {
@@ -33,10 +34,14 @@ const { handleApiError } = useApiErrorHandler();
 const formRef = ref<FormInstance>();
 const submitting = ref(false);
 const deleting = ref(false);
+const isOnlineLocation = computed(() =>
+  isOnlineLocationType(props.location?.locationType),
+);
 const canDelete = computed(
-  () =>
-    Boolean(props.showDelete) &&
-    !isOnlineLocationType(props.location?.locationType),
+  () => Boolean(props.showDelete) && !isOnlineLocation.value,
+);
+const onlineDisplayName = computed(() =>
+  props.location ? formatLocationLabel(t, props.location) : t("locations.typeOnline"),
 );
 
 const form = reactive({
@@ -125,13 +130,15 @@ async function handleSubmit() {
     submitting.value = true;
     try {
       if (props.isEdit && props.location) {
-        const dto: UpdateLocationDto = {
-          name: form.name,
-          contactInfo: form.contactInfo || undefined,
-          longitude: form.longitude || undefined,
-          latitude: form.latitude || undefined,
-          sortOrder: form.sortOrder,
-        };
+        const dto: UpdateLocationDto = isOnlineLocation.value
+          ? { sortOrder: form.sortOrder }
+          : {
+              name: form.name,
+              contactInfo: form.contactInfo || undefined,
+              longitude: form.longitude || undefined,
+              latitude: form.latitude || undefined,
+              sortOrder: form.sortOrder,
+            };
         await locationStore.updateLocation(
           props.electionGuid,
           props.location.locationGuid,
@@ -208,48 +215,57 @@ function handleCancel() {
       label-width="150px"
       label-position="left"
     >
-      <el-form-item :label="$t('locations.form.name')" prop="name">
+      <el-form-item
+        v-if="isOnlineLocation"
+        :label="$t('locations.form.name')"
+        data-testid="online-location-name"
+      >
+        <div class="location-form__readonly-name">{{ onlineDisplayName }}</div>
+      </el-form-item>
+      <el-form-item v-else :label="$t('locations.form.name')" prop="name">
         <el-input
           v-model="form.name"
           :placeholder="$t('locations.form.namePlaceholder')"
         />
       </el-form-item>
 
-      <el-form-item
-        :label="$t('locations.form.contactInfo')"
-        prop="contactInfo"
-      >
-        <el-input
-          v-model="form.contactInfo"
-          type="textarea"
-          :rows="3"
-          :placeholder="$t('locations.form.contactInfoPlaceholder')"
-        />
-      </el-form-item>
-
-      <el-form-item :label="$t('locations.form.longitude')" prop="longitude">
-        <el-input
-          v-model="form.longitude"
-          :placeholder="$t('locations.form.longitudePlaceholder')"
+      <template v-if="!isOnlineLocation">
+        <el-form-item
+          :label="$t('locations.form.contactInfo')"
+          prop="contactInfo"
         >
-          <template #append>°</template>
-        </el-input>
-        <div class="form-help-text">
-          {{ $t("locations.form.longitudeHelp") }}
-        </div>
-      </el-form-item>
+          <el-input
+            v-model="form.contactInfo"
+            type="textarea"
+            :rows="3"
+            :placeholder="$t('locations.form.contactInfoPlaceholder')"
+          />
+        </el-form-item>
 
-      <el-form-item :label="$t('locations.form.latitude')" prop="latitude">
-        <el-input
-          v-model="form.latitude"
-          :placeholder="$t('locations.form.latitudePlaceholder')"
-        >
-          <template #append>°</template>
-        </el-input>
-        <div class="form-help-text">
-          {{ $t("locations.form.latitudeHelp") }}
-        </div>
-      </el-form-item>
+        <el-form-item :label="$t('locations.form.longitude')" prop="longitude">
+          <el-input
+            v-model="form.longitude"
+            :placeholder="$t('locations.form.longitudePlaceholder')"
+          >
+            <template #append>°</template>
+          </el-input>
+          <div class="form-help-text">
+            {{ $t("locations.form.longitudeHelp") }}
+          </div>
+        </el-form-item>
+
+        <el-form-item :label="$t('locations.form.latitude')" prop="latitude">
+          <el-input
+            v-model="form.latitude"
+            :placeholder="$t('locations.form.latitudePlaceholder')"
+          >
+            <template #append>°</template>
+          </el-input>
+          <div class="form-help-text">
+            {{ $t("locations.form.latitudeHelp") }}
+          </div>
+        </el-form-item>
+      </template>
 
       <el-form-item :label="$t('locations.form.sortOrder')" prop="sortOrder">
         <el-input-number
@@ -259,7 +275,11 @@ function handleCancel() {
           style="width: 100%"
         />
         <div class="form-help-text">
-          {{ $t("locations.form.sortOrderHelp") }}
+          {{
+            isOnlineLocation
+              ? $t("locations.form.onlineSortOnlyHelp")
+              : $t("locations.form.sortOrderHelp")
+          }}
         </div>
       </el-form-item>
     </el-form>
@@ -285,6 +305,13 @@ function handleCancel() {
 
 <style lang="less">
 .location-form {
+  .location-form__readonly-name {
+    min-height: 32px;
+    display: flex;
+    align-items: center;
+    font-weight: 600;
+  }
+
   .form-help-text {
     font-size: 12px;
     color: var(--el-text-color-secondary);

--- a/frontend/src/components/locations/__tests__/LocationForm.spec.ts
+++ b/frontend/src/components/locations/__tests__/LocationForm.spec.ts
@@ -1,0 +1,171 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LocationDto } from "@/types";
+import LocationForm from "../LocationForm.vue";
+
+const mockUpdateLocation = vi.fn();
+const mockCreateLocation = vi.fn();
+
+vi.mock("@/stores/locationStore", () => ({
+  useLocationStore: () => ({
+    updateLocation: mockUpdateLocation,
+    createLocation: mockCreateLocation,
+    deleteLocation: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/useNotifications", () => ({
+  useNotifications: () => ({
+    showSuccessMessage: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/useApiErrorHandler", () => ({
+  useApiErrorHandler: () => ({
+    handleApiError: vi.fn(),
+  }),
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  messages: {
+    en: {
+      locations: {
+        typeOnline: "Online",
+        form: {
+          name: "Location Name",
+          namePlaceholder: "Enter location name",
+          nameRequired: "required",
+          nameMaxLength: "too long",
+          contactInfo: "Contact Info",
+          contactInfoPlaceholder: "Enter contact",
+          contactInfoMaxLength: "too long",
+          longitude: "Longitude",
+          longitudePlaceholder: "long",
+          longitudeHelp: "long help",
+          longitudeInvalid: "invalid",
+          latitude: "Latitude",
+          latitudePlaceholder: "lat",
+          latitudeHelp: "lat help",
+          latitudeInvalid: "invalid",
+          sortOrder: "Sort Order",
+          sortOrderHelp: "Used to order locations",
+          sortOrderInvalid: "invalid",
+          onlineSortOnlyHelp: "Only the sort order can be changed",
+          save: "Save",
+          create: "Create",
+          cancel: "Cancel",
+          delete: "Delete",
+          updated: "updated",
+          created: "created",
+        },
+      },
+    },
+  },
+});
+
+const onlineLocation: LocationDto = {
+  locationGuid: "loc-online",
+  electionGuid: "elec-1",
+  name: "Hall A",
+  contactInfo: "should hide",
+  longitude: "1",
+  latitude: "2",
+  sortOrder: 999,
+  locationType: "Online",
+};
+
+const paperLocation: LocationDto = {
+  locationGuid: "loc-hall",
+  electionGuid: "elec-1",
+  name: "Main Hall",
+  contactInfo: "555",
+  longitude: "-122.4",
+  latitude: "37.7",
+  sortOrder: 1,
+  locationType: "Manual",
+};
+
+function mountForm(location: LocationDto) {
+  return mount(LocationForm, {
+    props: {
+      electionGuid: "elec-1",
+      location,
+      isEdit: true,
+      showDelete: true,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        ElForm: {
+          template: "<form><slot /></form>",
+          methods: {
+            validate(cb: (valid: boolean) => void) {
+              cb(true);
+            },
+            resetFields() {},
+          },
+        },
+        ElFormItem: { template: "<div><slot /></div>" },
+        ElInput: true,
+        ElInputNumber: true,
+        ElButton: {
+          template:
+            '<button type="button" @click="$emit(\'click\')"><slot /></button>',
+        },
+      },
+    },
+  });
+}
+
+describe("LocationForm", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockUpdateLocation.mockReset().mockResolvedValue(undefined);
+    mockCreateLocation.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("locks name, contact, and coordinates for the Online location", () => {
+    const wrapper = mountForm(onlineLocation);
+
+    expect(wrapper.find('[data-testid="online-location-name"]').text()).toBe(
+      "Online",
+    );
+    expect(wrapper.find("input").exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("Contact Info");
+    expect(wrapper.text()).not.toContain("Longitude");
+    expect(wrapper.text()).not.toContain("Latitude");
+    expect(wrapper.text()).toContain("Sort Order");
+    expect(wrapper.text()).toContain("Only the sort order can be changed");
+    expect(wrapper.text()).not.toContain("Delete");
+  });
+
+  it("keeps name and contact editable for a paper location", () => {
+    const wrapper = mountForm(paperLocation);
+
+    expect(wrapper.find('[data-testid="online-location-name"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.text()).toContain("Contact Info");
+    expect(wrapper.text()).toContain("Longitude");
+    expect(wrapper.text()).toContain("Delete");
+  });
+
+  it("posts only sortOrder when saving the Online location", async () => {
+    const wrapper = mountForm(onlineLocation);
+    const saveButton = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Save"));
+    expect(saveButton).toBeTruthy();
+
+    await saveButton!.trigger("click");
+    await flushPromises();
+
+    expect(mockUpdateLocation).toHaveBeenCalledWith("elec-1", "loc-online", {
+      sortOrder: 999,
+    });
+  });
+});

--- a/frontend/src/components/locations/__tests__/LocationForm.spec.ts
+++ b/frontend/src/components/locations/__tests__/LocationForm.spec.ts
@@ -134,11 +134,18 @@ describe("LocationForm", () => {
     expect(wrapper.find('[data-testid="online-location-name"]').text()).toBe(
       "Online",
     );
-    expect(wrapper.find("input").exists()).toBe(false);
-    expect(wrapper.text()).not.toContain("Contact Info");
-    expect(wrapper.text()).not.toContain("Longitude");
-    expect(wrapper.text()).not.toContain("Latitude");
-    expect(wrapper.text()).toContain("Sort Order");
+    expect(wrapper.find('[data-testid="location-contact"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="location-longitude"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="location-latitude"]').exists()).toBe(
+      false,
+    );
+    expect(wrapper.find('[data-testid="location-sort-order"]').exists()).toBe(
+      true,
+    );
     expect(wrapper.text()).toContain("Only the sort order can be changed");
     expect(wrapper.text()).not.toContain("Delete");
   });
@@ -149,8 +156,12 @@ describe("LocationForm", () => {
     expect(wrapper.find('[data-testid="online-location-name"]').exists()).toBe(
       false,
     );
-    expect(wrapper.text()).toContain("Contact Info");
-    expect(wrapper.text()).toContain("Longitude");
+    expect(wrapper.find('[data-testid="location-contact"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.find('[data-testid="location-longitude"]').exists()).toBe(
+      true,
+    );
     expect(wrapper.text()).toContain("Delete");
   });
 

--- a/frontend/src/locales/en/locations.json
+++ b/frontend/src/locales/en/locations.json
@@ -32,6 +32,8 @@
   "locations.locationSelected": "Location selected successfully",
   "locations.selectLocation": "Select Location",
   "locations.typeOnline": "Online",
+  "locations.onlineVotingBadge": "Online voting",
+  "locations.form.onlineSortOnlyHelp": "Only the sort order can be changed for the Online location.",
   "locations.tallyStatus": "Tally Status",
   "locations.form.edit": "Edit",
   "locations.form.delete": "Delete",

--- a/frontend/src/pages/ballots/BallotManagementPage.vue
+++ b/frontend/src/pages/ballots/BallotManagementPage.vue
@@ -16,7 +16,10 @@ import {
   locationTypeForGuid,
   type BallotStartBlockReason,
 } from "@/utils/ballotStartRequirements";
-import { formatLocationLabel } from "@/utils/locationDisplay";
+import {
+  formatLocationLabel,
+  formatLocationLabelForGuid,
+} from "@/utils/locationDisplay";
 import {
   ballotGuidFromRouteParams,
   electionBallotsPath,
@@ -81,6 +84,18 @@ const isOnlineLocationSelected = computed(() =>
 );
 
 const showLocationColumn = computed(() => locationStore.locations.length > 1);
+
+function ballotLocationLabel(ballot: {
+  locationGuid: string;
+  locationName: string;
+}): string {
+  return formatLocationLabelForGuid(
+    t,
+    locationStore.locations,
+    ballot.locationGuid,
+    ballot.locationName,
+  );
+}
 
 const filteredBallots = computed(() =>
   filterBallotsByView(ballotStore.ballots, selectedViewFilter.value),
@@ -456,7 +471,11 @@ function handleLocationChange(locationGuid: string | null) {
             prop="locationName"
             :label="$t('ballots.location')"
             min-width="140"
-          />
+          >
+            <template #default="scope">
+              {{ ballotLocationLabel(scope.row) }}
+            </template>
+          </el-table-column>
           <el-table-column prop="statusCode" :label="$t('ballots.status')">
             <template #default="scope">
               <el-tag :type="getStatusType(scope.row?.statusCode)">

--- a/frontend/src/pages/locations/LocationsListPage.vue
+++ b/frontend/src/pages/locations/LocationsListPage.vue
@@ -7,6 +7,7 @@ import { useRoute } from "vue-router";
 import LocationForm from "../../components/locations/LocationForm.vue";
 import { useLocationStore } from "../../stores/locationStore";
 import type { LocationDto } from "../../types";
+import { isOnlineLocationType } from "@/utils/ballotStartRequirements";
 import { formatLocationLabel } from "@/utils/locationDisplay";
 
 const route = useRoute();
@@ -107,6 +108,14 @@ function formatCoordinate(coord: string | undefined): string {
   return Number.isNaN(num) ? coord : num.toFixed(4);
 }
 
+function isOnlineLocation(location: LocationDto): boolean {
+  return isOnlineLocationType(location.locationType);
+}
+
+function locationRowClassName({ row }: { row: LocationDto }): string {
+  return isOnlineLocation(row) ? "is-online-location" : "";
+}
+
 function getStatusType(status: string) {
   const typeMap: Record<string, any> = {
     NotStarted: "",
@@ -137,6 +146,7 @@ function getStatusType(status: string) {
           v-loading="loading"
           :data="sortedLocations"
           style="width: 100%"
+          :row-class-name="locationRowClassName"
           @sort-change="handleSortChange"
         >
           <el-table-column
@@ -146,9 +156,20 @@ function getStatusType(status: string) {
             sortable="custom"
           >
             <template #default="scope">
-              <el-button type="primary" link @click="handleEdit(scope.row)">
-                {{ formatLocationLabel($t, scope.row) }}
-              </el-button>
+              <div class="location-name-cell">
+                <el-button type="primary" link @click="handleEdit(scope.row)">
+                  {{ formatLocationLabel($t, scope.row) }}
+                </el-button>
+                <el-tag
+                  v-if="isOnlineLocation(scope.row)"
+                  type="info"
+                  size="small"
+                  effect="plain"
+                  class="online-location-badge"
+                >
+                  {{ $t("locations.onlineVotingBadge") }}
+                </el-tag>
+              </div>
             </template>
           </el-table-column>
           <el-table-column
@@ -255,6 +276,21 @@ function getStatusType(status: string) {
 <style lang="less">
 .locations-list-page {
   padding: 20px;
+
+  .location-name-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .online-location-badge {
+    pointer-events: none;
+  }
+
+  .el-table .is-online-location {
+    --el-table-tr-bg-color: var(--el-color-info-light-9);
+  }
 }
 
 .card-header {

--- a/frontend/src/pages/locations/__tests__/LocationsListPage.spec.ts
+++ b/frontend/src/pages/locations/__tests__/LocationsListPage.spec.ts
@@ -1,0 +1,165 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LocationDto } from "@/types";
+import LocationsListPage from "../LocationsListPage.vue";
+
+const mockLocations: LocationDto[] = [
+  {
+    locationGuid: "loc-hall",
+    electionGuid: "elec-1",
+    name: "Main Hall",
+    locationType: "Manual",
+    sortOrder: 1,
+  },
+  {
+    locationGuid: "loc-named-online",
+    electionGuid: "elec-1",
+    name: "Online",
+    locationType: "Manual",
+    sortOrder: 2,
+  },
+  {
+    locationGuid: "loc-true-online",
+    electionGuid: "elec-1",
+    name: "Hall A",
+    locationType: "Online",
+    sortOrder: 999,
+  },
+];
+
+const mockFetchLocations = vi.fn();
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ params: { id: "elec-1" } }),
+}));
+
+vi.mock("@/stores/locationStore", () => ({
+  useLocationStore: () => ({
+    loading: false,
+    sortedLocations: mockLocations,
+    pagination: {
+      pageNumber: 1,
+      pageSize: 50,
+      totalCount: 3,
+      totalPages: 1,
+    },
+    fetchLocations: mockFetchLocations,
+  }),
+}));
+
+vi.mock("@/composables/useNotifications", () => ({
+  useNotifications: () => ({
+    showErrorMessage: vi.fn(),
+  }),
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "fa",
+  messages: {
+    fa: {
+      locations: {
+        typeOnline: "آنلاین",
+        onlineVotingBadge: "رای‌گیری آنلاین",
+        form: {
+          name: "Name",
+          contactInfo: "Contact",
+          coordinates: "Coordinates",
+          ballots: "Ballots",
+          sortOrder: "Sort",
+          titleAdd: "Add",
+          titleEdit: "Edit",
+        },
+        editDrawerTitle: "Edit {name}",
+        tallyStatus: "Status",
+        button: {
+          addLocation: "Add Location",
+        },
+      },
+    },
+  },
+});
+
+describe("LocationsListPage", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockFetchLocations.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("marks the true Online location by type, not by the name Online", async () => {
+    const wrapper = mount(LocationsListPage, {
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ElCard: { template: "<div><slot name='header' /><slot /></div>" },
+          ElTable: {
+            props: ["data", "rowClassName"],
+            template: `
+              <div class="el-table">
+                <div
+                  v-for="row in data"
+                  :key="row.locationGuid"
+                  class="location-row"
+                  :class="typeof rowClassName === 'function' ? rowClassName({ row }) : ''"
+                  :data-location-guid="row.locationGuid"
+                >
+                  <slot />
+                </div>
+              </div>
+            `,
+          },
+          ElTableColumn: {
+            props: ["prop"],
+            template: `
+              <div>
+                <div
+                  v-for="row in [
+                    { locationGuid: 'loc-hall', name: 'Main Hall', locationType: 'Manual' },
+                    { locationGuid: 'loc-named-online', name: 'Online', locationType: 'Manual' },
+                    { locationGuid: 'loc-true-online', name: 'Hall A', locationType: 'Online' },
+                  ]"
+                  :key="row.locationGuid + (prop || 'col')"
+                >
+                  <slot name="default" :row="row" />
+                </div>
+              </div>
+            `,
+          },
+          ElButton: {
+            template:
+              '<button type="button" @click="$emit(\'click\')"><slot /></button>',
+          },
+          ElTag: {
+            template: '<span class="el-tag"><slot /></span>',
+          },
+          ElIcon: true,
+          ElDrawer: true,
+          ElPagination: true,
+        },
+      },
+    });
+    await flushPromises();
+
+    expect(mockFetchLocations).toHaveBeenCalledWith("elec-1", 1, 50);
+    expect(wrapper.text()).toContain("آنلاین");
+    expect(wrapper.text()).toContain("رای‌گیری آنلاین");
+    expect(wrapper.text()).toContain("Main Hall");
+
+    const badgeCount = wrapper
+      .findAll(".el-tag")
+      .filter((tag) => tag.text().includes("رای‌گیری آنلاین")).length;
+    expect(badgeCount).toBe(1);
+
+    const rows = wrapper.findAll(".location-row");
+    const trueOnline = rows.find(
+      (row) => row.attributes("data-location-guid") === "loc-true-online",
+    );
+    const namedOnline = rows.find(
+      (row) => row.attributes("data-location-guid") === "loc-named-online",
+    );
+    expect(trueOnline?.classes()).toContain("is-online-location");
+    expect(namedOnline?.classes()).not.toContain("is-online-location");
+  });
+});

--- a/frontend/src/pages/locations/__tests__/LocationsListPage.spec.ts
+++ b/frontend/src/pages/locations/__tests__/LocationsListPage.spec.ts
@@ -104,9 +104,8 @@ describe("LocationsListPage", () => {
                   class="location-row"
                   :class="typeof rowClassName === 'function' ? rowClassName({ row }) : ''"
                   :data-location-guid="row.locationGuid"
-                >
-                  <slot />
-                </div>
+                />
+                <slot />
               </div>
             `,
           },

--- a/frontend/src/utils/__tests__/locationDisplay.test.ts
+++ b/frontend/src/utils/__tests__/locationDisplay.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { formatLocationLabel } from "../locationDisplay";
+import {
+  formatLocationLabel,
+  formatLocationLabelForGuid,
+} from "../locationDisplay";
 
 describe("formatLocationLabel", () => {
-  const t = (key: string) => (key === "locations.typeOnline" ? "Online" : key);
+  const t = (key: string) =>
+    key === "locations.typeOnline" ? "آنلاین" : key;
 
   it("uses i18n for an Online-typed location regardless of name", () => {
     expect(
       formatLocationLabel(t, { name: "Hall A", locationType: "Online" }),
+    ).toBe("آنلاین");
+  });
+
+  it("uses the stored name for a paper location even if it is Online", () => {
+    expect(
+      formatLocationLabel(t, { name: "Online", locationType: "Manual" }),
     ).toBe("Online");
   });
 
@@ -14,5 +24,41 @@ describe("formatLocationLabel", () => {
     expect(
       formatLocationLabel(t, { name: "Main Hall", locationType: "Manual" }),
     ).toBe("Main Hall");
+  });
+});
+
+describe("formatLocationLabelForGuid", () => {
+  const t = (key: string) =>
+    key === "locations.typeOnline" ? "آنلاین" : key;
+
+  const locations = [
+    {
+      locationGuid: "loc-hall",
+      name: "Main Hall",
+      locationType: "Manual",
+    },
+    {
+      locationGuid: "loc-online",
+      name: "Hall A",
+      locationType: "Online",
+    },
+  ];
+
+  it("looks up type by guid and uses i18n for Online", () => {
+    expect(
+      formatLocationLabelForGuid(t, locations, "loc-online", "Hall A"),
+    ).toBe("آنلاین");
+  });
+
+  it("looks up a paper location by guid", () => {
+    expect(
+      formatLocationLabelForGuid(t, locations, "loc-hall", "ignored"),
+    ).toBe("Main Hall");
+  });
+
+  it("falls back to the supplied name when the guid is unknown", () => {
+    expect(
+      formatLocationLabelForGuid(t, locations, "missing", "Fallback"),
+    ).toBe("Fallback");
   });
 });

--- a/frontend/src/utils/__tests__/locationDisplay.test.ts
+++ b/frontend/src/utils/__tests__/locationDisplay.test.ts
@@ -5,8 +5,7 @@ import {
 } from "../locationDisplay";
 
 describe("formatLocationLabel", () => {
-  const t = (key: string) =>
-    key === "locations.typeOnline" ? "آنلاین" : key;
+  const t = (key: string) => (key === "locations.typeOnline" ? "آنلاین" : key);
 
   it("uses i18n for an Online-typed location regardless of name", () => {
     expect(
@@ -28,8 +27,7 @@ describe("formatLocationLabel", () => {
 });
 
 describe("formatLocationLabelForGuid", () => {
-  const t = (key: string) =>
-    key === "locations.typeOnline" ? "آنلاین" : key;
+  const t = (key: string) => (key === "locations.typeOnline" ? "آنلاین" : key);
 
   const locations = [
     {

--- a/frontend/src/utils/locationDisplay.ts
+++ b/frontend/src/utils/locationDisplay.ts
@@ -13,3 +13,26 @@ export function formatLocationLabel(
   }
   return location.name?.trim() || "";
 }
+
+/** Resolve a location by guid, then apply formatLocationLabel. */
+export function formatLocationLabelForGuid(
+  t: (key: string) => string,
+  locations: ReadonlyArray<{
+    locationGuid: string;
+    name?: string | null;
+    locationType?: string | null;
+  }>,
+  locationGuid: string | null | undefined,
+  fallbackName?: string | null,
+): string {
+  if (!locationGuid) {
+    return fallbackName?.trim() || "";
+  }
+
+  const location = locations.find((item) => item.locationGuid === locationGuid);
+  if (location) {
+    return formatLocationLabel(t, location);
+  }
+
+  return fallbackName?.trim() || "";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The reserved Online location is identified by location type, not by the string "Online".

## What changed
- Locations list marks the true Online row (badge + row treatment) by `LocationType`, including when a paper location is also named "Online".
- Editing that row shows the current-language label and only allows sort order. Name, contact, and lat/long are not offered and are not posted.
- Backend update ignores name/contact/coordinates on an Online-typed row and still refuses delete. Teller create never assigns Online type.
- Non-Online updates reject a missing or whitespace name before copy, so `Location.Name` cannot be cleared.
- Display name uses `formatLocationLabel` / `locations.typeOnline` on location selectors, ballot listing/headers, and report/monitor location names (localized when the row is Online-typed).

## Related
Related: #287 (issue stays open).

## Testing
- Backend: LocationService update/create/delete guards, including Manual update without Name (rejected, stored name unchanged); LocationDisplayHelper
- Frontend: Locations list distinction, LocationForm field lock + sort-only POST, formatLocationLabel / formatLocationLabelForGuid

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29020e7f-37c4-4678-96c7-d85a943c08f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29020e7f-37c4-4678-96c7-d85a943c08f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

