### PR TITLE
Stage-change tests: lock after analysis, guest menus, move-all tellers

### DIFF
--- a/Backend.Tests/IntegrationTests/ElectionsControllerTests.cs
+++ b/Backend.Tests/IntegrationTests/ElectionsControllerTests.cs
@@ -333,6 +333,60 @@ public class ElectionsControllerTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task ChangeElectionStage_ToFinalizedAfterAnalysis_LocksUntilConfirmed()
+    {
+        var token = await GetAuthTokenAsync();
+        SetAuthToken(token);
+
+        var createDto = new CreateElectionDto
+        {
+            Name = "Lock After Analysis Election",
+            DateOfElection = DateTime.UtcNow.AddDays(30),
+            ElectionType = ElectionTypeCode.LSA,
+            NumberToElect = 3
+        };
+
+        var createResponse = await PostJsonAsync("/api/elections/createElection", createDto);
+        var createResult = await DeserializeResponseAsync<ApiResponse<ElectionDto>>(createResponse);
+        var electionGuid = createResult!.Data!.ElectionGuid;
+
+        foreach (var stage in new[] { ElectionStage.GatheringBallots, ElectionStage.ProcessingBallots })
+        {
+            var advance = await PutJsonAsync(
+                $"/api/elections/{electionGuid}/stage",
+                new ChangeElectionStageDto { ElectionStage = stage });
+            Assert.Equal(HttpStatusCode.OK, advance.StatusCode);
+        }
+
+        await SeedAnalysisReadyForFinalizationAsync(electionGuid);
+
+        var finalizeResponse = await PutJsonAsync(
+            $"/api/elections/{electionGuid}/stage",
+            new ChangeElectionStageDto { ElectionStage = ElectionStage.Finalized });
+        Assert.Equal(HttpStatusCode.OK, finalizeResponse.StatusCode);
+
+        var finalized = await DeserializeResponseAsync<ApiResponse<ElectionDto>>(finalizeResponse);
+        Assert.Equal(ElectionStage.Finalized, finalized!.Data!.ElectionStage);
+
+        var leaveWithoutConfirm = await PutJsonAsync(
+            $"/api/elections/{electionGuid}/stage",
+            new ChangeElectionStageDto { ElectionStage = ElectionStage.ProcessingBallots });
+        Assert.Equal(HttpStatusCode.Conflict, leaveWithoutConfirm.StatusCode);
+
+        var leaveWithConfirm = await PutJsonAsync(
+            $"/api/elections/{electionGuid}/stage",
+            new ChangeElectionStageDto
+            {
+                ElectionStage = ElectionStage.ProcessingBallots,
+                ConfirmLeavingFinalized = true
+            });
+        Assert.Equal(HttpStatusCode.OK, leaveWithConfirm.StatusCode);
+
+        var unlocked = await DeserializeResponseAsync<ApiResponse<ElectionDto>>(leaveWithConfirm);
+        Assert.Equal(ElectionStage.ProcessingBallots, unlocked!.Data!.ElectionStage);
+    }
+
+    [Fact]
     public async Task ChangeElectionStage_WithInvalidEnum_ReturnsBadRequest()
     {
         var token = await GetAuthTokenAsync();
@@ -680,6 +734,42 @@ public class ElectionsControllerTests : IntegrationTestBase
 
         var getResponse = await GetAsync($"/api/elections/{electionGuid}/election");
         Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    /// <summary>
+    /// Analysis-complete + reconciled counts so Finalized is allowed (no Front Desk
+    /// registrations or ballots, so reconciliation has nothing to mismatch).
+    /// </summary>
+    private async Task SeedAnalysisReadyForFinalizationAsync(Guid electionGuid)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+
+        var personGuid = Guid.NewGuid();
+        db.People.Add(new Person
+        {
+            PersonGuid = personGuid,
+            ElectionGuid = electionGuid,
+            FirstName = "Analyzed",
+            LastName = "Candidate",
+            RowVersion = new byte[8]
+        });
+        db.Results.Add(new Result
+        {
+            ElectionGuid = electionGuid,
+            PersonGuid = personGuid,
+            Rank = 1,
+            Section = "E",
+            VoteCount = 10
+        });
+        db.ResultSummaries.Add(new ResultSummary
+        {
+            ElectionGuid = electionGuid,
+            ResultType = "F",
+            UseOnReports = true,
+            BallotsNeedingReview = 0
+        });
+        await db.SaveChangesAsync();
     }
 }
 

--- a/Backend.Tests/UnitTests/ElectionServiceTests.cs
+++ b/Backend.Tests/UnitTests/ElectionServiceTests.cs
@@ -582,6 +582,12 @@ public class ElectionServiceTests : ServiceTestBase
 
         var inDb = Context.Elections.Single(e => e.ElectionGuid == electionGuid);
         Assert.Equal(ElectionStage.Finalized, inDb.ElectionStage);
+
+        // Lock-after-analysis: other tellers hear the Finalized stage via statusChanged.
+        _signalRMock.Verify(
+            s => s.SendElectionUpdateAsync(It.Is<Backend.DTOs.SignalR.ElectionUpdateDto>(
+                u => u.ElectionGuid == electionGuid && u.ElectionStage == ElectionStage.Finalized)),
+            Times.Once);
     }
 
     [Fact]
@@ -639,9 +645,15 @@ public class ElectionServiceTests : ServiceTestBase
 
         Assert.True(result.RequiresConfirmation);
         Assert.NotNull(result.ConfirmationReason);
+        Assert.Equal(ElectionStageMessageKeys.ConfirmLeaveFinalized, result.ConfirmationReason);
 
         var inDb = Context.Elections.Single(e => e.ElectionGuid == electionGuid);
         Assert.Equal(ElectionStage.Finalized, inDb.ElectionStage);
+
+        // Lock holds: no statusChanged until the operator confirms leaving Finalized.
+        _signalRMock.Verify(
+            s => s.SendElectionUpdateAsync(It.IsAny<Backend.DTOs.SignalR.ElectionUpdateDto>()),
+            Times.Never);
     }
 
     [Fact]
@@ -670,6 +682,42 @@ public class ElectionServiceTests : ServiceTestBase
 
         Assert.True(result.IsSuccess);
         Assert.Equal(ElectionStage.ProcessingBallots, result.Election!.ElectionStage);
+
+        _signalRMock.Verify(
+            s => s.SendElectionUpdateAsync(It.Is<Backend.DTOs.SignalR.ElectionUpdateDto>(
+                u => u.ElectionGuid == electionGuid && u.ElectionStage == ElectionStage.ProcessingBallots)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ChangeElectionStageAsync_BroadcastsStatusChanged_SoOtherTellersMove()
+    {
+        var electionGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Move Tellers Election",
+            ElectionType = "LSA",
+            NumberToElect = 3,
+            ElectionStage = ElectionStage.SettingUp,
+            DateOfElection = DateTime.UtcNow.AddDays(10),
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ChangeElectionStageAsync(electionGuid, new ChangeElectionStageDto
+        {
+            ElectionStage = ElectionStage.GatheringBallots
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(ElectionStage.GatheringBallots, result.Election!.ElectionStage);
+
+        // "Move all tellers to this state" is this broadcast, not a separate API.
+        _signalRMock.Verify(
+            s => s.SendElectionUpdateAsync(It.Is<Backend.DTOs.SignalR.ElectionUpdateDto>(
+                u => u.ElectionGuid == electionGuid && u.ElectionStage == ElectionStage.GatheringBallots)),
+            Times.Once);
     }
 
     [Fact]

--- a/context/election-state.md
+++ b/context/election-state.md
@@ -11,6 +11,30 @@ State transitions affect what every teller can see and do. Silent or partial fai
 ### Design posture
 Treat state changes as high-consequence operations. Prefer clear, atomic transitions and strong feedback over optimistic updates.
 
+## Lock after analysis is the Finalized stage
+
+**Status:** active  
+**Evidence:** inferred (issue #172 names; implementation in `ElectionService.ChangeElectionStageAsync`)
+
+There is no separate `Locked` flag. After analysis is complete and counts reconcile, advancing to **Finalized** is the lock:
+
+- Finalization is rejected until `ElectionStageFinalizationReadiness` is ready (analysis present and reportable, no blocking ballots, no unresolved ties, counts reconcile).
+- Leaving Finalized requires `ConfirmLeavingFinalized`. The StageControl UI does not send that flag, so a FullTeller click away from Finalized stays locked and shows the confirmation error.
+- Accept-all online ballots is refused while Finalized.
+
+**Rejected alternative (not implemented):** a dedicated lock bit plus a “Move all tellers” command. Stage change + SignalR `statusChanged` is the coordination path.
+
+**Gap (intentional for this test slice):** people/ballot write APIs are not separately gated on Finalized. The lock is the stage + confirmation + guest menu/route rules.
+
+## “Move all tellers to this state” is the stage broadcast
+
+**Status:** active  
+**Evidence:** inferred (issue #172 names; no separate move-tellers API)
+
+Changing stage is the move. `ChangeElectionStageAsync` persists the stage and broadcasts `statusChanged` on MainHub. Remote `electionStore` clients update `currentStage`. GuestTellers are redirected to that stage’s work page; FullTellers are notified and stay on their current page (they can still open other stage groups).
+
+There is no separate “Move all tellers to this state” button or endpoint.
+
 ## GuestTeller page on stage change
 
 **Status:** active  

--- a/frontend/src/components/AppSidebar.test.ts
+++ b/frontend/src/components/AppSidebar.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { createRouter, createWebHistory } from "vue-router";
 import { createTestingPinia } from "@pinia/testing";
@@ -14,24 +14,6 @@ const authState = {
 
 vi.mock("../stores/authStore", () => ({
   useAuthStore: () => authState,
-}));
-
-vi.mock("./nav/SidebarStageHeader.vue", () => ({
-  default: {
-    name: "SidebarStageHeader",
-    props: ["electionGuid", "stage"],
-    template:
-      '<div class="mock-stage-header" :data-stage="stage" :data-guid="electionGuid" />',
-  },
-}));
-
-vi.mock("./nav/StageGroupedSidebarMenu.vue", () => ({
-  default: {
-    name: "StageGroupedSidebarMenu",
-    props: ["electionGuid", "currentStage", "isGuestTeller"],
-    template:
-      '<div class="mock-stage-menu" :data-guest="isGuestTeller ? \'true\' : \'false\'" :data-stage="currentStage" />',
-  },
 }));
 
 const ELECTION_GUID = "elec-sidebar";
@@ -87,6 +69,18 @@ async function mountSidebar(options: {
     global: {
       plugins: [pinia, router, i18n],
       stubs: {
+        SidebarStageHeader: {
+          name: "SidebarStageHeader",
+          props: ["electionGuid", "stage"],
+          template:
+            '<div class="mock-stage-header" :data-stage="stage" :data-guid="electionGuid" />',
+        },
+        StageGroupedSidebarMenu: {
+          name: "StageGroupedSidebarMenu",
+          props: ["electionGuid", "currentStage", "isGuestTeller"],
+          template:
+            '<div class="mock-stage-menu" :data-guest="isGuestTeller ? \'true\' : \'false\'" :data-stage="currentStage" />',
+        },
         ElIcon: { template: "<span />" },
         ElMenu: { template: "<div><slot /></div>" },
         ElMenuItem: { template: "<div><slot /></div>" },
@@ -134,6 +128,7 @@ describe("AppSidebar election nav", () => {
     expect(wrapper.find(".mock-stage-header").exists()).toBe(true);
     expect(wrapper.find(".back-to-elections").exists()).toBe(true);
     const menu = wrapper.find(".mock-stage-menu");
+    expect(menu.exists()).toBe(true);
     expect(menu.attributes("data-guest")).toBe("false");
     expect(menu.attributes("data-stage")).toBe("ProcessingBallots");
   });
@@ -145,6 +140,7 @@ describe("AppSidebar election nav", () => {
     });
 
     expect(wrapper.find(".mock-stage-header").exists()).toBe(false);
+    expect(wrapper.find(".mock-stage-menu").exists()).toBe(true);
     expect(wrapper.find(".mock-stage-menu").attributes("data-stage")).toBe(
       "Finalized",
     );

--- a/frontend/src/components/AppSidebar.test.ts
+++ b/frontend/src/components/AppSidebar.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createRouter, createWebHistory } from "vue-router";
+import { createTestingPinia } from "@pinia/testing";
+import AppSidebar from "./AppSidebar.vue";
+import { i18n } from "../test/setup";
+import type { ElectionDto } from "@/types";
+
+const authState = {
+  name: "Alice",
+  authMethod: "Local",
+  isSuperAdmin: false,
+};
+
+vi.mock("../stores/authStore", () => ({
+  useAuthStore: () => authState,
+}));
+
+vi.mock("./nav/SidebarStageHeader.vue", () => ({
+  default: {
+    name: "SidebarStageHeader",
+    props: ["electionGuid", "stage"],
+    template:
+      '<div class="mock-stage-header" :data-stage="stage" :data-guid="electionGuid" />',
+  },
+}));
+
+vi.mock("./nav/StageGroupedSidebarMenu.vue", () => ({
+  default: {
+    name: "StageGroupedSidebarMenu",
+    props: ["electionGuid", "currentStage", "isGuestTeller"],
+    template:
+      '<div class="mock-stage-menu" :data-guest="isGuestTeller ? \'true\' : \'false\'" :data-stage="currentStage" />',
+  },
+}));
+
+const ELECTION_GUID = "elec-sidebar";
+
+function testElection(stage: ElectionDto["electionStage"]): ElectionDto {
+  return {
+    electionGuid: ELECTION_GUID,
+    name: "Sidebar Election",
+    electionStage: stage,
+  } as ElectionDto;
+}
+
+async function mountSidebar(options: {
+  guest: boolean;
+  stage: ElectionDto["electionStage"];
+}) {
+  authState.name = options.guest ? "Teller" : "Alice";
+  authState.authMethod = options.guest ? "AccessCode" : "Local";
+
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      {
+        path: "/elections/:id",
+        name: "Election",
+        component: { template: "<div />" },
+      },
+      {
+        path: "/elections/:id/frontdesk",
+        name: "FrontDesk",
+        component: { template: "<div />" },
+      },
+      {
+        path: "/elections",
+        name: "Elections",
+        component: { template: "<div />" },
+      },
+    ],
+  });
+  await router.push(`/elections/${ELECTION_GUID}/frontdesk`);
+  await router.isReady();
+
+  const pinia = createTestingPinia({
+    stubActions: false,
+    initialState: {
+      election: {
+        currentElection: testElection(options.stage),
+      },
+    },
+  });
+
+  const wrapper = mount(AppSidebar, {
+    global: {
+      plugins: [pinia, router, i18n],
+      stubs: {
+        ElIcon: { template: "<span />" },
+        ElMenu: { template: "<div><slot /></div>" },
+        ElMenuItem: { template: "<div><slot /></div>" },
+        ElSkeleton: { template: "<div class='skeleton' />" },
+        ArrowLeft: { template: "<span />" },
+        Expand: { template: "<span />" },
+        Fold: { template: "<span />" },
+        HomeFilled: { template: "<span />" },
+        Setting: { template: "<span />" },
+        User: { template: "<span />" },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe("AppSidebar election nav", () => {
+  beforeEach(() => {
+    authState.name = "Alice";
+    authState.authMethod = "Local";
+    authState.isSuperAdmin = false;
+  });
+
+  it("hides the stage switcher from GuestTellers", async () => {
+    const wrapper = await mountSidebar({
+      guest: true,
+      stage: "GatheringBallots",
+    });
+
+    expect(wrapper.find(".mock-stage-header").exists()).toBe(false);
+    expect(wrapper.find(".back-to-elections").exists()).toBe(false);
+    const menu = wrapper.find(".mock-stage-menu");
+    expect(menu.exists()).toBe(true);
+    expect(menu.attributes("data-guest")).toBe("true");
+    expect(menu.attributes("data-stage")).toBe("GatheringBallots");
+  });
+
+  it("shows the stage switcher to FullTellers", async () => {
+    const wrapper = await mountSidebar({
+      guest: false,
+      stage: "ProcessingBallots",
+    });
+
+    expect(wrapper.find(".mock-stage-header").exists()).toBe(true);
+    expect(wrapper.find(".back-to-elections").exists()).toBe(true);
+    const menu = wrapper.find(".mock-stage-menu");
+    expect(menu.attributes("data-guest")).toBe("false");
+    expect(menu.attributes("data-stage")).toBe("ProcessingBallots");
+  });
+
+  it("passes Finalized to the guest menu after the election is locked", async () => {
+    const wrapper = await mountSidebar({
+      guest: true,
+      stage: "Finalized",
+    });
+
+    expect(wrapper.find(".mock-stage-header").exists()).toBe(false);
+    expect(wrapper.find(".mock-stage-menu").attributes("data-stage")).toBe(
+      "Finalized",
+    );
+    expect(wrapper.find(".mock-stage-menu").attributes("data-guest")).toBe(
+      "true",
+    );
+  });
+});

--- a/frontend/src/components/nav/__tests__/StageControl.test.ts
+++ b/frontend/src/components/nav/__tests__/StageControl.test.ts
@@ -6,6 +6,8 @@ import StageControl from "../StageControl.vue";
 const stagePhraseMessages: Record<string, string> = {
   "elections.stageChangeError.analysisNotReady":
     "Election analysis is not complete or ready for finalization",
+  "elections.stageChangeError.confirmLeaveFinalized":
+    "Reverting from Finalized requires confirmation",
   "elections.stageChangeError.generic": "Failed to change election stage",
 };
 
@@ -147,6 +149,40 @@ describe("StageControl", () => {
       expect(mockGetCountReconciliation).toHaveBeenCalledWith("abc-123");
       expect(mockSetStage).not.toHaveBeenCalled();
       expect(mockShowErrorMessage).toHaveBeenCalled();
+    });
+
+    it("calls setStage with Finalized when counts reconcile", async () => {
+      mockSetStage.mockResolvedValue(undefined);
+      const wrapper = mount(StageControl, {
+        props: { electionGuid: "abc-123", stage: "ProcessingBallots" },
+        global: { stubs: globalStubs },
+      });
+      const radios = wrapper.findAll('[role="radio"]');
+      await radios[3]!.trigger("click");
+      await flushPromises();
+
+      expect(mockGetCountReconciliation).toHaveBeenCalledWith("abc-123");
+      expect(mockSetStage).toHaveBeenCalledWith("abc-123", "Finalized");
+    });
+
+    it("shows lock confirmation error when leaving Finalized is rejected", async () => {
+      mockSetStage.mockRejectedValue({
+        message: "elections.stageChangeError.confirmLeaveFinalized",
+      });
+
+      const wrapper = mount(StageControl, {
+        props: { electionGuid: "abc-123", stage: "Finalized" },
+        global: { stubs: globalStubs },
+      });
+
+      const radios = wrapper.findAll('[role="radio"]');
+      await radios[2]!.trigger("click");
+      await flushPromises();
+
+      expect(mockSetStage).toHaveBeenCalledWith("abc-123", "ProcessingBallots");
+      expect(mockShowErrorMessage).toHaveBeenCalledWith(
+        "Reverting from Finalized requires confirmation",
+      );
     });
 
     it("shows translated server error when stage change fails", async () => {

--- a/frontend/src/components/nav/__tests__/StageGroupedSidebarMenu.test.ts
+++ b/frontend/src/components/nav/__tests__/StageGroupedSidebarMenu.test.ts
@@ -216,6 +216,35 @@ describe("StageGroupedSidebarMenu", () => {
       });
       const pages = wrapper.findAll(".stage-group__page");
       expect(pages).toHaveLength(2);
+      expect(pages.map((p) => p.text())).toEqual([
+        "elections.details",
+        "results.showFinalResults",
+      ]);
+    });
+
+    it("does not show FullTeller-only items during ProcessingBallots", () => {
+      const wrapper = mountMenu({
+        isGuestTeller: true,
+        currentStage: "ProcessingBallots",
+      });
+      const text = wrapper.text();
+      expect(text).toContain("ballots.management");
+      expect(text).not.toContain("results.monitor");
+      expect(text).not.toContain("results.calculateTally");
+      expect(text).not.toContain("results.title");
+      expect(text).not.toContain("results.reporting");
+    });
+
+    it("does not show FullTeller-only items during GatheringBallots", () => {
+      const wrapper = mountMenu({
+        isGuestTeller: true,
+        currentStage: "GatheringBallots",
+      });
+      const text = wrapper.text();
+      expect(text).toContain("nav.frontDesk");
+      expect(text).not.toContain("people.management");
+      expect(text).not.toContain("elections.edit");
+      expect(text).not.toContain("nav.tellers");
     });
 
     it("renders no pages when SettingUp (all admin-only)", () => {

--- a/frontend/src/composables/__tests__/useGuestTellerStageRedirect.spec.ts
+++ b/frontend/src/composables/__tests__/useGuestTellerStageRedirect.spec.ts
@@ -26,13 +26,17 @@ vi.mock("vue-router", () => ({
   }),
 }));
 
+const { isGuestTellerMock } = vi.hoisted(() => ({
+  isGuestTellerMock: vi.fn(() => true),
+}));
+
 vi.mock("@/domain/guestTellerAccess", async () => {
   const actual = await vi.importActual<
     typeof import("@/domain/guestTellerAccess")
   >("@/domain/guestTellerAccess");
   return {
     ...actual,
-    isGuestTeller: vi.fn(() => true),
+    isGuestTeller: (...args: unknown[]) => isGuestTellerMock(...args),
   };
 });
 
@@ -55,6 +59,8 @@ describe("useGuestTellerStageRedirect", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockRouterPush.mockReset();
+    isGuestTellerMock.mockReset();
+    isGuestTellerMock.mockReturnValue(true);
     routePath.value = "/elections/elec-1/frontdesk";
     routeId.value = "elec-1";
   });
@@ -112,6 +118,51 @@ describe("useGuestTellerStageRedirect", () => {
     await nextTick();
 
     expect(mockRouterPush).toHaveBeenCalledWith("/elections/elec-1/frontdesk");
+  });
+
+  it("redirects GuestTeller to election landing when stage becomes Finalized", async () => {
+    const store = useElectionStore();
+    store.currentElection = {
+      electionGuid: "elec-1",
+      name: "Test",
+      electionStage: "ProcessingBallots",
+    } as ElectionDto;
+    routePath.value = "/elections/elec-1/ballots";
+
+    mountHarness();
+    await nextTick();
+    mockRouterPush.mockReset();
+
+    store.currentElection = {
+      ...store.currentElection!,
+      electionStage: "Finalized",
+    };
+    await nextTick();
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/elections/elec-1");
+  });
+
+  it("does not move a FullTeller when the stage changes", async () => {
+    isGuestTellerMock.mockReturnValue(false);
+    routePath.value = "/elections/elec-1/people";
+    const store = useElectionStore();
+    store.currentElection = {
+      electionGuid: "elec-1",
+      name: "Test",
+      electionStage: "SettingUp",
+    } as ElectionDto;
+
+    mountHarness();
+    await nextTick();
+    mockRouterPush.mockReset();
+
+    store.currentElection = {
+      ...store.currentElection!,
+      electionStage: "GatheringBallots",
+    };
+    await nextTick();
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
   it("does not redirect when already on the correct ProcessingBallots page", async () => {

--- a/frontend/src/domain/__tests__/guestTellerAccess.test.ts
+++ b/frontend/src/domain/__tests__/guestTellerAccess.test.ts
@@ -66,6 +66,31 @@ describe("guestTellerAccess", () => {
       const pages = getGuestTellerMenuPages("Finalized", GUID);
       expect(pages.map((p) => p.key)).toEqual(["landing", "final-results"]);
     });
+
+    it("never includes FullTeller-only pages (tally, monitor, people, edit)", () => {
+      const stages: ElectionStage[] = [
+        "SettingUp",
+        "GatheringBallots",
+        "ProcessingBallots",
+        "Finalized",
+      ];
+      const hiddenKeys = [
+        "monitor",
+        "tally",
+        "people",
+        "edit",
+        "locations",
+        "tellers",
+        "reporting",
+      ];
+
+      for (const stage of stages) {
+        const keys = getGuestTellerMenuPages(stage, GUID).map((p) => p.key);
+        for (const hidden of hiddenKeys) {
+          expect(keys, `${stage} must not show ${hidden}`).not.toContain(hidden);
+        }
+      }
+    });
   });
 
   describe("isGuestTellerRouteAllowed", () => {

--- a/frontend/src/stores/electionStore.test.ts
+++ b/frontend/src/stores/electionStore.test.ts
@@ -570,6 +570,40 @@ describe("Election Store", () => {
       expect(elMessageMock).toHaveBeenCalledTimes(1);
     });
 
+    it("statusChanged to Finalized updates currentStage for other tellers", async () => {
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
+
+      electionStore.currentElection = {
+        electionGuid: "election-1",
+        name: "Springfield LSA",
+        electionStage: "ProcessingBallots",
+      } as ElectionDto;
+
+      await electionStore.initializeSignalR();
+      handlers.get("statusChanged")!({
+        electionGuid: "election-1",
+        name: "Springfield LSA",
+        electionStage: "Finalized",
+        updatedAt: new Date().toISOString(),
+      });
+
+      expect(electionStore.currentStage).toBe("Finalized");
+      expect(elMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Election changed to Finalized",
+          type: "info",
+        }),
+      );
+    });
+
     it("statusChanged does not toast when local setStage already suppressed echo", async () => {
       const { signalrService } = await import("../services/signalrService");
       const { electionService } = await import("../services/electionService");
@@ -701,6 +735,14 @@ describe("Election Store", () => {
       expect(electionStore.currentStage).toBe("ProcessingBallots");
     });
 
+    it("returns Finalized when electionStage is Finalized (lock after analysis)", () => {
+      electionStore.currentElection = {
+        electionGuid: "1",
+        electionStage: "Finalized",
+      } as ElectionDto;
+      expect(electionStore.currentStage).toBe("Finalized");
+    });
+
     it("reacts to currentElection changes", () => {
       electionStore.currentElection = {
         electionGuid: "1",
@@ -766,6 +808,22 @@ describe("Election Store", () => {
         "1",
         "ProcessingBallots",
       );
+    });
+
+    it("calls electionService.changeStage with Finalized", async () => {
+      const { electionService } = await import("../services/electionService");
+      const updatedElection = {
+        electionGuid: "1",
+        electionStage: "Finalized",
+      } as ElectionDto;
+      electionStore.elections = [{ electionGuid: "1" } as ElectionDto];
+      electionStore.currentElection = electionStore.elections[0]!;
+      electionService.changeStage.mockResolvedValue(updatedElection);
+
+      await electionStore.setStage("1", "Finalized");
+
+      expect(electionService.changeStage).toHaveBeenCalledWith("1", "Finalized");
+      expect(electionStore.currentElection?.electionStage).toBe("Finalized");
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds automated tests for the three remaining #172 items. No product behavior change.

## What “lock / guest menus / move all tellers” are in v4

These issue names do not appear as APIs or buttons. The existing product maps them as:

| Issue item | Current behavior |
|---|---|
| Lock after analysis | Advance to **Finalized** after analysis is ready. Leaving Finalized requires `ConfirmLeavingFinalized`. StageControl does not send that flag, so a click away from Finalized stays locked and shows the confirmation error. Accept-all is also refused while Finalized. |
| Guest teller menus | `getGuestTellerMenuPages` + sidebar: none in Setting Up; Front Desk while Gathering; Enter Ballots while Processing; landing + final results when Finalized. Tally / monitor / people / edit stay FullTeller-only. Guests do not see the stage switcher. |
| “Move all tellers to this state” | Changing stage broadcasts MainHub `statusChanged`. Remote stores update `currentStage`. **GuestTellers** redirect to that stage’s work page. **FullTellers** get a toast and stay on their current page. There is no separate move-tellers endpoint. |

## Tests added

**Lock after analysis**
- `ElectionServiceTests`: Finalized after analysis broadcasts `statusChanged`; leave without confirm stays Finalized and does not broadcast; leave with confirm broadcasts the new stage.
- `ElectionsControllerTests`: HTTP finalize-after-analysis → 409 without confirm → 200 with confirm.
- `StageControl` / `electionStore`: Finalized click path and lock-confirmation error toast.

**Guest menus**
- Domain contract: exact keys plus explicit “never show” FullTeller-only pages.
- `StageGroupedSidebarMenu`: visible i18n keys per stage; admin items absent.
- `AppSidebar`: guests hide the stage switcher and “back to elections”; FullTellers see both.

**Move all tellers**
- Stage change broadcasts `SendElectionUpdateAsync` (the move).
- Remote `statusChanged` updates `currentStage` (including Finalized).
- Guest redirect on Finalized; FullTeller is **not** redirected when the stage changes.

## Local verification

- Frontend (Vitest/jsdom): 108 passed in the six touched files.
- Backend: 10 passed for `ChangeElectionStageAsync*` and `ElectionsControllerTests.ChangeElectionStage*` (local SQLite test factory; no Azure SQL).

## Intentional gaps (leave #172 open unless Glen agrees these are done)

- People / ballot **write** APIs are not separately gated on Finalized. The lock is the stage + confirmation + guest menu/route rules. Accept-all already refuses Finalized.
- StageControl has no in-UI confirm dialog for leaving Finalized. The API supports `confirmLeavingFinalized`; the UI never sends it, so unlock is API-only today.
- FullTellers are notified of a stage change but not auto-navigated (v4 guest-only move). If “move all tellers” should also relocate FullTellers, that is a product change, not a missing test.

Related: #172

Does not close #172 (parent #167 stays open; Glen approve). Do not close #303.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ee2a461-098f-4bca-9e71-24aa988c1b9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ee2a461-098f-4bca-9e71-24aa988c1b9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

