### PR TITLE
Show Online location label in ballot UI and reports

### DIFF
--- a/Backend.Tests/UnitTests/TallyServiceTests.cs
+++ b/Backend.Tests/UnitTests/TallyServiceTests.cs
@@ -1779,6 +1779,41 @@ public class TallyServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task GetReportDataAsync_Ballots_FormatsOnlineLocationNameWithoutLoadingFullGraph()
+    {
+        var election = await CreateTestElectionAsync();
+        var location = await CreateTestLocationAsync(election.ElectionGuid);
+        location.Name = "Hall A";
+        location.LocationTypeCode = nameof(LocationType.Online);
+        await Context.SaveChangesAsync();
+
+        var people = await CreateTestPeopleAsync(election.ElectionGuid, 1);
+        var ballots = await CreateTestBallotsAsync(location.LocationGuid, 1);
+        Context.Votes.Add(new Vote
+        {
+            BallotGuid = ballots[0].BallotGuid,
+            PersonGuid = people[0].PersonGuid,
+            PositionOnBallot = 1,
+            VoteStatus = VoteStatus.Ok,
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+        Context.ChangeTracker.Clear();
+
+        var report = await _service.GetReportDataAsync(election.ElectionGuid, "ballots");
+        var data = Assert.IsType<List<BallotReportDto>>(report.Data);
+        var row = Assert.Single(data);
+
+        Assert.Equal("Online", row.LocationName);
+        var vote = Assert.Single(row.Votes);
+        Assert.Equal(people[0].FullNameFl, vote.FullName);
+        Assert.False(Context.ChangeTracker.Entries<Ballot>().Any());
+        Assert.False(Context.ChangeTracker.Entries<Location>().Any());
+        Assert.False(Context.ChangeTracker.Entries<Vote>().Any());
+        Assert.False(Context.ChangeTracker.Entries<Person>().Any());
+    }
+
+    [Fact]
     public void OnlineVotingInfoDto_HasNoPersonNameOrContactFields()
     {
         var names = typeof(OnlineVotingInfoDto).GetProperties().Select(p => p.Name).ToList();

--- a/backend/Services/TallyService.Reports.cs
+++ b/backend/Services/TallyService.Reports.cs
@@ -1,5 +1,7 @@
 using Backend.DTOs.Results;
+using Backend.Entities;
 using Backend.Enumerations;
+using Backend.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Backend.Services;
@@ -139,25 +141,50 @@ public partial class TallyService
 
     private async Task<List<BallotReportDto>> GetBallotReportDataAsync(Guid electionGuid)
     {
-        var ballots = await _context.Ballots
-            .Include(b => b.Location)
-            .Include(b => b.Votes)
-            .ThenInclude(v => v.Person)
+        var rows = await _context.Ballots
+            .AsNoTracking()
             .Where(b => b.Location.ElectionGuid == electionGuid)
             .OrderBy(b => b.Location.Name)
             .ThenBy(b => b.BallotNumAtComputer)
+            .Select(b => new
+            {
+                b.BallotGuid,
+                LocationName = b.Location.Name,
+                LocationTypeCode = b.Location.LocationTypeCode,
+                Status = b.StatusCode,
+                Votes = b.Votes
+                    .OrderBy(v => v.PositionOnBallot)
+                    .Select(v => new
+                    {
+                        v.PositionOnBallot,
+                        HasPerson = v.Person != null,
+                        FirstName = v.Person != null ? v.Person.FirstName : null,
+                        LastName = v.Person != null ? v.Person.LastName : null,
+                        OtherNames = v.Person != null ? v.Person.OtherNames : null,
+                        OtherLastNames = v.Person != null ? v.Person.OtherLastNames : null,
+                        OtherInfo = v.Person != null ? v.Person.OtherInfo : null,
+                    })
+            })
             .ToListAsync();
 
-        return ballots.Select(b => new BallotReportDto
+        return rows.Select(b => new BallotReportDto
         {
             BallotGuid = b.BallotGuid,
-            LocationName = FormatLocationName(b.Location),
-            Status = b.StatusCode,
+            LocationName = FormatLocationName(b.LocationName, b.LocationTypeCode),
+            Status = b.Status,
             Votes = b.Votes
-                .OrderBy(v => v.PositionOnBallot)
                 .Select(v => new VoteReportDto
                 {
-                    FullName = v.Person != null ? v.Person.FullNameFl ?? UnknownFallbackValue : UnknownFallbackValue,
+                    FullName = v.HasPerson
+                        ? PersonNameHelper.ComputeFullNameFl(new Person
+                        {
+                            FirstName = v.FirstName,
+                            LastName = v.LastName ?? "",
+                            OtherNames = v.OtherNames,
+                            OtherLastNames = v.OtherLastNames,
+                            OtherInfo = v.OtherInfo
+                        }) ?? UnknownFallbackValue
+                        : UnknownFallbackValue,
                     Position = v.PositionOnBallot
                 })
                 .ToList()

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -204,6 +204,12 @@ Editing that row may change sort order only. Name is read-only (the i18n label).
 
 **Rejected alternative:** treat a location named “Online” as reserved, or POST the translated label as the stored name. Names are user-facing and translated; writing the current language back would change the stored fallback and still would not identify the row.
 
+Ballot entry panels and the votes dialog load locations when the ballot’s `locationGuid` is not already in the location store, so `formatLocationLabel` can use type. If that fetch fails, the stored `locationName` remains the display fallback.
+
+The ballots report projects location name + type with `AsNoTracking` instead of materializing the full ballot/location/vote/person graph, then formats Online the same way. That keeps the report label correct without tracking entities for a read-only export.
+
+**Rejected alternative:** rely only on `ballot.locationName` in the UI, or keep `Include` graphs for the report. The stored name is the English (or setup-time) fallback and can disagree with the teller’s language; the Include path also tracked entities the report never updates.
+
 **Reason:** tellers need to see which row is the voter-only location, in their language, without being able to rename or dress it up as a paper station.
 
 ## Online and imported ballot codes

--- a/frontend/src/components/ballots/BallotEntryPanel.vue
+++ b/frontend/src/components/ballots/BallotEntryPanel.vue
@@ -73,6 +73,21 @@ function hasCachedPanelData(): boolean {
   );
 }
 
+async function ensureBallotLocationLoaded(locationGuid: string | undefined) {
+  if (
+    !locationGuid ||
+    locationStore.locations.some((item) => item.locationGuid === locationGuid)
+  ) {
+    return;
+  }
+
+  try {
+    await locationStore.fetchLocations(props.electionGuid);
+  } catch {
+    // Keep ballot.locationName as the display fallback.
+  }
+}
+
 async function loadBallotData() {
   const showLoading = !hasCachedPanelData();
   if (showLoading) {
@@ -85,6 +100,7 @@ async function loadBallotData() {
     ]);
 
     const loadedBallot = ballotStore.currentBallot;
+    await ensureBallotLocationLoaded(loadedBallot?.locationGuid);
     if (loadedBallot) {
       await ballotStore.updateBallot(props.ballotGuid, {
         ...getActiveTellerPayload(),

--- a/frontend/src/components/ballots/BallotVotesDialog.vue
+++ b/frontend/src/components/ballots/BallotVotesDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { ElMessageBox } from "element-plus";
 import { useNotifications } from "@/composables/useNotifications";
@@ -34,6 +34,33 @@ const ballotLocationLabel = computed(() =>
     props.ballot?.locationName,
   ),
 );
+
+watch(
+  () =>
+    [
+      props.modelValue,
+      props.electionGuid,
+      props.ballot?.locationGuid,
+    ] as const,
+  async ([open, electionGuid, locationGuid]) => {
+    if (
+      !open ||
+      !electionGuid ||
+      !locationGuid ||
+      locationStore.locations.some((item) => item.locationGuid === locationGuid)
+    ) {
+      return;
+    }
+
+    try {
+      await locationStore.fetchLocations(electionGuid);
+    } catch {
+      // Keep ballot.locationName as the display fallback.
+    }
+  },
+  { immediate: true },
+);
+
 const { showSuccessMessage } = useNotifications();
 
 const showAddVote = ref(false);

--- a/frontend/src/components/ballots/__tests__/BallotEntryPanel.spec.ts
+++ b/frontend/src/components/ballots/__tests__/BallotEntryPanel.spec.ts
@@ -56,8 +56,21 @@ const mockPeopleStore = {
   onPersonUpdated: vi.fn(() => () => undefined),
 };
 
+const mockLocationStore = vi.hoisted(() => ({
+  locations: [] as Array<{
+    locationGuid: string;
+    name?: string | null;
+    locationType?: string | null;
+  }>,
+  fetchLocations: vi.fn(),
+}));
+
 vi.mock("@/stores/ballotStore", () => ({
   useBallotStore: () => mockBallotStore,
+}));
+
+vi.mock("@/stores/locationStore", () => ({
+  useLocationStore: () => mockLocationStore,
 }));
 
 vi.mock("@/stores/electionStore", () => ({
@@ -145,6 +158,9 @@ const i18n = createI18n({
         teller2: "Teller 2",
         loadError: "Failed to load",
       },
+      locations: {
+        typeOnline: "Online",
+      },
     },
   },
 });
@@ -189,7 +205,34 @@ describe("BallotEntryPanel session tellers", () => {
     mockPeopleStore.initializeSignalR.mockResolvedValue(undefined);
     mockPeopleStore.joinElection.mockResolvedValue(undefined);
     mockPeopleStore.leaveElection.mockResolvedValue(undefined);
+    mockLocationStore.locations = [];
+    mockLocationStore.fetchLocations.mockReset();
+    mockLocationStore.fetchLocations.mockResolvedValue(undefined);
     useActiveTellers().refreshActiveTellers();
+  });
+
+  it("loads locations when the ballot location is not already in the store", async () => {
+    mountPanel();
+    await flushPromises();
+
+    expect(mockLocationStore.fetchLocations).toHaveBeenCalledWith("elec-1");
+  });
+
+  it("shows the localized Online label when the location type is in the store", async () => {
+    mockLocationStore.locations = [
+      {
+        locationGuid: "loc-1",
+        name: "Main Hall",
+        locationType: "Online",
+      },
+    ];
+
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    expect(mockLocationStore.fetchLocations).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain("Online");
+    expect(wrapper.text()).not.toContain("Main Hall");
   });
 
   it("shows Teller 1 and Teller 2 as session inputs, not the stored ballot names", async () => {


### PR DESCRIPTION
## Summary
- Load locations on demand in `BallotEntryPanel` and `BallotVotesDialog` so the type-based i18n Online label can render (falls back to stored `locationName` if fetch fails).
- Project the ballots report with `AsNoTracking` (name + type) instead of materializing the full Include graph, and keep Online formatting consistent.
- Cover both paths with unit/component tests; record the why in `context/online-ballots.md`.

Follow-up to #301 (that PR was already merged; these leftovers were still uncommitted on the old branch).

## Test plan
- [ ] Open a ballot at the Online location from Ballot Management and confirm the header shows the localized Online label, not the stored name.
- [ ] Open the votes dialog for an Online ballot and confirm the same label.
- [ ] Run a Ballots report that includes Online ballots and confirm Location shows Online.
- [ ] `dotnet test --filter FullyQualifiedName~GetReportDataAsync_Ballots_FormatsOnlineLocationNameWithoutLoadingFullGraph`
- [ ] `cd frontend && npx vitest run src/components/ballots/__tests__/BallotEntryPanel.spec.ts`