### PR TITLE
Tests: voter submit → teller Accept-all → counts and OL ballot

### DIFF
--- a/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
@@ -1,9 +1,16 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Backend.Context;
+using Backend.DTOs.Ballots;
+using Backend.DTOs.Elections;
 using Backend.DTOs.OnlineVoting;
+using Backend.DTOs.Reports;
+using Backend.DTOs.Results;
 using Backend.Entities;
 using Backend.Enumerations;
+using Backend.Helpers;
+using Backend.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -286,6 +293,297 @@ public class OnlineVotingBallotFlowTests : IntegrationTestBase
         Assert.Equal(2, updatedStatus.PriorVotes.Count);
         Assert.False(updatedStatus.NotifyWhenProcessed);
         Assert.NotEqual(status.WhenSubmitted, updatedStatus.WhenSubmitted);
+    }
+
+    [Fact]
+    public async Task AcceptAll_WithoutTellerAuth_ReturnsUnauthorized()
+    {
+        var response = await Client.PostAsync(
+            $"/api/elections/{Guid.NewGuid()}/online-ballots/accept-all",
+            null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SubmitOnline_ThenTellerAcceptAll_UpdatesCounts_WipesPendingPayload_AndCreatesOlBallotForTally()
+    {
+        // HTTP path: voter submit stays pending; teller Accept-all creates the
+        // regular OL ballot (relational ExecuteUpdate claim) and wipes ListPool.
+        var voterEmail = $"zelda_{Guid.NewGuid():N}@example.com";
+        const string voterFirst = "ZeldaQuorum";
+        const string voterLast = "Nightingale";
+        const string poolMarker = "SecretPoolAlpha";
+
+        var token = await GetAuthTokenAsync();
+        SetAuthToken(token);
+
+        var createResponse = await PostJsonAsync("/api/elections/createElection", new CreateElectionDto
+        {
+            Name = "Accept-all flow election",
+            DateOfElection = DateTime.UtcNow.AddDays(7),
+            ElectionType = ElectionTypeCode.LSA,
+            NumberToElect = 2,
+            UseOnlineVoting = true,
+            OnlineSelectionProcess = "A"
+        });
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var created = await DeserializeResponseAsync<ApiResponse<ElectionDto>>(createResponse);
+        var electionGuid = created!.Data!.ElectionGuid;
+
+        var windowResponse = await PutJsonAsync(
+            $"/api/elections/{electionGuid}/online-voting-window",
+            new UpdateOnlineVotingWindowDto
+            {
+                OnlineWhenOpen = DateTimeOffset.UtcNow.AddHours(-1),
+                OnlineWhenClose = DateTimeOffset.UtcNow.AddHours(2),
+                OnlineCloseIsEstimate = true
+            });
+        Assert.Equal(HttpStatusCode.OK, windowResponse.StatusCode);
+
+        var candidates = await SeedVoterAndCandidatesAsync(
+            electionGuid, voterEmail, voterFirst, voterLast);
+
+        var submitResponse = await Client.PostAsJsonAsync(
+            $"/api/online-voting/{electionGuid}/submitBallot",
+            new SubmitOnlineBallotDto
+            {
+                ElectionGuid = electionGuid,
+                VoterId = voterEmail,
+                ListPool = [new OnlinePoolEntryDto { FullName = poolMarker }],
+                Votes = candidates.Select((personGuid, i) => new OnlineVoteDto
+                {
+                    PersonGuid = personGuid,
+                    PositionOnBallot = i + 1
+                }).ToList()
+            });
+        Assert.Equal(HttpStatusCode.OK, submitResponse.StatusCode);
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+            var pending = await context.OnlineVotingInfos
+                .SingleAsync(o => o.ElectionGuid == electionGuid);
+            Assert.Equal(OnlineBallotStatus.Submitted, pending.Status);
+            Assert.Null(pending.BallotGuid);
+            Assert.Contains(poolMarker, pending.ListPool);
+            Assert.Equal(0, await context.Ballots.CountAsync(b => b.Location.ElectionGuid == electionGuid));
+        }
+
+        var summaryBeforeResponse = await GetAsync(
+            $"/api/elections/{electionGuid}/online-ballots/accept-all-summary");
+        Assert.Equal(HttpStatusCode.OK, summaryBeforeResponse.StatusCode);
+        var summaryBefore = await DeserializeResponseAsync<AcceptAllOnlineBallotsSummaryDto>(
+            summaryBeforeResponse);
+        Assert.NotNull(summaryBefore);
+        Assert.Equal(1, summaryBefore.PendingCount);
+        Assert.Equal(0, summaryBefore.ProcessedCount);
+        await AssertAnonymousCountPayloadAsync(
+            await GetAsync($"/api/elections/{electionGuid}/online-ballots/accept-all-summary"),
+            voterEmail, voterFirst, voterLast, poolMarker);
+
+        var monitorBeforeResponse = await GetAsync(
+            $"/api/results/election/{electionGuid}/monitor");
+        Assert.Equal(HttpStatusCode.OK, monitorBeforeResponse.StatusCode);
+        var monitorBefore = await DeserializeResponseAsync<MonitorInfoDto>(monitorBeforeResponse);
+        Assert.NotNull(monitorBefore);
+        Assert.Equal(1, monitorBefore.OnlineVotingInfo.PendingOnlineBallots);
+        Assert.Equal(1, monitorBefore.OnlineVotingInfo.SubmittedOnlineBallots);
+        Assert.Equal(0, monitorBefore.OnlineVotingInfo.ProcessingOnlineBallots);
+        Assert.Equal(0, monitorBefore.OnlineVotingInfo.ProcessedOnlineBallots);
+        Assert.Equal(0, monitorBefore.TotalBallots);
+        await AssertAnonymousCountPayloadAsync(
+            await GetAsync($"/api/results/election/{electionGuid}/monitor"),
+            voterEmail, voterFirst, voterLast, poolMarker);
+
+        var acceptResponse = await Client.PostAsync(
+            $"/api/elections/{electionGuid}/online-ballots/accept-all",
+            null);
+        Assert.Equal(HttpStatusCode.OK, acceptResponse.StatusCode);
+        var accept = await DeserializeResponseAsync<AcceptAllOnlineBallotsResultDto>(acceptResponse);
+        Assert.NotNull(accept);
+        Assert.True(accept.Success);
+        Assert.Equal(1, accept.AcceptedCount);
+        Assert.Equal(0, accept.PendingRemaining);
+        Assert.Equal("monitoring.acceptAll.complete", accept.MessageKey);
+
+        var summaryAfter = await DeserializeResponseAsync<AcceptAllOnlineBallotsSummaryDto>(
+            await GetAsync($"/api/elections/{electionGuid}/online-ballots/accept-all-summary"));
+        Assert.NotNull(summaryAfter);
+        Assert.Equal(0, summaryAfter.PendingCount);
+        Assert.Equal(1, summaryAfter.ProcessedCount);
+
+        var monitorAfter = await DeserializeResponseAsync<MonitorInfoDto>(
+            await GetAsync($"/api/results/election/{electionGuid}/monitor"));
+        Assert.NotNull(monitorAfter);
+        Assert.Equal(0, monitorAfter.OnlineVotingInfo.PendingOnlineBallots);
+        Assert.Equal(0, monitorAfter.OnlineVotingInfo.SubmittedOnlineBallots);
+        Assert.Equal(0, monitorAfter.OnlineVotingInfo.ProcessingOnlineBallots);
+        Assert.Equal(1, monitorAfter.OnlineVotingInfo.ProcessedOnlineBallots);
+        Assert.Equal(1, monitorAfter.TotalBallots);
+        Assert.Equal(2, monitorAfter.TotalVotes);
+        Assert.Contains(monitorAfter.Locations, l => l.BallotCount == 1);
+        Assert.DoesNotContain(
+            monitorAfter.OnlineVotingInfo.AcceptAllRuns,
+            run => (run.AcceptedBy ?? "").Contains(voterEmail, StringComparison.OrdinalIgnoreCase));
+        await AssertAnonymousCountPayloadAsync(
+            await Client.GetAsync($"/api/results/election/{electionGuid}/monitor"),
+            voterEmail, voterFirst, voterLast, poolMarker);
+
+        using (var scope = Factory.Services.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+            var processed = await context.OnlineVotingInfos
+                .SingleAsync(o => o.ElectionGuid == electionGuid);
+            Assert.Equal(OnlineBallotStatus.Processed, processed.Status);
+            Assert.Null(processed.ListPool);
+            Assert.Null(processed.PoolLocked);
+            Assert.Null(processed.BallotGuid);
+            Assert.Contains(OnlineBallotStatus.Processed, processed.HistoryStatus);
+
+            var location = await context.Locations.SingleAsync(l =>
+                l.ElectionGuid == electionGuid
+                && l.LocationTypeCode == nameof(LocationType.Online));
+            var ballot = await context.Ballots.SingleAsync(b => b.LocationGuid == location.LocationGuid);
+            Assert.Equal(ComputerCodeHelper.Online, ballot.ComputerCode);
+            Assert.Equal($"{ComputerCodeHelper.Online}1", ballot.BallotCode);
+            Assert.Equal(2, await context.Votes.CountAsync(v => v.BallotGuid == ballot.BallotGuid));
+        }
+
+        var ballotsResponse = await GetAsync($"/api/ballots/{electionGuid}/ballots");
+        Assert.Equal(HttpStatusCode.OK, ballotsResponse.StatusCode);
+        var ballots = await DeserializeResponseAsync<PaginatedResponse<BallotDto>>(ballotsResponse);
+        var olBallot = Assert.Single(ballots!.Items);
+        Assert.Equal(ComputerCodeHelper.Online, olBallot.ComputerCode);
+        Assert.Equal($"{ComputerCodeHelper.Online}1", olBallot.BallotCode);
+        Assert.Equal(2, olBallot.VoteCount);
+
+        var onlineReportResponse = await GetAsync($"/api/reports/{electionGuid}/BallotsOnline");
+        Assert.Equal(HttpStatusCode.OK, onlineReportResponse.StatusCode);
+        var onlineReport = await DeserializeResponseAsync<BallotsReportDto>(onlineReportResponse);
+        var reported = Assert.Single(onlineReport!.Ballots);
+        Assert.True(reported.IsOnline);
+
+        var tallyResponse = await Client.PostAsync(
+            $"/api/results/election/{electionGuid}/calculate",
+            null);
+        Assert.Equal(HttpStatusCode.OK, tallyResponse.StatusCode);
+        var tally = await DeserializeResponseAsync<TallyResultDto>(tallyResponse);
+        Assert.NotNull(tally);
+        Assert.Equal(1, tally.Statistics.BallotsReceived);
+        Assert.Equal(2, tally.Statistics.TotalVotes);
+        Assert.Contains(tally.Results, r => r.PersonGuid == candidates[0] && r.VoteCount >= 1);
+        Assert.Contains(tally.Results, r => r.PersonGuid == candidates[1] && r.VoteCount >= 1);
+
+        var voteStatus = await Client.GetFromJsonAsync<OnlineVoteStatusDto>(
+            $"/api/online-voting/{electionGuid}/{voterEmail}/voteStatus");
+        Assert.NotNull(voteStatus);
+        Assert.True(voteStatus.HasVoted);
+        Assert.False(voteStatus.CanChangeVote);
+        Assert.Empty(voteStatus.PriorVotes);
+        Assert.Empty(voteStatus.ListPool);
+    }
+
+    private static async Task AssertAnonymousCountPayloadAsync(
+        HttpResponseMessage response,
+        string voterEmail,
+        string voterFirst,
+        string voterLast,
+        string poolMarker)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain(voterEmail, json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(voterFirst, json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(voterLast, json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(poolMarker, json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("personName", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("whenStatus", json, StringComparison.OrdinalIgnoreCase);
+        using var doc = JsonDocument.Parse(json);
+        AssertNoIdentityArrays(doc.RootElement);
+    }
+
+    private static void AssertNoIdentityArrays(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("acceptAllRuns") || property.NameEquals("locations")
+                    || property.NameEquals("computers"))
+                {
+                    continue;
+                }
+
+                Assert.False(
+                    property.Name.Contains("pending", StringComparison.OrdinalIgnoreCase)
+                    && property.Value.ValueKind == JsonValueKind.Array,
+                    "Monitor/summary must not return a pending row list.");
+                Assert.False(
+                    property.Name.Contains("accepted", StringComparison.OrdinalIgnoreCase)
+                    && property.Value.ValueKind == JsonValueKind.Array
+                    && property.Name != "acceptAllRuns",
+                    "Monitor/summary must not return an accepted row list.");
+                AssertNoIdentityArrays(property.Value);
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                AssertNoIdentityArrays(item);
+            }
+        }
+    }
+
+    private async Task<List<Guid>> SeedVoterAndCandidatesAsync(
+        Guid electionGuid,
+        string voterEmail,
+        string voterFirst,
+        string voterLast)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+
+        context.People.Add(new Person
+        {
+            ElectionGuid = electionGuid,
+            PersonGuid = Guid.NewGuid(),
+            FirstName = voterFirst,
+            LastName = voterLast,
+            Email = voterEmail,
+            CanVote = true,
+            RowVersion = new byte[8]
+        });
+
+        var candidates = new List<Guid>();
+        for (var i = 0; i < 2; i++)
+        {
+            var guid = Guid.NewGuid();
+            candidates.Add(guid);
+            context.People.Add(new Person
+            {
+                ElectionGuid = electionGuid,
+                PersonGuid = guid,
+                FirstName = $"Candidate{i}",
+                LastName = "Eligible",
+                CanReceiveVotes = true,
+                CanVote = true,
+                RowVersion = new byte[8]
+            });
+        }
+
+        if (!await context.OnlineVoters.AnyAsync(ov => ov.VoterId == voterEmail))
+        {
+            context.OnlineVoters.Add(new OnlineVoter
+            {
+                VoterId = voterEmail,
+                VoterIdType = "E",
+                WhenRegistered = DateTimeOffset.UtcNow
+            });
+        }
+
+        await context.SaveChangesAsync();
+        return candidates;
     }
 
     private async Task EnsureOnlineVoterAsync(string voterId, string voterIdType)

--- a/backend/Controllers/ElectionsController.cs
+++ b/backend/Controllers/ElectionsController.cs
@@ -336,11 +336,12 @@ public class ElectionsController : ControllerBase
     }
 
     /// <summary>
-    /// Accepts current pending (Submitted) online ballots into regular ballots.
-    /// The online voting window may stay open. Each run only accepts what is pending
-    /// at that moment. Concurrent Accept-all for the same election is rejected.
-    /// Acceptance is not reversible: online vote content is wiped and is not linked
-    /// to the regular ballot.
+    /// Accepts current pending (<c>Submitted</c> and already-<c>Processing</c>)
+    /// online ballots into regular ballots. The online voting window may stay
+    /// open. Each run only accepts what is pending at that moment. Concurrent
+    /// Accept-all for the same election is rejected. Acceptance is not
+    /// reversible: online vote content is wiped and is not linked to the
+    /// regular ballot.
     /// </summary>
     [HttpPost("{guid}/online-ballots/accept-all")]
     [Authorize(Policy = "FullTellerAccess")]

--- a/backend/DTOs/OnlineVoting/AcceptAllOnlineBallotsResultDto.cs
+++ b/backend/DTOs/OnlineVoting/AcceptAllOnlineBallotsResultDto.cs
@@ -1,8 +1,9 @@
 namespace Backend.DTOs.OnlineVoting;
 
 /// <summary>
-/// Outcome of one Accept-all run. Only pending (Submitted) online ballots at the
-/// start of the run are accepted. The online voting window may stay open.
+/// Outcome of one Accept-all run. Only rows that are <c>Submitted</c> or already
+/// <c>Processing</c> at the start of the run are accepted. The online voting
+/// window may stay open.
 /// </summary>
 public class AcceptAllOnlineBallotsResultDto
 {
@@ -25,7 +26,8 @@ public class AcceptAllOnlineBallotsResultDto
     public int SkippedCount { get; set; }
 
     /// <summary>
-    /// Submitted rows still pending after this run (usually 0 unless new votes arrived).
+    /// <c>Submitted</c> + <c>Processing</c> rows still pending after this run
+    /// (usually 0 unless new votes arrived).
     /// </summary>
     public int PendingRemaining { get; set; }
 

--- a/backend/DTOs/OnlineVoting/AcceptAllOnlineBallotsSummaryDto.cs
+++ b/backend/DTOs/OnlineVoting/AcceptAllOnlineBallotsSummaryDto.cs
@@ -6,12 +6,14 @@ namespace Backend.DTOs.OnlineVoting;
 public class AcceptAllOnlineBallotsSummaryDto
 {
     /// <summary>
-    /// Online ballots with status Submitted that this run would accept.
+    /// Online ballots this run would accept: <c>Submitted</c> + <c>Processing</c>.
+    /// Same set as monitor pending. Count only; no person identity.
     /// </summary>
     public int PendingCount { get; set; }
 
     /// <summary>
-    /// Online ballots already processed into regular ballots.
+    /// Online ballots already accepted (<c>Processed</c>) into regular ballots.
+    /// Count only; no person identity.
     /// </summary>
     public int ProcessedCount { get; set; }
 }

--- a/backend/Helpers/OnlineBallotStatus.cs
+++ b/backend/Helpers/OnlineBallotStatus.cs
@@ -2,9 +2,10 @@ namespace Backend.Helpers;
 
 /// <summary>
 /// Status values stored on <c>OnlineVotingInfo.Status</c> (varchar(10)).
-/// Submitted = pending. Processing = claimed by an Accept-all run (persisted so
-/// another server can see the claim). Processed = regular ballot created (or a
-/// legacy row unlinked) and the online payload wiped. There is no Draft value.
+/// Submitted = still changeable. Processing = claimed by Accept-all (persisted
+/// so another server can see the claim). Monitor and Accept-all pending is
+/// Submitted + Processing. Processed = regular ballot created (or a legacy row
+/// unlinked) and the online payload wiped. There is no Draft value.
 /// "Processing" is 10 characters and fits the column.
 /// </summary>
 public static class OnlineBallotStatus

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -44,6 +44,19 @@ Rows that already have a `BallotGuid` from the older submit-creates-ballot path 
 
 **Reason:** pending votes stay changeable until a teller accepts them; accepted votes become ordinary ballots with no remaining online payload.
 
+### Automated coverage for submit → Accept-all → counts
+
+**Status:** active  
+**Evidence:** confirmed (issue #169 remaining; HTTP integration in `OnlineVotingBallotFlowTests`)
+
+Issue #169 is the test script for this process, not a second product build. Coverage is the HTTP integration path (voter submit → teller Accept-all → monitor/summary counts, ListPool wipe, OL regular ballot, tally) plus the existing Accept-all service tests and monitor Vitest counts. That HTTP test uses the shared SQLite `CustomWebApplicationFactory`, which is relational, so it exercises the `ExecuteUpdate` claim that in-memory unit tests skip.
+
+**Rejected alternative:** Playwright browser E2E. Frontend tests stay Vitest + jsdom; the monitor already locks counts-only (no named pending/accepted list) and a reload after Accept-all.
+
+**Rejected alternative:** run these automated tests against Azure SQL. Backend.Tests stay on the local SQLite factory. Live cloud-agent app runs use local Docker SQL + migrations + SeedOnStartup, not production Azure SQL.
+
+**Reason:** lock the already-shipped Accept-all contract (including anonymity: counts only) without a browser driver and without a production database.
+
 ## Pending vs accepted on the monitor (counts only)
 
 **Status:** active  

--- a/frontend/src/pages/results/__tests__/MonitoringDashboardPage.spec.ts
+++ b/frontend/src/pages/results/__tests__/MonitoringDashboardPage.spec.ts
@@ -12,6 +12,7 @@ const {
   mockShowError,
   mockUpdateWindow,
   mockFetchElection,
+  mockFetchMonitor,
   mockElection,
 } = vi.hoisted(() => ({
   mockGetSummary: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockShowError: vi.fn(),
   mockUpdateWindow: vi.fn(),
   mockFetchElection: vi.fn(),
+  mockFetchMonitor: vi.fn(),
   mockElection: {
     electionGuid: "election-1",
     onlineCloseIsEstimate: true,
@@ -96,9 +98,23 @@ const mockMonitor: MonitorInfoDto = {
 
 vi.mock("@/stores/resultStore", () => ({
   useResultStore: () => ({
-    fetchMonitorInfo: vi.fn().mockResolvedValue(mockMonitor),
+    fetchMonitorInfo: (...args: unknown[]) => mockFetchMonitor(...args),
   }),
 }));
+
+function copyMonitor(
+  online: Partial<MonitorInfoDto["onlineVotingInfo"]> = {},
+  extras: Partial<MonitorInfoDto> = {},
+): MonitorInfoDto {
+  return {
+    ...mockMonitor,
+    ...extras,
+    onlineVotingInfo: {
+      ...mockMonitor.onlineVotingInfo,
+      ...online,
+    },
+  };
+}
 
 vi.mock("@/services/signalrService", () => ({
   signalrService: {
@@ -155,6 +171,8 @@ describe("MonitoringDashboardPage Accept all", () => {
     mockShowError.mockReset();
     mockUpdateWindow.mockReset();
     mockFetchElection.mockReset();
+    mockFetchMonitor.mockReset();
+    mockFetchMonitor.mockResolvedValue(mockMonitor);
     mockElection.onlineCloseIsEstimate = true;
     mockMonitor.onlineVotingInfo.pendingOnlineBallots = 3;
     mockMonitor.onlineVotingInfo.submittedOnlineBallots = 2;
@@ -325,8 +343,27 @@ describe("MonitoringDashboardPage Accept all", () => {
       acceptedCount: 3,
       messageKey: "monitoring.acceptAll.complete",
     });
+    mockFetchMonitor
+      .mockReset()
+      .mockResolvedValueOnce(copyMonitor())
+      .mockResolvedValueOnce(
+        copyMonitor({
+          pendingOnlineBallots: 0,
+          submittedOnlineBallots: 0,
+          processingOnlineBallots: 0,
+          processedOnlineBallots: 4,
+          totalOnlineBallots: 4,
+        }),
+      );
 
     const wrapper = await mountPage();
+    expect(
+      wrapper.find("[data-testid='submitted-online-ballots-count']").text(),
+    ).toBe("2");
+    expect(
+      wrapper.find("[data-testid='accepted-online-ballots-count']").text(),
+    ).toBe("1");
+
     await wrapper
       .find("[data-testid='accept-all-online-ballots']")
       .trigger("click");
@@ -338,6 +375,21 @@ describe("MonitoringDashboardPage Accept all", () => {
     expect(confirmMessage).toContain("3");
     expect(mockAcceptAll).toHaveBeenCalledWith("election-1");
     expect(mockShowSuccess).toHaveBeenCalled();
+    expect(mockFetchMonitor).toHaveBeenCalledTimes(2);
+    expect(
+      wrapper.find("[data-testid='submitted-online-ballots-count']").text(),
+    ).toBe("0");
+    expect(
+      wrapper.find("[data-testid='processing-online-ballots-count']").text(),
+    ).toBe("0");
+    expect(
+      wrapper.find("[data-testid='accepted-online-ballots-count']").text(),
+    ).toBe("4");
+    expect(
+      wrapper.find("[data-testid='accept-all-online-ballots']").attributes(
+        "disabled",
+      ),
+    ).toBeDefined();
   });
 
   it("does not accept when the teller cancels the confirmation", async () => {
@@ -417,6 +469,8 @@ describe("MonitoringDashboardPage close countdown", () => {
   beforeEach(() => {
     mockUpdateWindow.mockReset();
     mockShowSuccess.mockReset();
+    mockFetchMonitor.mockReset();
+    mockFetchMonitor.mockResolvedValue(mockMonitor);
     mockElection.onlineCloseIsEstimate = true;
     mockMonitor.onlineVotingInfo.onlineVotingStart = new Date(
       Date.now() - 60 * 60 * 1000,

--- a/frontend/src/pages/results/__tests__/MonitoringDashboardPage.spec.ts
+++ b/frontend/src/pages/results/__tests__/MonitoringDashboardPage.spec.ts
@@ -386,9 +386,9 @@ describe("MonitoringDashboardPage Accept all", () => {
       wrapper.find("[data-testid='accepted-online-ballots-count']").text(),
     ).toBe("4");
     expect(
-      wrapper.find("[data-testid='accept-all-online-ballots']").attributes(
-        "disabled",
-      ),
+      wrapper
+        .find("[data-testid='accept-all-online-ballots']")
+        .attributes("disabled"),
     ).toBeDefined();
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The online-ballot acceptance **process** already shipped (#188 / #256 / #294–#296 and earlier). This PR is **tests only**.

## What this adds

HTTP integration coverage in `OnlineVotingBallotFlowTests` for the #169 script:

1. Voter submits online (payload stays on `OnlineVotingInfo`, no regular ballot yet).
2. Teller Accept-all via the existing elections API.
3. Monitor / accept-all-summary **counts** move pending → accepted (`Submitted`+`Processing` vs `Processed`).
4. Original pending payload is gone (`ListPool` / `PoolLocked` wiped, status `Processed`, `BallotGuid` unlinked).
5. A regular ballot appears at the Online location with computer code `OL`, and tally includes its votes.

The HTTP test uses the existing SQLite `CustomWebApplicationFactory` (relational), so it also exercises the `ExecuteUpdate` claim path that in-memory Accept-all unit tests skip.

Monitor Vitest now asserts that after Accept-all the page reloads and **counts update** (still no named pending/accepted list).

Comments on Accept-all DTOs / status helpers now match behavior: pending is `Submitted` + `Processing`, not Submitted only.

## Local verification

- `dotnet test Backend.Tests --filter "FullyQualifiedName~OnlineVotingBallotFlowTests|FullyQualifiedName~OnlineVotingServiceAcceptAllTests"` — 32 passed
- `npm run test:run -- src/pages/results/__tests__/MonitoringDashboardPage.spec.ts` — 19 passed
- `npm run check` — clean for the touched spec (pre-existing prettier warnings elsewhere)

## What this does not add

- No product/behavior change to Accept-all.
- No Playwright (frontend stays Vitest + jsdom).
- No named pending/accepted lists (anonymity contract unchanged).
- Does not close #303 (user-test backlog).

Related: #169

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd13e157-87ef-4fc4-96a3-0d5982465cf9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd13e157-87ef-4fc4-96a3-0d5982465cf9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

