### PR TITLE
Finalized stage: refuse people, ballot, and online-submit writes

### DIFF
--- a/Backend.Tests/IntegrationTests/ElectionsControllerTests.cs
+++ b/Backend.Tests/IntegrationTests/ElectionsControllerTests.cs
@@ -387,6 +387,53 @@ public class ElectionsControllerTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task ChangeElectionStage_ToFinalized_RefusedWhileOnlineWindowOpen_ThenSucceedsAfterClose()
+    {
+        var token = await GetAuthTokenAsync();
+        SetAuthToken(token);
+
+        var createDto = new CreateElectionDto
+        {
+            Name = "Finalize After Online Close Election",
+            DateOfElection = DateTime.UtcNow.AddDays(30),
+            ElectionType = ElectionTypeCode.LSA,
+            NumberToElect = 3,
+            UseOnlineVoting = true
+        };
+
+        var createResponse = await PostJsonAsync("/api/elections/createElection", createDto);
+        var createResult = await DeserializeResponseAsync<ApiResponse<ElectionDto>>(createResponse);
+        var electionGuid = createResult!.Data!.ElectionGuid;
+
+        foreach (var stage in new[] { ElectionStage.GatheringBallots, ElectionStage.ProcessingBallots })
+        {
+            var advance = await PutJsonAsync(
+                $"/api/elections/{electionGuid}/stage",
+                new ChangeElectionStageDto { ElectionStage = stage });
+            Assert.Equal(HttpStatusCode.OK, advance.StatusCode);
+        }
+
+        await SeedAnalysisReadyForFinalizationAsync(electionGuid);
+        await OpenOnlineWindowAsync(electionGuid);
+
+        var refused = await PutJsonAsync(
+            $"/api/elections/{electionGuid}/stage",
+            new ChangeElectionStageDto { ElectionStage = ElectionStage.Finalized });
+        Assert.Equal(HttpStatusCode.BadRequest, refused.StatusCode);
+        var refusedBody = await refused.Content.ReadAsStringAsync();
+        Assert.Contains(ElectionStageMessageKeys.OnlineVotingStillOpen, refusedBody);
+
+        await CloseOnlineWindowAsync(electionGuid);
+
+        var finalizeResponse = await PutJsonAsync(
+            $"/api/elections/{electionGuid}/stage",
+            new ChangeElectionStageDto { ElectionStage = ElectionStage.Finalized });
+        Assert.Equal(HttpStatusCode.OK, finalizeResponse.StatusCode);
+        var finalized = await DeserializeResponseAsync<ApiResponse<ElectionDto>>(finalizeResponse);
+        Assert.Equal(ElectionStage.Finalized, finalized!.Data!.ElectionStage);
+    }
+
+    [Fact]
     public async Task ChangeElectionStage_WithInvalidEnum_ReturnsBadRequest()
     {
         var token = await GetAuthTokenAsync();
@@ -769,6 +816,26 @@ public class ElectionsControllerTests : IntegrationTestBase
             UseOnReports = true,
             BallotsNeedingReview = 0
         });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task OpenOnlineWindowAsync(Guid electionGuid)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+        var election = await db.Elections.SingleAsync(e => e.ElectionGuid == electionGuid);
+        election.UseOnlineVoting = true;
+        election.OnlineWhenOpen = DateTimeOffset.UtcNow.AddHours(-1);
+        election.OnlineWhenClose = DateTimeOffset.UtcNow.AddHours(2);
+        await db.SaveChangesAsync();
+    }
+
+    private async Task CloseOnlineWindowAsync(Guid electionGuid)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+        var election = await db.Elections.SingleAsync(e => e.ElectionGuid == electionGuid);
+        election.OnlineWhenClose = DateTimeOffset.UtcNow.AddSeconds(-1);
         await db.SaveChangesAsync();
     }
 }

--- a/Backend.Tests/IntegrationTests/FinalizedPeopleBallotWriteTests.cs
+++ b/Backend.Tests/IntegrationTests/FinalizedPeopleBallotWriteTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using Backend.Context;
+using Backend.DTOs.Ballots;
+using Backend.DTOs.Elections;
+using Backend.DTOs.FrontDesk;
+using Backend.DTOs.Locations;
+using Backend.DTOs.OnlineVoting;
+using Backend.DTOs.People;
+using Backend.DTOs.Votes;
+using Backend.Enumerations;
+using Backend.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Backend.Tests.IntegrationTests;
+
+public class FinalizedPeopleBallotWriteTests : IntegrationTestBase
+{
+    public FinalizedPeopleBallotWriteTests(CustomWebApplicationFactory factory) : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task FinalizedElection_RefusesPeopleBallotAndRollWrites_AllowsReads()
+    {
+        var token = await GetAuthTokenAsync();
+        SetAuthToken(token);
+
+        var (electionGuid, locationGuid, personGuid) = await SeedWritableElectionAsync();
+
+        var ballotBeforeLock = await PostJsonAsync("/api/Ballots/createBallot", new CreateBallotDto
+        {
+            ElectionGuid = electionGuid,
+            LocationGuid = locationGuid,
+            ComputerCode = "A",
+            Teller1 = "Ada"
+        });
+        ballotBeforeLock.EnsureSuccessStatusCode();
+        var existingBallot = await DeserializeResponseAsync<ApiResponse<BallotDto>>(ballotBeforeLock);
+
+        await SetStageAsync(electionGuid, ElectionStage.Finalized);
+
+        var createPerson = await PostJsonAsync("/api/People/createPerson", new CreatePersonDto
+        {
+            ElectionGuid = electionGuid,
+            LastName = "Blocked",
+            FirstName = "New"
+        });
+        await AssertFinalizedWriteRefusal(createPerson);
+
+        var updatePerson = await PutJsonAsync($"/api/People/{personGuid}/updatePerson", new UpdatePersonDto
+        {
+            LastName = "Changed",
+            FirstName = "Ada"
+        });
+        await AssertFinalizedWriteRefusal(updatePerson);
+
+        var deletePerson = await DeleteAsync($"/api/People/{personGuid}/deletePerson");
+        await AssertFinalizedWriteRefusal(deletePerson);
+
+        var createBallot = await PostJsonAsync("/api/Ballots/createBallot", new CreateBallotDto
+        {
+            ElectionGuid = electionGuid,
+            LocationGuid = locationGuid,
+            ComputerCode = "B",
+            Teller1 = "Ada"
+        });
+        await AssertFinalizedWriteRefusal(createBallot);
+
+        var createVote = await PostJsonAsync("/api/Votes/createVote", new CreateVoteDto
+        {
+            BallotGuid = existingBallot!.Data!.BallotGuid,
+            PersonGuid = personGuid,
+            PositionOnBallot = 1
+        });
+        await AssertFinalizedWriteRefusal(createVote);
+
+        var checkIn = await PostJsonAsync($"/api/{electionGuid}/frontdesk/checkInVoter", new CheckInVoterDto
+        {
+            PersonGuid = personGuid,
+            VotingMethod = "P",
+            Teller1 = "Ada"
+        });
+        await AssertFinalizedWriteRefusal(checkIn);
+
+        var acceptAll = await Client.PostAsync(
+            $"/api/elections/{electionGuid}/online-ballots/accept-all",
+            null);
+        Assert.Equal(HttpStatusCode.BadRequest, acceptAll.StatusCode);
+        var acceptAllBody = await DeserializeResponseAsync<AcceptAllOnlineBallotsResultDto>(acceptAll);
+        Assert.False(acceptAllBody!.Success);
+        Assert.Equal("monitoring.acceptAll.finalized", acceptAllBody.MessageKey);
+
+        var peopleRead = await GetAsync($"/api/People/{electionGuid}/getPeople?pageNumber=1&pageSize=50");
+        Assert.Equal(HttpStatusCode.OK, peopleRead.StatusCode);
+
+        var personRead = await GetAsync($"/api/People/{personGuid}/getPerson");
+        Assert.Equal(HttpStatusCode.OK, personRead.StatusCode);
+
+        var ballotsRead = await GetAsync($"/api/Ballots/{electionGuid}/ballots?pageNumber=1&pageSize=50");
+        Assert.Equal(HttpStatusCode.OK, ballotsRead.StatusCode);
+
+        var rollRead = await GetAsync($"/api/{electionGuid}/frontdesk/eligibleVoters");
+        Assert.Equal(HttpStatusCode.OK, rollRead.StatusCode);
+
+        var votesRead = await GetAsync($"/api/Votes/{existingBallot.Data.BallotGuid}/getVotesByBallot");
+        Assert.Equal(HttpStatusCode.OK, votesRead.StatusCode);
+
+        var ballotRead = await GetAsync($"/api/Ballots/{existingBallot.Data.BallotGuid}/ballot");
+        Assert.Equal(HttpStatusCode.OK, ballotRead.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProcessingBallotsElection_AllowsPeopleBallotAndRollWrites()
+    {
+        var token = await GetAuthTokenAsync();
+        SetAuthToken(token);
+
+        var (electionGuid, locationGuid, personGuid) = await SeedWritableElectionAsync();
+        await SetStageAsync(electionGuid, ElectionStage.ProcessingBallots);
+
+        var createPerson = await PostJsonAsync("/api/People/createPerson", new CreatePersonDto
+        {
+            ElectionGuid = electionGuid,
+            LastName = "Allowed",
+            FirstName = "New"
+        });
+        Assert.Equal(HttpStatusCode.Created, createPerson.StatusCode);
+
+        var createBallot = await PostJsonAsync("/api/Ballots/createBallot", new CreateBallotDto
+        {
+            ElectionGuid = electionGuid,
+            LocationGuid = locationGuid,
+            ComputerCode = "A",
+            Teller1 = "Ada"
+        });
+        Assert.Equal(HttpStatusCode.Created, createBallot.StatusCode);
+        var ballot = await DeserializeResponseAsync<ApiResponse<BallotDto>>(createBallot);
+        Assert.NotNull(ballot?.Data?.BallotGuid);
+
+        var createVote = await PostJsonAsync("/api/Votes/createVote", new CreateVoteDto
+        {
+            BallotGuid = ballot!.Data!.BallotGuid,
+            PersonGuid = personGuid,
+            PositionOnBallot = 1
+        });
+        Assert.Equal(HttpStatusCode.Created, createVote.StatusCode);
+
+        var checkIn = await PostJsonAsync($"/api/{electionGuid}/frontdesk/checkInVoter", new CheckInVoterDto
+        {
+            PersonGuid = personGuid,
+            VotingMethod = "P",
+            Teller1 = "Ada"
+        });
+        Assert.Equal(HttpStatusCode.OK, checkIn.StatusCode);
+    }
+
+    private async Task<(Guid ElectionGuid, Guid LocationGuid, Guid PersonGuid)> SeedWritableElectionAsync()
+    {
+        var createElection = await PostJsonAsync("/api/elections/createElection", new CreateElectionDto
+        {
+            Name = $"Finalized write gate {Guid.NewGuid():N}",
+            DateOfElection = DateTime.UtcNow.AddDays(1),
+            ElectionType = ElectionTypeCode.LSA,
+            NumberToElect = 3
+        });
+        createElection.EnsureSuccessStatusCode();
+        var election = await DeserializeResponseAsync<ApiResponse<ElectionDto>>(createElection);
+        var electionGuid = election!.Data!.ElectionGuid;
+
+        var createLocation = await PostJsonAsync($"/api/{electionGuid}/locations/createLocation", new CreateLocationDto
+        {
+            ElectionGuid = electionGuid,
+            Name = "Main Hall"
+        });
+        createLocation.EnsureSuccessStatusCode();
+        var location = await DeserializeResponseAsync<ApiResponse<LocationDto>>(createLocation);
+        var locationGuid = location!.Data!.LocationGuid;
+
+        var createPerson = await PostJsonAsync("/api/People/createPerson", new CreatePersonDto
+        {
+            ElectionGuid = electionGuid,
+            LastName = "Smith",
+            FirstName = "Ada"
+        });
+        createPerson.EnsureSuccessStatusCode();
+        var person = await DeserializeResponseAsync<ApiResponse<PersonDto>>(createPerson);
+
+        return (electionGuid, locationGuid, person!.Data!.PersonGuid);
+    }
+
+    private async Task SetStageAsync(Guid electionGuid, ElectionStage stage)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+        var election = await db.Elections.SingleAsync(e => e.ElectionGuid == electionGuid);
+        election.ElectionStage = stage;
+        await db.SaveChangesAsync();
+    }
+
+    private async Task AssertFinalizedWriteRefusal(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains(ElectionStageMessageKeys.FinalizedWriteBlocked, body);
+    }
+}

--- a/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
+++ b/Backend.Tests/IntegrationTests/OnlineVotingBallotFlowTests.cs
@@ -63,6 +63,39 @@ public class OnlineVotingBallotFlowTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task SubmitBallot_WhenElectionFinalized_AndOnlineWindowOpen_Returns400WithVoterPhraseKey()
+    {
+        var email = $"finalized_{Guid.NewGuid():N}@example.com";
+        var electionGuid = await SetupOpenElectionWithVoter(email);
+        await EnsureOnlineVoterAsync(email, "E");
+        await SetElectionStageAsync(electionGuid, ElectionStage.Finalized);
+
+        var response = await Client.PostAsJsonAsync(
+            $"/api/online-voting/{electionGuid}/submitBallot",
+            new SubmitOnlineBallotDto
+            {
+                ElectionGuid = electionGuid,
+                VoterId = email,
+                Votes =
+                [
+                    new OnlineVoteDto
+                    {
+                        VoteName = "Someone",
+                        PositionOnBallot = 1
+                    }
+                ]
+            });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains(ElectionStageMessageKeys.FinalizedOnlineSubmit, body);
+
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+        Assert.Equal(0, await context.OnlineVotingInfos.CountAsync(ovi => ovi.ElectionGuid == electionGuid));
+    }
+
+    [Fact]
     public async Task SubmitBallot_RandomModeB_WithNineFreeTextVotes_Succeeds()
     {
         var email = $"random_{Guid.NewGuid():N}@example.com";
@@ -584,6 +617,15 @@ public class OnlineVotingBallotFlowTests : IntegrationTestBase
 
         await context.SaveChangesAsync();
         return candidates;
+    }
+
+    private async Task SetElectionStageAsync(Guid electionGuid, ElectionStage stage)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<MainDbContext>();
+        var election = await context.Elections.SingleAsync(e => e.ElectionGuid == electionGuid);
+        election.ElectionStage = stage;
+        await context.SaveChangesAsync();
     }
 
     private async Task EnsureOnlineVoterAsync(string voterId, string voterIdType)

--- a/Backend.Tests/UnitTests/ElectionServiceTests.cs
+++ b/Backend.Tests/UnitTests/ElectionServiceTests.cs
@@ -591,6 +591,66 @@ public class ElectionServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task ChangeElectionStageAsync_ToFinalized_IsRejectedWhileOnlineWindowOpen()
+    {
+        var electionGuid = await SeedReadyElectionForFinalizeAsync(
+            useOnlineVoting: true,
+            onlineWhenOpen: DateTimeOffset.UtcNow.AddHours(-1),
+            onlineWhenClose: DateTimeOffset.UtcNow.AddHours(1));
+
+        var result = await _service.ChangeElectionStageAsync(electionGuid, new ChangeElectionStageDto
+        {
+            ElectionStage = ElectionStage.Finalized
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(ElectionStageMessageKeys.OnlineVotingStillOpen, result.ErrorMessage);
+        Assert.Equal(ElectionStage.ProcessingBallots,
+            Context.Elections.Single(e => e.ElectionGuid == electionGuid).ElectionStage);
+    }
+
+    [Fact]
+    public async Task ChangeElectionStageAsync_ToFinalized_SucceedsAfterOnlineWindowCloses()
+    {
+        var electionGuid = await SeedReadyElectionForFinalizeAsync(
+            useOnlineVoting: true,
+            onlineWhenOpen: DateTimeOffset.UtcNow.AddHours(-2),
+            onlineWhenClose: DateTimeOffset.UtcNow.AddHours(1));
+
+        var refused = await _service.ChangeElectionStageAsync(electionGuid, new ChangeElectionStageDto
+        {
+            ElectionStage = ElectionStage.Finalized
+        });
+        Assert.False(refused.IsSuccess);
+
+        var election = Context.Elections.Single(e => e.ElectionGuid == electionGuid);
+        election.OnlineWhenClose = DateTimeOffset.UtcNow.AddSeconds(-1);
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ChangeElectionStageAsync(electionGuid, new ChangeElectionStageDto
+        {
+            ElectionStage = ElectionStage.Finalized
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(ElectionStage.Finalized, result.Election!.ElectionStage);
+    }
+
+    [Fact]
+    public async Task ChangeElectionStageAsync_ToFinalized_WhenUseOnlineVotingFalse_Succeeds()
+    {
+        var electionGuid = await SeedReadyElectionForFinalizeAsync(useOnlineVoting: false);
+
+        var result = await _service.ChangeElectionStageAsync(electionGuid, new ChangeElectionStageDto
+        {
+            ElectionStage = ElectionStage.Finalized
+        });
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(ElectionStage.Finalized, result.Election!.ElectionStage);
+    }
+
+    [Fact]
     public async Task ChangeElectionStageAsync_ToFinalized_IsRejectedWhenNotReady()
     {
         var electionGuid = Guid.NewGuid();
@@ -1418,9 +1478,58 @@ public class ElectionServiceTests : ServiceTestBase
     /// (UseOnlineVoting plus a null window counts as open; ShowAsTest is not checked).
     /// </summary>
     private static bool IsAvailableToOnlineVoters(Election election, DateTimeOffset now) =>
-        election.UseOnlineVoting
-        && (election.OnlineWhenOpen == null || election.OnlineWhenOpen <= now)
-        && (election.OnlineWhenClose == null || election.OnlineWhenClose > now);
+        OnlineVotingWindow.IsCurrentlyOpen(
+            election.UseOnlineVoting,
+            election.OnlineWhenOpen,
+            election.OnlineWhenClose,
+            now);
+
+    private async Task<Guid> SeedReadyElectionForFinalizeAsync(
+        bool useOnlineVoting,
+        DateTimeOffset? onlineWhenOpen = null,
+        DateTimeOffset? onlineWhenClose = null)
+    {
+        var electionGuid = Guid.NewGuid();
+        var personGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Stage Test Election",
+            ElectionType = "LSA",
+            NumberToElect = 3,
+            ElectionStage = ElectionStage.ProcessingBallots,
+            DateOfElection = DateTime.UtcNow.AddDays(10),
+            UseOnlineVoting = useOnlineVoting,
+            OnlineWhenOpen = onlineWhenOpen,
+            OnlineWhenClose = onlineWhenClose,
+            RowVersion = new byte[8]
+        });
+        Context.People.Add(new Person
+        {
+            PersonGuid = personGuid,
+            ElectionGuid = electionGuid,
+            FirstName = "Test",
+            LastName = "Person",
+            RowVersion = new byte[8]
+        });
+        Context.Results.Add(new Result
+        {
+            ElectionGuid = electionGuid,
+            PersonGuid = personGuid,
+            Rank = 1,
+            Section = "E",
+            VoteCount = 10
+        });
+        Context.ResultSummaries.Add(new ResultSummary
+        {
+            ElectionGuid = electionGuid,
+            ResultType = "F",
+            UseOnReports = true,
+            BallotsNeedingReview = 0
+        });
+        await Context.SaveChangesAsync();
+        return electionGuid;
+    }
 }
 
 

--- a/Backend.Tests/UnitTests/ElectionStageFinalizationReadinessTests.cs
+++ b/Backend.Tests/UnitTests/ElectionStageFinalizationReadinessTests.cs
@@ -160,4 +160,88 @@ public class ElectionStageFinalizationReadinessTests : ServiceTestBase
         Assert.False(readiness.IsReady);
         Assert.Contains(readiness.Blockers, b => b.StartsWith(CountsDoNotReconcile));
     }
+
+    [Fact]
+    public async Task EvaluateAsync_ReturnsOnlineVotingStillOpenWhenWindowIsOpen()
+    {
+        var electionGuid = await SeedReadyElectionAsync(useOnlineVoting: true);
+        var election = Context.Elections.Single(e => e.ElectionGuid == electionGuid);
+        election.OnlineWhenOpen = DateTimeOffset.UtcNow.AddHours(-1);
+        election.OnlineWhenClose = DateTimeOffset.UtcNow.AddHours(1);
+        await Context.SaveChangesAsync();
+
+        var readiness = await ElectionStageFinalizationReadiness.EvaluateAsync(Context, electionGuid);
+
+        Assert.False(readiness.IsReady);
+        Assert.Contains(OnlineVotingStillOpen, readiness.Blockers);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ReadyWhenOnlineVotingEnabledButWindowClosed()
+    {
+        var electionGuid = await SeedReadyElectionAsync(useOnlineVoting: true);
+        var election = Context.Elections.Single(e => e.ElectionGuid == electionGuid);
+        election.OnlineWhenOpen = DateTimeOffset.UtcNow.AddHours(-2);
+        election.OnlineWhenClose = DateTimeOffset.UtcNow.AddHours(-1);
+        await Context.SaveChangesAsync();
+
+        var readiness = await ElectionStageFinalizationReadiness.EvaluateAsync(Context, electionGuid);
+
+        Assert.True(readiness.IsReady);
+        Assert.Empty(readiness.Blockers);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ReadyWhenUseOnlineVotingIsFalse()
+    {
+        var electionGuid = await SeedReadyElectionAsync(useOnlineVoting: false);
+
+        var readiness = await ElectionStageFinalizationReadiness.EvaluateAsync(Context, electionGuid);
+
+        Assert.True(readiness.IsReady);
+        Assert.Empty(readiness.Blockers);
+    }
+
+    private async Task<Guid> SeedReadyElectionAsync(bool useOnlineVoting)
+    {
+        var electionGuid = Guid.NewGuid();
+        var personGuid = Guid.NewGuid();
+
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Ready Election",
+            ElectionType = "LSA",
+            NumberToElect = 3,
+            ElectionStage = ElectionStage.ProcessingBallots,
+            DateOfElection = DateTime.UtcNow,
+            UseOnlineVoting = useOnlineVoting,
+            RowVersion = new byte[8]
+        });
+        Context.People.Add(new Person
+        {
+            PersonGuid = personGuid,
+            ElectionGuid = electionGuid,
+            FirstName = "A",
+            LastName = "B",
+            RowVersion = new byte[8]
+        });
+        Context.Results.Add(new Result
+        {
+            ElectionGuid = electionGuid,
+            PersonGuid = personGuid,
+            Rank = 1,
+            Section = "E",
+            VoteCount = 5
+        });
+        Context.ResultSummaries.Add(new ResultSummary
+        {
+            ElectionGuid = electionGuid,
+            ResultType = "F",
+            UseOnReports = true,
+            BallotsNeedingReview = 0
+        });
+        await Context.SaveChangesAsync();
+        return electionGuid;
+    }
 }

--- a/Backend.Tests/UnitTests/Helpers/ElectionFinalizedWriteGuardTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/ElectionFinalizedWriteGuardTests.cs
@@ -1,0 +1,71 @@
+using Backend.Entities;
+using Backend.Enumerations;
+using Backend.Helpers;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class ElectionFinalizedWriteGuardTests : ServiceTestBase
+{
+    [Fact]
+    public void IsLocked_OnlyFinalized()
+    {
+        Assert.False(ElectionFinalizedWriteGuard.IsLocked(ElectionStage.SettingUp));
+        Assert.False(ElectionFinalizedWriteGuard.IsLocked(ElectionStage.GatheringBallots));
+        Assert.False(ElectionFinalizedWriteGuard.IsLocked(ElectionStage.ProcessingBallots));
+        Assert.True(ElectionFinalizedWriteGuard.IsLocked(ElectionStage.Finalized));
+    }
+
+    [Fact]
+    public void ThrowIfLocked_Finalized_ThrowsPhraseKey()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ElectionFinalizedWriteGuard.ThrowIfLocked(ElectionStage.Finalized));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+    }
+
+    [Fact]
+    public async Task ThrowIfLockedAsync_MissingElection_DoesNotThrow()
+    {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(Context, Guid.NewGuid());
+    }
+
+    [Fact]
+    public async Task ThrowIfLockedAsync_FinalizedElection_Throws()
+    {
+        var electionGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Locked",
+            NumberToElect = 3,
+            ElectionType = "LSA",
+            ElectionStage = ElectionStage.Finalized,
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            ElectionFinalizedWriteGuard.ThrowIfLockedAsync(Context, electionGuid));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+    }
+
+    [Fact]
+    public async Task IsLockedAsync_ProcessingBallots_IsFalse()
+    {
+        var electionGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Open",
+            NumberToElect = 3,
+            ElectionType = "LSA",
+            ElectionStage = ElectionStage.ProcessingBallots,
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        Assert.False(await ElectionFinalizedWriteGuard.IsLockedAsync(Context, electionGuid));
+    }
+}

--- a/Backend.Tests/UnitTests/Helpers/OnlineVotingWindowTests.cs
+++ b/Backend.Tests/UnitTests/Helpers/OnlineVotingWindowTests.cs
@@ -1,0 +1,58 @@
+using Backend.Helpers;
+
+namespace Backend.Tests.UnitTests.Helpers;
+
+public class OnlineVotingWindowTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 9, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void IsCurrentlyOpen_FalseWhenOnlineVotingDisabled()
+    {
+        Assert.False(OnlineVotingWindow.IsCurrentlyOpen(
+            useOnlineVoting: false,
+            onlineWhenOpen: Now.AddHours(-1),
+            onlineWhenClose: Now.AddHours(1),
+            now: Now));
+    }
+
+    [Fact]
+    public void IsCurrentlyOpen_TrueWhenEnabledAndWindowDatesNull()
+    {
+        Assert.True(OnlineVotingWindow.IsCurrentlyOpen(
+            useOnlineVoting: true,
+            onlineWhenOpen: null,
+            onlineWhenClose: null,
+            now: Now));
+    }
+
+    [Fact]
+    public void IsCurrentlyOpen_FalseBeforeScheduledOpen()
+    {
+        Assert.False(OnlineVotingWindow.IsCurrentlyOpen(
+            useOnlineVoting: true,
+            onlineWhenOpen: Now.AddHours(1),
+            onlineWhenClose: Now.AddHours(2),
+            now: Now));
+    }
+
+    [Fact]
+    public void IsCurrentlyOpen_FalseAtOrAfterClose()
+    {
+        Assert.False(OnlineVotingWindow.IsCurrentlyOpen(
+            useOnlineVoting: true,
+            onlineWhenOpen: Now.AddHours(-2),
+            onlineWhenClose: Now,
+            now: Now));
+    }
+
+    [Fact]
+    public void IsCurrentlyOpen_TrueInsideScheduledWindow()
+    {
+        Assert.True(OnlineVotingWindow.IsCurrentlyOpen(
+            useOnlineVoting: true,
+            onlineWhenOpen: Now.AddHours(-1),
+            onlineWhenClose: Now.AddHours(1),
+            now: Now));
+    }
+}

--- a/Backend.Tests/UnitTests/Services/BallotServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/BallotServiceTests.cs
@@ -230,4 +230,81 @@ public class BallotServiceTests : ServiceTestBase
         Assert.NotNull(result);
         Assert.Equal(BallotStatus.Review, result.StatusCode);
     }
+
+    [Fact]
+    public async Task CreateBallotAsync_FinalizedElection_Throws()
+    {
+        SetElectionStage(ElectionStage.Finalized);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreateBallotAsync(new CreateBallotDto
+            {
+                ElectionGuid = ElectionGuid,
+                LocationGuid = LocationGuid,
+                ComputerCode = "B",
+                Teller1 = "Ada"
+            }));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Equal(1, Context.Ballots.Count());
+    }
+
+    [Fact]
+    public async Task CreateBallotAsync_ProcessingBallots_Succeeds()
+    {
+        SetElectionStage(ElectionStage.ProcessingBallots);
+
+        var result = await _service.CreateBallotAsync(new CreateBallotDto
+        {
+            ElectionGuid = ElectionGuid,
+            LocationGuid = LocationGuid,
+            ComputerCode = "B",
+            Teller1 = "Ada"
+        });
+
+        Assert.Equal("B", result.ComputerCode);
+        Assert.Equal(2, Context.Ballots.Count());
+    }
+
+    [Fact]
+    public async Task UpdateBallotAsync_FinalizedElection_Throws()
+    {
+        SetElectionStage(ElectionStage.Finalized);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.UpdateBallotAsync(BallotGuid, new UpdateBallotDto
+            {
+                Teller1 = "Changed"
+            }));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+    }
+
+    [Fact]
+    public async Task DeleteBallotAsync_FinalizedElection_Throws()
+    {
+        SetElectionStage(ElectionStage.Finalized);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.DeleteBallotAsync(BallotGuid));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Single(Context.Ballots);
+    }
+
+    [Fact]
+    public async Task GetBallotsByElectionAsync_FinalizedElection_StillReads()
+    {
+        SetElectionStage(ElectionStage.Finalized);
+
+        var result = await _service.GetBallotsByElectionAsync(ElectionGuid, pageSize: 50);
+
+        Assert.Single(result.Items);
+    }
+
+    private void SetElectionStage(ElectionStage stage)
+    {
+        Context.Elections.Single().ElectionStage = stage;
+        Context.SaveChanges();
+    }
 }

--- a/Backend.Tests/UnitTests/Services/FrontDeskServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/FrontDeskServiceTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Backend.DTOs.FrontDesk;
+using Backend.Entities;
+using Backend.Enumerations;
+using Backend.Services;
+
+namespace Backend.Tests.UnitTests.Services;
+
+public class FrontDeskServiceTests : ServiceTestBase
+{
+    private readonly FrontDeskService _service;
+    private readonly Guid _electionGuid = Guid.NewGuid();
+
+    public FrontDeskServiceTests()
+    {
+        _service = new FrontDeskService(
+            Context,
+            new Mock<ILogger<FrontDeskService>>().Object,
+            new Mock<ISignalRNotificationService>().Object);
+    }
+
+    [Fact]
+    public async Task CheckInVoterAsync_FinalizedElection_Throws()
+    {
+        SeedElection(ElectionStage.Finalized);
+        var person = SeedEligiblePerson();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CheckInVoterAsync(_electionGuid, new CheckInVoterDto
+            {
+                PersonGuid = person.PersonGuid,
+                VotingMethod = "P",
+                Teller1 = "Ada"
+            }));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Null(Context.People.Single().RegistrationTime);
+    }
+
+    [Fact]
+    public async Task CheckInVoterAsync_GatheringBallots_Succeeds()
+    {
+        SeedElection(ElectionStage.GatheringBallots);
+        var person = SeedEligiblePerson();
+
+        var result = await _service.CheckInVoterAsync(_electionGuid, new CheckInVoterDto
+        {
+            PersonGuid = person.PersonGuid,
+            VotingMethod = "P",
+            Teller1 = "Ada"
+        });
+
+        Assert.Equal("P", result.VotingMethod);
+        Assert.NotNull(Context.People.Single().RegistrationTime);
+    }
+
+    [Fact]
+    public async Task GetEligibleVotersAsync_FinalizedElection_StillReads()
+    {
+        SeedElection(ElectionStage.Finalized);
+        SeedEligiblePerson();
+
+        var voters = await _service.GetEligibleVotersAsync(_electionGuid);
+
+        Assert.Single(voters);
+    }
+
+    private void SeedElection(ElectionStage stage)
+    {
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = _electionGuid,
+            Name = "Front desk lock test",
+            NumberToElect = 3,
+            ElectionType = "LSA",
+            ElectionStage = stage,
+            RowVersion = new byte[8]
+        });
+        Context.SaveChanges();
+    }
+
+    private Person SeedEligiblePerson()
+    {
+        var person = new Person
+        {
+            PersonGuid = Guid.NewGuid(),
+            ElectionGuid = _electionGuid,
+            FirstName = "Ada",
+            LastName = "Smith",
+            CanVote = true,
+            CanReceiveVotes = true,
+            RowVersion = new byte[8]
+        };
+        Context.People.Add(person);
+        Context.SaveChanges();
+        return person;
+    }
+}

--- a/Backend.Tests/UnitTests/Services/OnlineVotingServiceAcceptAllTests.cs
+++ b/Backend.Tests/UnitTests/Services/OnlineVotingServiceAcceptAllTests.cs
@@ -224,6 +224,53 @@ public class OnlineVotingServiceAcceptAllTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task Submit_WhenGatheringBallots_AndOnlineWindowOpen_Succeeds()
+    {
+        var election = await SeedOpenElectionAsync();
+        var (person, email) = await SeedVoterAsync(election.ElectionGuid);
+
+        var submit = await SubmitPendingAsync(election.ElectionGuid, email, person.PersonGuid);
+
+        Assert.True(submit.Success);
+        Assert.Null(submit.Error);
+        Assert.Equal(OnlineBallotStatus.Submitted, Context.OnlineVotingInfos.Single().Status);
+    }
+
+    [Fact]
+    public async Task Submit_WhenFinalized_EvenIfOnlineWindowOpen_IsRefused()
+    {
+        var election = await SeedOpenElectionAsync();
+        var (person, email) = await SeedVoterAsync(election.ElectionGuid);
+        election.ElectionStage = ElectionStage.Finalized;
+        await Context.SaveChangesAsync();
+
+        var submit = await SubmitPendingAsync(election.ElectionGuid, email, person.PersonGuid);
+
+        Assert.False(submit.Success);
+        Assert.Equal(ElectionStageMessageKeys.FinalizedOnlineSubmit, submit.Error);
+        Assert.Empty(Context.OnlineVotingInfos);
+    }
+
+    [Fact]
+    public async Task Submit_WhenFinalizedAfterPendingSubmit_RefusesUpdate_AndLeavesPayload()
+    {
+        var election = await SeedOpenElectionAsync();
+        var (person, email) = await SeedVoterAsync(election.ElectionGuid);
+        var first = await SubmitPendingAsync(election.ElectionGuid, email, person.PersonGuid, voteName: "First Name");
+        Assert.True(first.Success);
+        var originalPool = Context.OnlineVotingInfos.Single().ListPool;
+
+        election.ElectionStage = ElectionStage.Finalized;
+        await Context.SaveChangesAsync();
+
+        var again = await SubmitPendingAsync(election.ElectionGuid, email, person.PersonGuid, voteName: "Changed After Finalized");
+
+        Assert.False(again.Success);
+        Assert.Equal(ElectionStageMessageKeys.FinalizedOnlineSubmit, again.Error);
+        Assert.Equal(originalPool, Context.OnlineVotingInfos.Single().ListPool);
+    }
+
+    [Fact]
     public async Task AcceptAll_FinalizedElection_DoesNotCreateBallots()
     {
         var election = await SeedOpenElectionAsync();

--- a/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
@@ -1094,6 +1094,57 @@ public class PeopleImportServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task DeleteAllPeopleAsync_FinalizedElection_Throws()
+    {
+        var electionGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Import lock test",
+            NumberToElect = 3,
+            ElectionType = "LSA",
+            ElectionStage = ElectionStage.Finalized,
+            RowVersion = new byte[8]
+        });
+        Context.People.Add(new Person
+        {
+            PersonGuid = Guid.NewGuid(),
+            ElectionGuid = electionGuid,
+            FirstName = "Ada",
+            LastName = "Smith",
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.DeleteAllPeopleAsync(electionGuid));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Single(Context.People);
+    }
+
+    [Fact]
+    public async Task ImportPeopleAsync_FinalizedElection_ReturnsPhraseKey()
+    {
+        var electionGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "Import lock test",
+            NumberToElect = 3,
+            ElectionType = "LSA",
+            ElectionStage = ElectionStage.Finalized,
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ImportPeopleAsync(electionGuid, 1);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Errors, e => e.Key == ElectionStageMessageKeys.FinalizedWriteBlocked);
+    }
+
+    [Fact]
     public async Task GetPeopleCountAsync_ReturnsCorrectCount()
     {
         // Arrange

--- a/Backend.Tests/UnitTests/Services/PeopleServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleServiceTests.cs
@@ -1046,6 +1046,127 @@ public class PeopleServiceTests : ServiceTestBase
         Assert.Null(details.PhoneOnlineVoter.WhenLastLogin);
         Assert.Null(details.PhoneOnlineVoter.SmsStatus);
     }
+
+    [Fact]
+    public async Task CreatePersonAsync_FinalizedElection_Throws()
+    {
+        var electionGuid = SeedElection(ElectionStage.Finalized);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreatePersonAsync(new CreatePersonDto
+            {
+                ElectionGuid = electionGuid,
+                LastName = "Smith",
+                FirstName = "Ada"
+            }));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Empty(Context.People);
+    }
+
+    [Fact]
+    public async Task CreatePersonAsync_ProcessingBallots_Succeeds()
+    {
+        var electionGuid = SeedElection(ElectionStage.ProcessingBallots);
+
+        var result = await _service.CreatePersonAsync(new CreatePersonDto
+        {
+            ElectionGuid = electionGuid,
+            LastName = "Smith",
+            FirstName = "Ada"
+        });
+
+        Assert.Equal("Ada", result.FirstName);
+        Assert.Single(Context.People);
+    }
+
+    [Fact]
+    public async Task UpdatePersonAsync_FinalizedElection_Throws()
+    {
+        var electionGuid = SeedElection(ElectionStage.Finalized);
+        var person = SeedPerson(electionGuid);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.UpdatePersonAsync(person.PersonGuid, new UpdatePersonDto
+            {
+                LastName = "Changed",
+                FirstName = "Ada"
+            }));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Equal("Smith", Context.People.Single().LastName);
+    }
+
+    [Fact]
+    public async Task DeletePersonAsync_FinalizedElection_Throws()
+    {
+        var electionGuid = SeedElection(ElectionStage.Finalized);
+        var person = SeedPerson(electionGuid);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.DeletePersonAsync(person.PersonGuid));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Single(Context.People);
+    }
+
+    [Fact]
+    public async Task GetPeopleByElectionAsync_FinalizedElection_StillReads()
+    {
+        var electionGuid = SeedElection(ElectionStage.Finalized);
+        SeedPerson(electionGuid);
+
+        var result = await _service.GetPeopleByElectionAsync(electionGuid, pageSize: 50);
+
+        Assert.Single(result.Items);
+    }
+
+    [Fact]
+    public async Task GetPersonDetailsAsync_FinalizedElection_DoesNotGenerateKioskCode()
+    {
+        var electionGuid = SeedElection(ElectionStage.Finalized, votingMethods: "K");
+        var person = SeedPerson(electionGuid);
+
+        var details = await _service.GetPersonDetailsAsync(person.PersonGuid);
+
+        Assert.NotNull(details);
+        Assert.True(string.IsNullOrWhiteSpace(details.KioskCode));
+        Assert.True(string.IsNullOrWhiteSpace(Context.People.Single().KioskCode));
+    }
+
+    private Guid SeedElection(ElectionStage stage, string? votingMethods = null)
+    {
+        var electionGuid = Guid.NewGuid();
+        Context.Elections.Add(new Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "People lock test",
+            NumberToElect = 3,
+            ElectionType = "LSA",
+            ElectionStage = stage,
+            VotingMethods = votingMethods,
+            RowVersion = new byte[8]
+        });
+        Context.SaveChanges();
+        return electionGuid;
+    }
+
+    private Person SeedPerson(Guid electionGuid)
+    {
+        var person = new Person
+        {
+            PersonGuid = Guid.NewGuid(),
+            ElectionGuid = electionGuid,
+            FirstName = "Ada",
+            LastName = "Smith",
+            CanVote = true,
+            CanReceiveVotes = true,
+            RowVersion = new byte[8]
+        };
+        Context.People.Add(person);
+        Context.SaveChanges();
+        return person;
+    }
 }
 
 

--- a/Backend.Tests/UnitTests/Services/VoteServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/VoteServiceTests.cs
@@ -770,6 +770,65 @@ public class VoteServiceTests : ServiceTestBase
         Assert.NotNull(stored.OnlineVoteRaw);
     }
 
+    [Fact]
+    public async Task CreateVoteAsync_FinalizedElection_Throws()
+    {
+        SetElectionStage(ElectionStage.Finalized);
+        var person = CreatePerson();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.CreateVoteAsync(new CreateVoteDto
+            {
+                BallotGuid = BallotGuid,
+                PersonGuid = person.PersonGuid,
+                PositionOnBallot = 1
+            }));
+
+        Assert.Equal(ElectionStageMessageKeys.FinalizedWriteBlocked, ex.Message);
+        Assert.Empty(Context.Votes);
+    }
+
+    [Fact]
+    public async Task CreateVoteAsync_ProcessingBallots_Succeeds()
+    {
+        SetElectionStage(ElectionStage.ProcessingBallots);
+        var person = CreatePerson();
+
+        var result = await _service.CreateVoteAsync(new CreateVoteDto
+        {
+            BallotGuid = BallotGuid,
+            PersonGuid = person.PersonGuid,
+            PositionOnBallot = 1
+        });
+
+        Assert.NotNull(result.Vote);
+        Assert.Single(Context.Votes);
+    }
+
+    [Fact]
+    public async Task GetVotesByBallotAsync_FinalizedElection_StillReads()
+    {
+        SetElectionStage(ElectionStage.ProcessingBallots);
+        var person = CreatePerson();
+        await _service.CreateVoteAsync(new CreateVoteDto
+        {
+            BallotGuid = BallotGuid,
+            PersonGuid = person.PersonGuid,
+            PositionOnBallot = 1
+        });
+        SetElectionStage(ElectionStage.Finalized);
+
+        var votes = await _service.GetVotesByBallotAsync(BallotGuid);
+
+        Assert.Single(votes);
+    }
+
+    private void SetElectionStage(ElectionStage stage)
+    {
+        Context.Elections.Single().ElectionStage = stage;
+        Context.SaveChanges();
+    }
+
     private static void AssertUniqueContiguousPositions(IReadOnlyList<VoteDto> votes)
     {
         var positions = votes.Select(v => v.PositionOnBallot).ToList();

--- a/backend/Enumerations/ElectionStageMessageKeys.cs
+++ b/backend/Enumerations/ElectionStageMessageKeys.cs
@@ -10,6 +10,7 @@ public static class ElectionStageMessageKeys
     public const string InvalidStage = "elections.stageChangeError.invalidStage";
     public const string NotFound = "elections.stageChangeError.notFound";
     public const string ConfirmLeaveFinalized = "elections.stageChangeError.confirmLeaveFinalized";
+    public const string FinalizedWriteBlocked = "elections.finalizedWriteBlocked";
     public const string AnalysisNotCompleted = "elections.stageChangeError.analysisNotCompleted";
     public const string AnalysisNotReady = "elections.stageChangeError.analysisNotReady";
     public const string UnresolvedTies = "elections.stageChangeError.unresolvedTies";

--- a/backend/Enumerations/ElectionStageMessageKeys.cs
+++ b/backend/Enumerations/ElectionStageMessageKeys.cs
@@ -1,8 +1,9 @@
 namespace Backend.Enumerations;
 
 /// <summary>
-/// i18n phrase keys returned to the client for election stage change errors.
-/// Values match keys in frontend/src/locales/en/elections.json.
+/// i18n phrase keys returned to the client for election stage errors.
+/// Values match keys in frontend/src/locales/en/elections.json
+/// and frontend/src/locales/en/voting.json.
 /// </summary>
 public static class ElectionStageMessageKeys
 {
@@ -11,6 +12,7 @@ public static class ElectionStageMessageKeys
     public const string NotFound = "elections.stageChangeError.notFound";
     public const string ConfirmLeaveFinalized = "elections.stageChangeError.confirmLeaveFinalized";
     public const string FinalizedWriteBlocked = "elections.finalizedWriteBlocked";
+    public const string FinalizedOnlineSubmit = "voting.submit.finalized";
     public const string AnalysisNotCompleted = "elections.stageChangeError.analysisNotCompleted";
     public const string AnalysisNotReady = "elections.stageChangeError.analysisNotReady";
     public const string UnresolvedTies = "elections.stageChangeError.unresolvedTies";

--- a/backend/Enumerations/ElectionStageMessageKeys.cs
+++ b/backend/Enumerations/ElectionStageMessageKeys.cs
@@ -19,6 +19,7 @@ public static class ElectionStageMessageKeys
     public const string BallotsNeedReview = "elections.stageChangeError.ballotsNeedReview";
     public const string BallotsOutstanding = "elections.stageChangeError.ballotsOutstanding";
     public const string CountsDoNotReconcile = "elections.stageChangeError.countsDoNotReconcile";
+    public const string OnlineVotingStillOpen = "elections.stageChangeError.onlineVotingStillOpen";
 
     /// <summary>
     /// Builds a phrase key with interpolation parameters (e.g. key|count=3).

--- a/backend/Helpers/ElectionFinalizedWriteGuard.cs
+++ b/backend/Helpers/ElectionFinalizedWriteGuard.cs
@@ -8,6 +8,8 @@ namespace Backend.Helpers;
 /// Finalized is the election lock. There is no separate Locked flag.
 /// People, ballot, vote, roll, and import mutations throw
 /// <see cref="ElectionStageMessageKeys.FinalizedWriteBlocked"/>.
+/// Online voter submit uses the same stage check but returns
+/// <see cref="ElectionStageMessageKeys.FinalizedOnlineSubmit"/>.
 /// Accept-all uses the same stage check but keeps its own message key.
 /// </summary>
 public static class ElectionFinalizedWriteGuard

--- a/backend/Helpers/ElectionFinalizedWriteGuard.cs
+++ b/backend/Helpers/ElectionFinalizedWriteGuard.cs
@@ -1,0 +1,49 @@
+using Backend.Context;
+using Backend.Enumerations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Helpers;
+
+/// <summary>
+/// Finalized is the election lock. There is no separate Locked flag.
+/// People, ballot, vote, roll, and import mutations throw
+/// <see cref="ElectionStageMessageKeys.FinalizedWriteBlocked"/>.
+/// Accept-all uses the same stage check but keeps its own message key.
+/// </summary>
+public static class ElectionFinalizedWriteGuard
+{
+    public static bool IsLocked(ElectionStage stage) => stage == ElectionStage.Finalized;
+
+    public static void ThrowIfLocked(ElectionStage stage)
+    {
+        if (IsLocked(stage))
+        {
+            throw new InvalidOperationException(ElectionStageMessageKeys.FinalizedWriteBlocked);
+        }
+    }
+
+    public static async Task<bool> IsLockedAsync(
+        MainDbContext context,
+        Guid electionGuid,
+        CancellationToken cancellationToken = default)
+    {
+        var stage = await context.Elections
+            .AsNoTracking()
+            .Where(e => e.ElectionGuid == electionGuid)
+            .Select(e => (ElectionStage?)e.ElectionStage)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return stage is ElectionStage s && IsLocked(s);
+    }
+
+    public static async Task ThrowIfLockedAsync(
+        MainDbContext context,
+        Guid electionGuid,
+        CancellationToken cancellationToken = default)
+    {
+        if (await IsLockedAsync(context, electionGuid, cancellationToken))
+        {
+            throw new InvalidOperationException(ElectionStageMessageKeys.FinalizedWriteBlocked);
+        }
+    }
+}

--- a/backend/Helpers/OnlineVotingWindow.cs
+++ b/backend/Helpers/OnlineVotingWindow.cs
@@ -1,0 +1,34 @@
+namespace Backend.Helpers;
+
+/// <summary>
+/// Whether the online voting window is currently open for voters.
+/// Matches voter submit and available-elections: <c>UseOnlineVoting</c>
+/// plus open/close vs now. A null open or close does not close the window.
+/// </summary>
+public static class OnlineVotingWindow
+{
+    public static bool IsCurrentlyOpen(
+        bool useOnlineVoting,
+        DateTimeOffset? onlineWhenOpen,
+        DateTimeOffset? onlineWhenClose,
+        DateTimeOffset? now = null)
+    {
+        if (!useOnlineVoting)
+        {
+            return false;
+        }
+
+        var at = now ?? DateTimeOffset.UtcNow;
+        if (onlineWhenOpen != null && onlineWhenOpen > at)
+        {
+            return false;
+        }
+
+        if (onlineWhenClose != null && onlineWhenClose <= at)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/backend/Services/BallotService.cs
+++ b/backend/Services/BallotService.cs
@@ -102,6 +102,8 @@ public class BallotService : IBallotService
     /// </exception>
     public async Task<BallotDto> CreateBallotAsync(CreateBallotDto createDto)
     {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, createDto.ElectionGuid);
+
         var location = await _context.Locations.FirstOrDefaultAsync(l =>
             l.LocationGuid == createDto.LocationGuid
             && l.ElectionGuid == createDto.ElectionGuid);
@@ -163,6 +165,8 @@ public class BallotService : IBallotService
             return null;
         }
 
+        await ThrowIfBallotElectionLockedAsync(ballot.LocationGuid);
+
         ballot.Teller1 = NormalizeTellerName(updateDto.Teller1);
         ballot.Teller2 = NormalizeTellerName(updateDto.Teller2);
 
@@ -199,6 +203,20 @@ public class BallotService : IBallotService
         return await GetBallotByGuidAsync(ballotGuid);
     }
 
+    private async Task ThrowIfBallotElectionLockedAsync(Guid locationGuid)
+    {
+        var electionGuid = await _context.Locations
+            .AsNoTracking()
+            .Where(l => l.LocationGuid == locationGuid)
+            .Select(l => (Guid?)l.ElectionGuid)
+            .FirstOrDefaultAsync();
+
+        if (electionGuid.HasValue)
+        {
+            await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, electionGuid.Value);
+        }
+    }
+
     private static string? NormalizeTellerName(string? tellerName)
     {
         return string.IsNullOrWhiteSpace(tellerName) ? null : tellerName.Trim();
@@ -217,6 +235,8 @@ public class BallotService : IBallotService
         {
             return false;
         }
+
+        await ThrowIfBallotElectionLockedAsync(ballot.LocationGuid);
 
         if (ComputerCodeHelper.IsOnlineCode(ballot.ComputerCode)
             || ComputerCodeHelper.IsImportedCode(ballot.ComputerCode))

--- a/backend/Services/CdnBallotImportService.cs
+++ b/backend/Services/CdnBallotImportService.cs
@@ -249,6 +249,14 @@ public class CdnBallotImportService : ElectionImportExportBase
     public async Task<ImportResultDto> ImportCdnBallotsAsync(Guid electionGuid, Stream xmlStream)
     {
         var result = new ImportResultDto();
+
+        if (await ElectionFinalizedWriteGuard.IsLockedAsync(_context, electionGuid))
+        {
+            result.Success = false;
+            result.Errors.Add(ElectionStageMessageKeys.FinalizedWriteBlocked);
+            return result;
+        }
+
         using var transaction = await _context.Database.BeginTransactionAsync();
 
         try

--- a/backend/Services/ElectionStageFinalizationReadiness.cs
+++ b/backend/Services/ElectionStageFinalizationReadiness.cs
@@ -1,5 +1,6 @@
 using Backend.Context;
 using Backend.Enumerations;
+using Backend.Helpers;
 using static Backend.Enumerations.ElectionStageMessageKeys;
 using Microsoft.EntityFrameworkCore;
 
@@ -27,6 +28,21 @@ public static class ElectionStageFinalizationReadiness
         Guid electionGuid)
     {
         var blockers = new List<string>();
+
+        var onlineWindow = await context.Elections
+            .AsNoTracking()
+            .Where(e => e.ElectionGuid == electionGuid)
+            .Select(e => new { e.UseOnlineVoting, e.OnlineWhenOpen, e.OnlineWhenClose })
+            .FirstOrDefaultAsync();
+
+        if (onlineWindow != null &&
+            OnlineVotingWindow.IsCurrentlyOpen(
+                onlineWindow.UseOnlineVoting,
+                onlineWindow.OnlineWhenOpen,
+                onlineWindow.OnlineWhenClose))
+        {
+            blockers.Add(OnlineVotingStillOpen);
+        }
 
         var hasResults = await context.Results.AnyAsync(r => r.ElectionGuid == electionGuid);
         var finalSummary = await context.ResultSummaries

--- a/backend/Services/FrontDeskService.cs
+++ b/backend/Services/FrontDeskService.cs
@@ -52,6 +52,8 @@ public class FrontDeskService : IFrontDeskService
     /// <inheritdoc />
     public async Task<FrontDeskVoterDto> CheckInVoterAsync(Guid electionGuid, CheckInVoterDto checkInDto)
     {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, electionGuid);
+
         var person = await _context.People
             .FirstOrDefaultAsync(p => p.PersonGuid == checkInDto.PersonGuid && p.ElectionGuid == electionGuid);
 
@@ -129,6 +131,8 @@ public class FrontDeskService : IFrontDeskService
     /// <inheritdoc />
     public async Task<FrontDeskVoterDto> UnregisterVoterAsync(Guid electionGuid, UnregisterVoterDto unregisterDto)
     {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, electionGuid);
+
         var person = await _context.People
             .FirstOrDefaultAsync(p => p.PersonGuid == unregisterDto.PersonGuid && p.ElectionGuid == electionGuid);
 
@@ -218,6 +222,8 @@ public class FrontDeskService : IFrontDeskService
     /// <inheritdoc />
     public async Task<FrontDeskVoterDto> UpdatePersonFlagsAsync(Guid electionGuid, UpdatePersonFlagsDto updateFlagsDto)
     {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, electionGuid);
+
         var person = await _context.People
             .FirstOrDefaultAsync(p => p.PersonGuid == updateFlagsDto.PersonGuid && p.ElectionGuid == electionGuid);
 
@@ -245,6 +251,8 @@ public class FrontDeskService : IFrontDeskService
         Guid electionGuid,
         UpdateEnvelopeNumberDto updateDto)
     {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, electionGuid);
+
         var person = await _context.People
             .FirstOrDefaultAsync(p =>
                 p.PersonGuid == updateDto.PersonGuid && p.ElectionGuid == electionGuid);

--- a/backend/Services/ImportService.cs
+++ b/backend/Services/ImportService.cs
@@ -72,6 +72,13 @@ public class ImportService
         var result = new ImportResultDto();
         var electionGuid = request.ElectionGuid;
 
+        if (await ElectionFinalizedWriteGuard.IsLockedAsync(_context, electionGuid))
+        {
+            result.Success = false;
+            result.Errors.Add(ElectionStageMessageKeys.FinalizedWriteBlocked);
+            return result;
+        }
+
         try
         {
             var location = request.LocationGuid.HasValue

--- a/backend/Services/OnlineVotingService.Accept.cs
+++ b/backend/Services/OnlineVotingService.Accept.cs
@@ -50,7 +50,7 @@ public partial class OnlineVotingService
             };
         }
 
-        if (election.ElectionStage == ElectionStage.Finalized)
+        if (ElectionFinalizedWriteGuard.IsLocked(election.ElectionStage))
         {
             return new AcceptAllOnlineBallotsResultDto
             {

--- a/backend/Services/OnlineVotingService.Ballot.cs
+++ b/backend/Services/OnlineVotingService.Ballot.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Backend.Entities;
 using Backend.DTOs.OnlineVoting;
+using Backend.Enumerations;
 using Backend.Helpers;
 using Backend.Models;
 using Microsoft.EntityFrameworkCore;
@@ -29,6 +30,11 @@ public partial class OnlineVotingService
             if (election == null)
             {
                 return (false, "voting.submit.electionNotFound");
+            }
+
+            if (ElectionFinalizedWriteGuard.IsLocked(election.ElectionStage))
+            {
+                return (false, ElectionStageMessageKeys.FinalizedOnlineSubmit);
             }
 
             if (!election.UseOnlineVoting ||

--- a/backend/Services/OnlineVotingService.Ballot.cs
+++ b/backend/Services/OnlineVotingService.Ballot.cs
@@ -37,9 +37,11 @@ public partial class OnlineVotingService
                 return (false, ElectionStageMessageKeys.FinalizedOnlineSubmit);
             }
 
-            if (!election.UseOnlineVoting ||
-                (election.OnlineWhenOpen != null && election.OnlineWhenOpen > now) ||
-                (election.OnlineWhenClose != null && election.OnlineWhenClose <= now))
+            if (!OnlineVotingWindow.IsCurrentlyOpen(
+                    election.UseOnlineVoting,
+                    election.OnlineWhenOpen,
+                    election.OnlineWhenClose,
+                    now))
             {
                 return (false, "voting.submit.notOpen");
             }

--- a/backend/Services/PeopleImportService.Files.cs
+++ b/backend/Services/PeopleImportService.Files.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Backend.Entities;
 using Backend.DTOs.Import;
+using Backend.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
@@ -310,6 +311,8 @@ public partial class PeopleImportService
     public async Task<DeleteAllPeopleResult> DeleteAllPeopleAsync(Guid electionGuid)
     {
         var result = new DeleteAllPeopleResult();
+
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, electionGuid);
 
         // Check for existing ballots
         var ballotCount = await _context.Ballots

--- a/backend/Services/PeopleImportService.Import.cs
+++ b/backend/Services/PeopleImportService.Import.cs
@@ -25,6 +25,17 @@ public partial class PeopleImportService
         var result = new ImportPeopleResult();
         var startTime = DateTimeOffset.UtcNow;
 
+        if (await ElectionFinalizedWriteGuard.IsLockedAsync(_context, electionGuid))
+        {
+            result.Success = false;
+            result.Errors.Add(new ImportErrorDto
+            {
+                Key = ElectionStageMessageKeys.FinalizedWriteBlocked,
+                Parameters = new Dictionary<string, string>()
+            });
+            return result;
+        }
+
         var importFile = await _context.ImportFiles
             .FirstOrDefaultAsync(f => f.ElectionGuid == electionGuid && f.RowId == rowId);
 

--- a/backend/Services/PeopleService.cs
+++ b/backend/Services/PeopleService.cs
@@ -118,6 +118,8 @@ public class PeopleService : IPeopleService
     /// <exception cref="InvalidOperationException">Thrown when a person with the same email or phone already exists.</exception>
     public async Task<PersonDto> CreatePersonAsync(CreatePersonDto createDto)
     {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, createDto.ElectionGuid);
+
         var existingPerson = await _context.People
             .FirstOrDefaultAsync(p => p.ElectionGuid == createDto.ElectionGuid &&
                                      ((p.Email != null && createDto.Email != null && p.Email == createDto.Email) ||
@@ -176,6 +178,8 @@ public class PeopleService : IPeopleService
         {
             return null;
         }
+
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, person.ElectionGuid);
 
         var previousIneligibleReasonCode = person.IneligibleReasonCode;
 
@@ -415,6 +419,8 @@ public class PeopleService : IPeopleService
             return null;
         }
 
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, person.ElectionGuid);
+
         if (!string.IsNullOrWhiteSpace(person.VotingMethod))
         {
             throw new InvalidOperationException("Cannot generate a kiosk code for a person who has already registered.");
@@ -511,6 +517,8 @@ public class PeopleService : IPeopleService
 
     private async Task ValidateCanDeletePersonAsync(Person person)
     {
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, person.ElectionGuid);
+
         if (!string.IsNullOrWhiteSpace(person.VotingMethod))
         {
             throw new InvalidOperationException("Cannot delete a person who has already voted.");
@@ -536,6 +544,11 @@ public class PeopleService : IPeopleService
         }
 
         if (!string.IsNullOrWhiteSpace(person.VotingMethod))
+        {
+            return false;
+        }
+
+        if (await ElectionFinalizedWriteGuard.IsLockedAsync(_context, person.ElectionGuid))
         {
             return false;
         }

--- a/backend/Services/VoteService.cs
+++ b/backend/Services/VoteService.cs
@@ -101,6 +101,7 @@ public class VoteService : IVoteService
         }
 
         var electionGuid = ballot.Location.ElectionGuid;
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, electionGuid);
         var statusCode = VoteStatus.Ok;
         string? ineligibleReasonCode = null;
 
@@ -188,6 +189,8 @@ public class VoteService : IVoteService
             throw new InvalidOperationException($"Ballot with GUID '{updateDto.BallotGuid}' not found");
         }
 
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, ballot.Location.ElectionGuid);
+
         var statusCode = VoteStatus.Ok;
         string? ineligibleReasonCode = null;
         string? personCombinedInfo = vote.PersonCombinedInfo;
@@ -272,6 +275,8 @@ public class VoteService : IVoteService
             return null;
         }
 
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, vote.Ballot.Location.ElectionGuid);
+
         if (ComputerCodeHelper.IsOnlineCode(vote.Ballot.ComputerCode)
             || ComputerCodeHelper.IsImportedCode(vote.Ballot.ComputerCode))
         {
@@ -322,6 +327,8 @@ public class VoteService : IVoteService
         {
             return null;
         }
+
+        await ElectionFinalizedWriteGuard.ThrowIfLockedAsync(_context, ballot.Location.ElectionGuid);
 
         if (ComputerCodeHelper.IsOnlineCode(ballot.ComputerCode)
             || ComputerCodeHelper.IsImportedCode(ballot.ComputerCode))

--- a/context/election-state.md
+++ b/context/election-state.md
@@ -18,7 +18,8 @@ Treat state changes as high-consequence operations. Prefer clear, atomic transit
 
 There is no separate `Locked` flag. After analysis is complete and counts reconcile, advancing to **Finalized** is the lock:
 
-- Finalization is rejected until `ElectionStageFinalizationReadiness` is ready (analysis present and reportable, no blocking ballots, no unresolved ties, counts reconcile).
+- Finalization is rejected until `ElectionStageFinalizationReadiness` is ready (analysis present and reportable, no blocking ballots, no unresolved ties, counts reconcile, and the online voting window is not currently open).
+- When online voting is enabled and the window is currently open (same rule as voter submit / available-elections: `UseOnlineVoting` plus open/close vs now; a null open or close does not close the window), stage change **to** Finalized is refused (`elections.stageChangeError.onlineVotingStillOpen`). Tellers must close the window first. Finalize does not auto-close it. Elections with online voting off, a future-only window, or an already-closed window can still Finalize.
 - Leaving Finalized requires `ConfirmLeavingFinalized`. The StageControl UI does not send that flag, so a FullTeller click away from Finalized stays locked and shows the confirmation error.
 - Accept-all online ballots is refused while Finalized (`monitoring.acceptAll.finalized`).
 - People, ballot, vote, Front Desk roll, people-import execute / delete-all, ballot/CDN import mutations, and online voter submit (create or update a pending online ballot) are refused while Finalized. Tellers see `elections.finalizedWriteBlocked`; voters see `voting.submit.finalized`. Reads stay open. Leaving Finalized still requires `ConfirmLeavingFinalized` (#309 is the in-UI unlock confirm; not this gate).
@@ -30,6 +31,8 @@ There is no separate `Locked` flag. After analysis is complete and counts reconc
 **What stays writable on purpose:** election settings, locations, teller names, computers, analysis/results, test-election reset, and people-import file upload/mapping (those do not change the roll until execute). GetPersonDetails does not mint a new kiosk code after Finalized. Online-window open/close still gates submit when the election is not Finalized.
 
 **Rejected alternative:** leave online voter submit writable while Finalized because the online window (not stage) already gates it. Rejected — Finalized is the lock for people/ballot mutations, including creating or updating a pending online ballot.
+
+**Rejected alternative:** auto-close the online window as part of advancing to Finalized. Rejected — the teller must close the window first; Finalize only refuses while it is still open.
 
 ## “Move all tellers to this state” is the stage broadcast
 

--- a/context/election-state.md
+++ b/context/election-state.md
@@ -14,17 +14,20 @@ Treat state changes as high-consequence operations. Prefer clear, atomic transit
 ## Lock after analysis is the Finalized stage
 
 **Status:** active  
-**Evidence:** inferred (issue #172 names; implementation in `ElectionService.ChangeElectionStageAsync`)
+**Evidence:** inferred (issue #172 names; implementation in `ElectionService.ChangeElectionStageAsync`); people/ballot write gate confirmed by issue #308
 
 There is no separate `Locked` flag. After analysis is complete and counts reconcile, advancing to **Finalized** is the lock:
 
 - Finalization is rejected until `ElectionStageFinalizationReadiness` is ready (analysis present and reportable, no blocking ballots, no unresolved ties, counts reconcile).
 - Leaving Finalized requires `ConfirmLeavingFinalized`. The StageControl UI does not send that flag, so a FullTeller click away from Finalized stays locked and shows the confirmation error.
-- Accept-all online ballots is refused while Finalized.
+- Accept-all online ballots is refused while Finalized (`monitoring.acceptAll.finalized`).
+- People, ballot, vote, Front Desk roll, people-import execute / delete-all, and ballot/CDN import mutations are refused while Finalized (`elections.finalizedWriteBlocked`). Reads stay open. Leaving Finalized still requires `ConfirmLeavingFinalized` (#309 is the in-UI unlock confirm; not this gate).
 
 **Rejected alternative (not implemented):** a dedicated lock bit plus a “Move all tellers” command. Stage change + SignalR `statusChanged` is the coordination path.
 
-**Gap (intentional for this test slice):** people/ballot write APIs are not separately gated on Finalized. The lock is the stage + confirmation + guest menu/route rules.
+**Rejected alternative:** invent a second lock type or middleware. The existing `ElectionStage.Finalized` check (same as Accept-all) is the lock; `ElectionFinalizedWriteGuard` is only a shared helper.
+
+**What stays writable on purpose:** election settings, locations, teller names, computers, analysis/results, online voter submit (window-based, not stage-based), test-election reset, and people-import file upload/mapping (those do not change the roll until execute). GetPersonDetails does not mint a new kiosk code after Finalized.
 
 ## “Move all tellers to this state” is the stage broadcast
 

--- a/context/election-state.md
+++ b/context/election-state.md
@@ -14,20 +14,22 @@ Treat state changes as high-consequence operations. Prefer clear, atomic transit
 ## Lock after analysis is the Finalized stage
 
 **Status:** active  
-**Evidence:** inferred (issue #172 names; implementation in `ElectionService.ChangeElectionStageAsync`); people/ballot write gate confirmed by issue #308
+**Evidence:** inferred (issue #172 names; implementation in `ElectionService.ChangeElectionStageAsync`); people/ballot write gate and online-submit refusal confirmed by issue #308
 
 There is no separate `Locked` flag. After analysis is complete and counts reconcile, advancing to **Finalized** is the lock:
 
 - Finalization is rejected until `ElectionStageFinalizationReadiness` is ready (analysis present and reportable, no blocking ballots, no unresolved ties, counts reconcile).
 - Leaving Finalized requires `ConfirmLeavingFinalized`. The StageControl UI does not send that flag, so a FullTeller click away from Finalized stays locked and shows the confirmation error.
 - Accept-all online ballots is refused while Finalized (`monitoring.acceptAll.finalized`).
-- People, ballot, vote, Front Desk roll, people-import execute / delete-all, and ballot/CDN import mutations are refused while Finalized (`elections.finalizedWriteBlocked`). Reads stay open. Leaving Finalized still requires `ConfirmLeavingFinalized` (#309 is the in-UI unlock confirm; not this gate).
+- People, ballot, vote, Front Desk roll, people-import execute / delete-all, ballot/CDN import mutations, and online voter submit (create or update a pending online ballot) are refused while Finalized. Tellers see `elections.finalizedWriteBlocked`; voters see `voting.submit.finalized`. Reads stay open. Leaving Finalized still requires `ConfirmLeavingFinalized` (#309 is the in-UI unlock confirm; not this gate).
 
 **Rejected alternative (not implemented):** a dedicated lock bit plus a “Move all tellers” command. Stage change + SignalR `statusChanged` is the coordination path.
 
 **Rejected alternative:** invent a second lock type or middleware. The existing `ElectionStage.Finalized` check (same as Accept-all) is the lock; `ElectionFinalizedWriteGuard` is only a shared helper.
 
-**What stays writable on purpose:** election settings, locations, teller names, computers, analysis/results, online voter submit (window-based, not stage-based), test-election reset, and people-import file upload/mapping (those do not change the roll until execute). GetPersonDetails does not mint a new kiosk code after Finalized.
+**What stays writable on purpose:** election settings, locations, teller names, computers, analysis/results, test-election reset, and people-import file upload/mapping (those do not change the roll until execute). GetPersonDetails does not mint a new kiosk code after Finalized. Online-window open/close still gates submit when the election is not Finalized.
+
+**Rejected alternative:** leave online voter submit writable while Finalized because the online window (not stage) already gates it. Rejected — Finalized is the lock for people/ballot mutations, including creating or updating a pending online ballot.
 
 ## “Move all tellers to this state” is the stage broadcast
 

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -15,7 +15,9 @@ Treat online ballot paths with the same rigor as core analysis. Prefer explicit 
 **Status:** active  
 **Evidence:** confirmed (issue #188, Glen; v3 `ElectionHelper.ProcessOnlineBallots`)
 
-A voter submit stores a pending payload on `OnlineVotingInfo` (status `Submitted`). It does not create a regular `Ballot`. A logged-in teller may Accept-all current pending online ballots while the online voting window is still open, and may do so more than once. Each run only accepts rows that are `Submitted` or already `Processing` at that moment.
+A voter submit stores a pending payload on `OnlineVotingInfo` (status `Submitted`). It does not create a regular `Ballot`. Submit (create or update a pending online ballot) is refused while the election is Finalized (`voting.submit.finalized`), even if the online window is still open. Window-based open/close still applies when the election is not Finalized.
+
+A logged-in teller may Accept-all current pending online ballots while the online voting window is still open, and may do so more than once. Each run only accepts rows that are `Submitted` or already `Processing` at that moment.
 
 Accept-all creates a regular ballot at the Online location (computer code `OL`) as if a teller had typed from paper, then wipes the online payload (`ListPool`, `PoolLocked`, `BallotGuid`) and sets status `Processed`. After that, the voter cannot change the vote. Acceptance is not reversible: we do not keep a link from the online row to the regular ballot.
 

--- a/context/online-ballots.md
+++ b/context/online-ballots.md
@@ -17,6 +17,8 @@ Treat online ballot paths with the same rigor as core analysis. Prefer explicit 
 
 A voter submit stores a pending payload on `OnlineVotingInfo` (status `Submitted`). It does not create a regular `Ballot`. Submit (create or update a pending online ballot) is refused while the election is Finalized (`voting.submit.finalized`), even if the online window is still open. Window-based open/close still applies when the election is not Finalized.
 
+Advancing **to** Finalized is refused while that same window is currently open (`elections.stageChangeError.onlineVotingStillOpen`). Close the window first; Finalize does not close it. `UseOnlineVoting` plus a null open/close is treated as open (same as submit / available-elections).
+
 A logged-in teller may Accept-all current pending online ballots while the online voting window is still open, and may do so more than once. Each run only accepts rows that are `Submitted` or already `Processing` at that moment.
 
 Accept-all creates a regular ballot at the Online location (computer code `OL`) as if a teller had typed from paper, then wipes the online payload (`ListPool`, `PoolLocked`, `BallotGuid`) and sets status `Processed`. After that, the voter cannot change the vote. Acceptance is not reversible: we do not keep a link from the online row to the regular ballot.

--- a/frontend/src/components/nav/StageControl.vue
+++ b/frontend/src/components/nav/StageControl.vue
@@ -11,8 +11,9 @@ import { useElectionStore } from "@/stores/electionStore";
 import type { CountReconciliationReportDto } from "@/types";
 import { extractApiErrorMessage } from "@/utils/errorHandler";
 import { translateElectionStageChangeError } from "@/utils/electionStageErrorMessages";
+import { isOnlineVotingCurrentlyOpen } from "@/utils/onlineVotingWindowOpen";
 import { ElIcon } from "element-plus";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 
 const props = defineProps<{
@@ -27,12 +28,25 @@ const { showSuccessMessage, showErrorMessage } = useNotifications();
 const finalizeReportVisible = ref(false);
 const finalizeReport = ref<CountReconciliationReportDto | null>(null);
 
+const onlineWindowBlocksFinalize = computed(() => {
+  const election = electionStore.currentElection;
+  if (!election || election.electionGuid !== props.electionGuid) {
+    return false;
+  }
+  return isOnlineVotingCurrentlyOpen(election);
+});
+
 async function selectStage(newStage: ElectionStage) {
   if (newStage === props.stage) {
     return;
   }
 
   if (newStage === "Finalized") {
+    if (onlineWindowBlocksFinalize.value) {
+      showErrorMessage(t("elections.stageChangeError.onlineVotingStillOpen"));
+      return;
+    }
+
     try {
       const report = await resultService.getCountReconciliation(
         props.electionGuid,
@@ -74,6 +88,12 @@ async function selectStage(newStage: ElectionStage) {
       :key="s"
       role="radio"
       :aria-checked="s === stage"
+      :disabled="s === 'Finalized' && onlineWindowBlocksFinalize"
+      :title="
+        s === 'Finalized' && onlineWindowBlocksFinalize
+          ? t('elections.stageChangeError.onlineVotingStillOpen')
+          : undefined
+      "
       class="stage-control__seg"
       :class="{ 'is-selected': s === stage }"
       :style="
@@ -134,8 +154,13 @@ async function selectStage(newStage: ElectionStage) {
       border-bottom: none;
     }
 
-    &:hover:not(.is-selected) {
+    &:hover:not(.is-selected):not(:disabled) {
       background: var(--el-fill-color-light);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
     }
 
     &.is-selected {

--- a/frontend/src/components/nav/__tests__/StageControl.test.ts
+++ b/frontend/src/components/nav/__tests__/StageControl.test.ts
@@ -9,6 +9,8 @@ const stagePhraseMessages: Record<string, string> = {
   "elections.stageChangeError.confirmLeaveFinalized":
     "Reverting from Finalized requires confirmation",
   "elections.stageChangeError.generic": "Failed to change election stage",
+  "elections.stageChangeError.onlineVotingStillOpen":
+    "Close the online voting window before finalizing this election.",
 };
 
 vi.mock("vue-i18n", () => ({
@@ -37,11 +39,18 @@ vi.mock("@/composables/useNotifications", () => ({
 
 const mockSetStage = vi.fn();
 const mockGetCountReconciliation = vi.fn();
+const mockElectionStore = {
+  setStage: mockSetStage,
+  currentElection: null as {
+    electionGuid: string;
+    useOnlineVoting?: boolean;
+    onlineWhenOpen?: string | null;
+    onlineWhenClose?: string | null;
+  } | null,
+};
 
 vi.mock("@/stores/electionStore", () => ({
-  useElectionStore: () => ({
-    setStage: mockSetStage,
-  }),
+  useElectionStore: () => mockElectionStore,
 }));
 
 vi.mock("@/services/resultService", () => ({
@@ -66,6 +75,7 @@ describe("StageControl", () => {
     mockSetStage.mockReset();
     mockShowErrorMessage.mockReset();
     mockGetCountReconciliation.mockReset();
+    mockElectionStore.currentElection = null;
     mockGetCountReconciliation.mockResolvedValue({
       isReconciled: true,
       frontDeskCount: 0,
@@ -149,6 +159,28 @@ describe("StageControl", () => {
       expect(mockGetCountReconciliation).toHaveBeenCalledWith("abc-123");
       expect(mockSetStage).not.toHaveBeenCalled();
       expect(mockShowErrorMessage).toHaveBeenCalled();
+    });
+
+    it("disables Finalize and does not call setStage when the online window is open", async () => {
+      mockElectionStore.currentElection = {
+        electionGuid: "abc-123",
+        useOnlineVoting: true,
+        onlineWhenOpen: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        onlineWhenClose: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      };
+
+      const wrapper = mount(StageControl, {
+        props: { electionGuid: "abc-123", stage: "ProcessingBallots" },
+        global: { stubs: globalStubs },
+      });
+
+      const radios = wrapper.findAll('[role="radio"]');
+      expect(radios[3]!.attributes("disabled")).toBeDefined();
+      await radios[3]!.trigger("click");
+      await flushPromises();
+
+      expect(mockGetCountReconciliation).not.toHaveBeenCalled();
+      expect(mockSetStage).not.toHaveBeenCalled();
     });
 
     it("calls setStage with Finalized when counts reconcile", async () => {

--- a/frontend/src/components/nav/__tests__/StageControl.test.ts
+++ b/frontend/src/components/nav/__tests__/StageControl.test.ts
@@ -13,20 +13,24 @@ const stagePhraseMessages: Record<string, string> = {
     "Close the online voting window before finalizing this election.",
 };
 
-vi.mock("vue-i18n", () => ({
-  useI18n: () => ({
-    t: (key: string, opts?: Record<string, string>) => {
-      let message = stagePhraseMessages[key] ?? key;
-      if (opts) {
-        message = Object.entries(opts).reduce(
-          (s, [k, v]) => s.replace(`{${k}}`, String(v)),
-          message,
-        );
-      }
-      return message;
-    },
-  }),
-}));
+vi.mock("vue-i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("vue-i18n")>();
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string, opts?: Record<string, string>) => {
+        let message = stagePhraseMessages[key] ?? key;
+        if (opts) {
+          message = Object.entries(opts).reduce(
+            (s, [k, v]) => s.replace(`{${k}}`, String(v)),
+            message,
+          );
+        }
+        return message;
+      },
+    }),
+  };
+});
 
 const mockShowErrorMessage = vi.fn();
 

--- a/frontend/src/composables/useApiErrorHandler.ts
+++ b/frontend/src/composables/useApiErrorHandler.ts
@@ -1,3 +1,4 @@
+import { translateIfPhraseKey } from "../utils/errorHandler";
 import { useNotifications } from "./useNotifications";
 import { i18n } from "../locales";
 
@@ -76,6 +77,7 @@ export function useApiErrorHandler() {
       message = t(error.error) || error.error || message;
     }
 
+    message = translateIfPhraseKey(message);
     showErrorMessage(message);
     return message;
   };

--- a/frontend/src/composables/useFrontDeskRegistration.ts
+++ b/frontend/src/composables/useFrontDeskRegistration.ts
@@ -3,6 +3,7 @@ import type {
   RegistrationHistoryEntryDto,
 } from "@/types/FrontDesk";
 import { getActiveTellerPayload } from "@/utils/activeTellerStorage";
+import { resolveUserFacingApiError } from "@/utils/errorHandler";
 import { formatRegistrationHistoryDetails } from "@/utils/formatRegistrationHistory";
 import { ElMessageBox } from "element-plus";
 import { computed, nextTick, ref, type ComputedRef, type Ref } from "vue";
@@ -334,12 +335,8 @@ export function useFrontDeskRegistration(
       pendingVotingMethod.value = null;
       checkInInProgress.value = false;
       pendingCheckInPersonGuid.value = null;
-      const message =
-        err instanceof Error
-          ? err.message
-          : options.t("frontDesk.errors.checkIn");
       options.showErrorMessage(
-        message || options.t("frontDesk.errors.checkIn"),
+        resolveUserFacingApiError(err, options.t("frontDesk.errors.checkIn")),
       );
     }
   }
@@ -432,12 +429,11 @@ export function useFrontDeskRegistration(
       options.selectedVoter.value = updated;
       options.showSuccessMessage(options.t("frontDesk.messages.flagsUpdated"));
     } catch (err: unknown) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : options.t("frontDesk.errors.updateFlags");
       options.showErrorMessage(
-        message || options.t("frontDesk.errors.updateFlags"),
+        resolveUserFacingApiError(
+          err,
+          options.t("frontDesk.errors.updateFlags"),
+        ),
       );
     }
   }
@@ -469,12 +465,11 @@ export function useFrontDeskRegistration(
       return true;
     } catch (err: unknown) {
       if (err !== "cancel") {
-        const message =
-          err instanceof Error
-            ? err.message
-            : options.t("frontDesk.errors.unregister");
         options.showErrorMessage(
-          message || options.t("frontDesk.errors.unregister"),
+          resolveUserFacingApiError(
+            err,
+            options.t("frontDesk.errors.unregister"),
+          ),
         );
       }
       return false;

--- a/frontend/src/composables/useFrontDeskVoters.ts
+++ b/frontend/src/composables/useFrontDeskVoters.ts
@@ -8,6 +8,7 @@ import type {
   UnregisterVoterDto,
   UpdatePersonFlagsDto,
 } from "@/types/FrontDesk";
+import { resolveUserFacingApiError } from "@/utils/errorHandler";
 import { matchesFrontDeskVoterSearch } from "@/utils/searchStrategies";
 import { computed, ref, type Ref } from "vue";
 
@@ -212,9 +213,10 @@ export function useFrontDeskVoters(options: UseFrontDeskVotersOptions) {
       updateVoterInList(updatedVoter);
       return updatedVoter;
     } catch (e: unknown) {
-      const message =
-        e instanceof Error ? e.message : options.t("frontDesk.errors.checkIn");
-      error.value = message || options.t("frontDesk.errors.checkIn");
+      error.value = resolveUserFacingApiError(
+        e,
+        options.t("frontDesk.errors.checkIn"),
+      );
       throw e;
     }
   }
@@ -233,11 +235,10 @@ export function useFrontDeskVoters(options: UseFrontDeskVotersOptions) {
       updateVoterInList(updatedVoter);
       return updatedVoter;
     } catch (e: unknown) {
-      const message =
-        e instanceof Error
-          ? e.message
-          : options.t("frontDesk.errors.unregister");
-      error.value = message || options.t("frontDesk.errors.unregister");
+      error.value = resolveUserFacingApiError(
+        e,
+        options.t("frontDesk.errors.unregister"),
+      );
       throw e;
     } finally {
       loading.value = false;
@@ -263,11 +264,10 @@ export function useFrontDeskVoters(options: UseFrontDeskVotersOptions) {
       }
       return updatedVoter;
     } catch (e: unknown) {
-      const message =
-        e instanceof Error
-          ? e.message
-          : options.t("frontDesk.errors.updatePersonFlags");
-      error.value = message || options.t("frontDesk.errors.updatePersonFlags");
+      error.value = resolveUserFacingApiError(
+        e,
+        options.t("frontDesk.errors.updatePersonFlags"),
+      );
       throw e;
     } finally {
       loading.value = false;

--- a/frontend/src/locales/en/elections.json
+++ b/frontend/src/locales/en/elections.json
@@ -185,6 +185,7 @@
   "elections.stageChangeError.ballotsNeedReview": "{count} ballot(s) still need review",
   "elections.stageChangeError.ballotsOutstanding": "{count} ballot(s) have outstanding issues",
   "elections.stageChangeError.confirmLeaveFinalized": "Reverting from Finalized requires confirmation",
+  "elections.finalizedWriteBlocked": "This election is finalized. People and ballot data cannot be changed.",
   "elections.stageChangeError.invalidStage": "Invalid election stage",
   "elections.stageChangeError.notFound": "Election not found",
   "elections.stageChangeError.unresolvedTies": "Unresolved ties must be broken before finalizing",

--- a/frontend/src/locales/en/elections.json
+++ b/frontend/src/locales/en/elections.json
@@ -190,6 +190,7 @@
   "elections.stageChangeError.notFound": "Election not found",
   "elections.stageChangeError.unresolvedTies": "Unresolved ties must be broken before finalizing",
   "elections.stageChangeError.countsDoNotReconcile": "{count} count-reconciliation mismatch(es) must be resolved before analyzing or finalizing",
+  "elections.stageChangeError.onlineVotingStillOpen": "Close the online voting window before finalizing this election.",
   "elections.stageProgression": "Election Stage",
   "elections.statistics": "Statistics",
   "elections.status": "Status",

--- a/frontend/src/locales/en/voting.json
+++ b/frontend/src/locales/en/voting.json
@@ -86,6 +86,7 @@
   "voting.submit.alreadyProcessed": "Tellers have accepted your ballot. You cannot change it.",
   "voting.submit.alreadyVoted": "You have already submitted a ballot for this election.",
   "voting.submit.electionNotFound": "Election not found.",
+  "voting.submit.finalized": "This election is finalized. You cannot submit or change an online ballot.",
   "voting.submit.error": "An error occurred while submitting your ballot. Please try again.",
   "voting.submit.notOpen": "Online voting is not currently open for this election.",
   "voting.submit.voterNotFound": "Voter not found. Please authenticate first."

--- a/frontend/src/pages/ballots/BallotImportPage.vue
+++ b/frontend/src/pages/ballots/BallotImportPage.vue
@@ -166,6 +166,10 @@
 
 <script setup lang="ts">
 import { useNotifications } from "@/composables/useNotifications";
+import {
+  resolveUserFacingApiError,
+  translateIfPhraseKey,
+} from "@/utils/errorHandler";
 import { UploadFilled } from "@element-plus/icons-vue";
 import type { UploadFile } from "element-plus";
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
@@ -336,10 +340,17 @@ async function handleImport() {
         router.push(`/elections/${electionGuid}/ballots`);
       }, 2000);
     } else {
-      showErrorMessage(t("ballots.import.failed"));
+      const firstError = result.errors?.[0];
+      showErrorMessage(
+        firstError
+          ? translateIfPhraseKey(firstError)
+          : t("ballots.import.failed"),
+      );
     }
-  } catch (error: any) {
-    showErrorMessage(error.message || t("ballots.import.failed"));
+  } catch (error: unknown) {
+    showErrorMessage(
+      resolveUserFacingApiError(error, t("ballots.import.failed")),
+    );
   } finally {
     importing.value = false;
   }

--- a/frontend/src/pages/ballots/CdnBallotImportPage.vue
+++ b/frontend/src/pages/ballots/CdnBallotImportPage.vue
@@ -5,12 +5,13 @@ import { useI18n } from "vue-i18n";
 import { UploadFilled } from "@element-plus/icons-vue";
 import type { UploadFile, UploadRawFile } from "element-plus";
 import { useNotifications } from "@/composables/useNotifications";
+import { resolveUserFacingApiError } from "@/utils/errorHandler";
 import { electionService } from "../../services/electionService";
 import type { ImportResultDto } from "../../types";
 
 const router = useRouter();
 const route = useRoute();
-const { t } = useI18n();
+const { t, te } = useI18n();
 const { showErrorMessage } = useNotifications();
 
 const electionGuid = route.params.id as string;
@@ -34,7 +35,9 @@ async function handleFileChange(uploadFile: UploadFile) {
     const result = await electionService.importCdnBallots(electionGuid, file);
     importResult.value = result;
   } catch (error: any) {
-    showErrorMessage(error.message || t("ballots.cdnImport.failed"));
+    showErrorMessage(
+      resolveUserFacingApiError(error, t("ballots.cdnImport.failed")),
+    );
   } finally {
     importing.value = false;
   }
@@ -166,7 +169,7 @@ function beforeUpload(file: UploadRawFile) {
                   v-for="(error, index) in importResult.errors"
                   :key="index"
                   type="error"
-                  :title="error"
+                  :title="te(error) ? t(error) : error"
                   :closable="false"
                   show-icon
                   style="margin-bottom: 8px"

--- a/frontend/src/pages/voting/VoterBallotPage.vue
+++ b/frontend/src/pages/voting/VoterBallotPage.vue
@@ -17,6 +17,7 @@ import {
 import { Delete } from "@element-plus/icons-vue";
 import { useOnlineVotingStore } from "../../stores/onlineVotingStore";
 import { useNotifications } from "../../composables/useNotifications";
+import { resolveUserFacingApiError } from "../../utils/errorHandler";
 import { useI18n } from "vue-i18n";
 import type { OnlinePerson } from "../../types";
 import {
@@ -208,7 +209,9 @@ async function handleSubmit() {
     router.push({ name: "voter-confirmation" });
   } catch (error) {
     console.error("Error submitting ballot:", error);
-    showErrorMessage(t("voting.ballot.submitError"));
+    showErrorMessage(
+      resolveUserFacingApiError(error, t("voting.ballot.submitError")),
+    );
   } finally {
     submitting.value = false;
   }

--- a/frontend/src/stores/onlineVotingStore.ts
+++ b/frontend/src/stores/onlineVotingStore.ts
@@ -196,14 +196,7 @@ export const useOnlineVotingStore = defineStore("onlineVoting", () => {
   ) {
     try {
       loading.value = true;
-      const response = await onlineVotingService.submitBallot(
-        electionGuid,
-        data,
-      );
-      return response;
-    } catch (error) {
-      handleApiError(error as any);
-      throw error;
+      return await onlineVotingService.submitBallot(electionGuid, data);
     } finally {
       loading.value = false;
     }

--- a/frontend/src/utils/__tests__/electionStageErrorMessages.test.ts
+++ b/frontend/src/utils/__tests__/electionStageErrorMessages.test.ts
@@ -18,6 +18,8 @@ const i18n = createI18n({
         "Unresolved ties must be broken before finalizing",
       "elections.stageChangeError.countsDoNotReconcile":
         "{count} count-reconciliation mismatch(es) must be resolved before analyzing or finalizing",
+      "elections.stageChangeError.onlineVotingStillOpen":
+        "Close the online voting window before finalizing this election.",
     },
   },
 });
@@ -72,6 +74,15 @@ describe("translateElectionStageChangeError", () => {
     ).toBe(
       "4 count-reconciliation mismatch(es) must be resolved before analyzing or finalizing",
     );
+  });
+
+  it("translates the online-window-still-open finalize key", () => {
+    expect(
+      translateElectionStageChangeError(
+        "elections.stageChangeError.onlineVotingStillOpen",
+        t,
+      ),
+    ).toBe("Close the online voting window before finalizing this election.");
   });
 
   it("falls back to generic message for unknown keys", () => {

--- a/frontend/src/utils/__tests__/errorHandler.finalizedWrite.test.ts
+++ b/frontend/src/utils/__tests__/errorHandler.finalizedWrite.test.ts
@@ -15,6 +15,23 @@ describe("finalized write refusal messages", () => {
     expect(translateIfPhraseKey("Person not found")).toBe("Person not found");
   });
 
+  it("translates the Finalized online-submit voter key", () => {
+    expect(translateIfPhraseKey("voting.submit.finalized")).toBe(
+      "This election is finalized. You cannot submit or change an online ballot.",
+    );
+  });
+
+  it("surfaces a hey-api 400 body error key for online voter submit", () => {
+    expect(
+      resolveUserFacingApiError(
+        { error: "voting.submit.finalized" },
+        "Failed to submit ballot. Please try again.",
+      ),
+    ).toBe(
+      "This election is finalized. You cannot submit or change an online ballot.",
+    );
+  });
+
   it("surfaces a hey-api 400 body message key for Front Desk and people/ballot forms", () => {
     expect(
       resolveUserFacingApiError(

--- a/frontend/src/utils/__tests__/errorHandler.finalizedWrite.test.ts
+++ b/frontend/src/utils/__tests__/errorHandler.finalizedWrite.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveUserFacingApiError,
+  translateIfPhraseKey,
+} from "../errorHandler";
+
+describe("finalized write refusal messages", () => {
+  it("translates the Finalized people/ballot write key", () => {
+    expect(translateIfPhraseKey("elections.finalizedWriteBlocked")).toBe(
+      "This election is finalized. People and ballot data cannot be changed.",
+    );
+  });
+
+  it("leaves ordinary exception text unchanged", () => {
+    expect(translateIfPhraseKey("Person not found")).toBe("Person not found");
+  });
+
+  it("surfaces a hey-api 400 body message key for Front Desk and people/ballot forms", () => {
+    expect(
+      resolveUserFacingApiError(
+        { message: "elections.finalizedWriteBlocked" },
+        "Failed to check in voter",
+      ),
+    ).toBe(
+      "This election is finalized. People and ballot data cannot be changed.",
+    );
+  });
+});

--- a/frontend/src/utils/__tests__/onlineVotingWindowOpen.test.ts
+++ b/frontend/src/utils/__tests__/onlineVotingWindowOpen.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { isOnlineVotingCurrentlyOpen } from "../onlineVotingWindowOpen";
+
+const now = Date.parse("2026-09-09T12:00:00.000Z");
+
+describe("isOnlineVotingCurrentlyOpen", () => {
+  it("is closed when online voting is not enabled", () => {
+    expect(
+      isOnlineVotingCurrentlyOpen(
+        {
+          useOnlineVoting: false,
+          onlineWhenOpen: "2026-09-09T11:00:00.000Z",
+          onlineWhenClose: "2026-09-09T13:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("treats UseOnlineVoting plus a null window as open", () => {
+    expect(
+      isOnlineVotingCurrentlyOpen(
+        { useOnlineVoting: true, onlineWhenOpen: null, onlineWhenClose: null },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("is closed before the scheduled open", () => {
+    expect(
+      isOnlineVotingCurrentlyOpen(
+        {
+          useOnlineVoting: true,
+          onlineWhenOpen: "2026-09-09T13:00:00.000Z",
+          onlineWhenClose: "2026-09-09T14:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("is closed at or after the close time", () => {
+    expect(
+      isOnlineVotingCurrentlyOpen(
+        {
+          useOnlineVoting: true,
+          onlineWhenOpen: "2026-09-09T11:00:00.000Z",
+          onlineWhenClose: "2026-09-09T12:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("is open inside a scheduled window", () => {
+    expect(
+      isOnlineVotingCurrentlyOpen(
+        {
+          useOnlineVoting: true,
+          onlineWhenOpen: "2026-09-09T11:00:00.000Z",
+          onlineWhenClose: "2026-09-09T13:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/utils/errorHandler.ts
+++ b/frontend/src/utils/errorHandler.ts
@@ -1,3 +1,5 @@
+import { i18n } from "@/locales";
+
 export interface ApiError {
   title?: string;
   error?: string;
@@ -75,4 +77,28 @@ export function extractApiErrorMessage(error: any): string {
   }
 
   return "An unknown error occurred";
+}
+
+/// When the API returns an i18n phrase key (e.g. elections.finalizedWriteBlocked),
+/// translate it. Leave ordinary English exception text unchanged.
+export function translateIfPhraseKey(message: string): string {
+  const key = message?.trim();
+  if (!key) {
+    return message;
+  }
+
+  const { t, te } = i18n.global;
+  return te(key) ? String(t(key)) : message;
+}
+
+export function resolveUserFacingApiError(
+  error: unknown,
+  fallback: string,
+): string {
+  const raw = extractApiErrorMessage(error);
+  if (!raw || raw === "An unknown error occurred") {
+    return fallback;
+  }
+
+  return translateIfPhraseKey(raw);
 }

--- a/frontend/src/utils/onlineVotingWindowOpen.ts
+++ b/frontend/src/utils/onlineVotingWindowOpen.ts
@@ -1,10 +1,13 @@
 /** Matches backend OnlineVotingWindow.IsCurrentlyOpen / voter submit. */
 export function isOnlineVotingCurrentlyOpen(
-  election: {
-    useOnlineVoting?: boolean | null;
-    onlineWhenOpen?: Date | string | null;
-    onlineWhenClose?: Date | string | null;
-  } | null | undefined,
+  election:
+    | {
+        useOnlineVoting?: boolean | null;
+        onlineWhenOpen?: Date | string | null;
+        onlineWhenClose?: Date | string | null;
+      }
+    | null
+    | undefined,
   nowMs: number = Date.now(),
 ): boolean {
   if (!election?.useOnlineVoting) {
@@ -26,6 +29,7 @@ function toTimeMs(value: Date | string | null | undefined): number | null {
   if (value === null || value === undefined || value === "") {
     return null;
   }
-  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  const ms =
+    value instanceof Date ? value.getTime() : new Date(value).getTime();
   return Number.isNaN(ms) ? null : ms;
 }

--- a/frontend/src/utils/onlineVotingWindowOpen.ts
+++ b/frontend/src/utils/onlineVotingWindowOpen.ts
@@ -1,0 +1,31 @@
+/** Matches backend OnlineVotingWindow.IsCurrentlyOpen / voter submit. */
+export function isOnlineVotingCurrentlyOpen(
+  election: {
+    useOnlineVoting?: boolean | null;
+    onlineWhenOpen?: Date | string | null;
+    onlineWhenClose?: Date | string | null;
+  } | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!election?.useOnlineVoting) {
+    return false;
+  }
+
+  const openMs = toTimeMs(election.onlineWhenOpen);
+  const closeMs = toTimeMs(election.onlineWhenClose);
+  if (openMs !== null && nowMs < openMs) {
+    return false;
+  }
+  if (closeMs !== null && nowMs >= closeMs) {
+    return false;
+  }
+  return true;
+}
+
+function toTimeMs(value: Date | string | null | undefined): number | null {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const ms = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #308.

Advancing to Finalized is already the election lock for stage changes (`ConfirmLeavingFinalized`) and Accept-all. People, ballot, vote, Front Desk roll, import, and online voter submit writes are gated the same way. **Finalize itself is now refused while the online voting window is still open.**

## What this does

Reuses the existing `ElectionStage.Finalized` check (no new lock flag). `ElectionFinalizedWriteGuard` is a shared helper; Accept-all still returns `monitoring.acceptAll.finalized`.

**Cannot advance to Finalized** while online voting is currently open (same rule as voter submit / available-elections: `UseOnlineVoting` plus `OnlineWhenOpen` / `OnlineWhenClose` vs now; a null open or close does **not** close the window). Phrase key: `elections.stageChangeError.onlineVotingStillOpen`. Tellers must close the window first — Finalize does not auto-close it. Elections with online voting off, a future-only window, or an already-closed window can still Finalize.

**Refused while Finalized** (HTTP 400):

- People create / update / delete / generate kiosk code — `elections.finalizedWriteBlocked`
- Ballot create / update / delete — `elections.finalizedWriteBlocked`
- Vote create / update / delete / reorder — `elections.finalizedWriteBlocked`
- Front Desk check-in / unregister / flags / envelope — `elections.finalizedWriteBlocked`
- People import execute and delete-all-people — `elections.finalizedWriteBlocked`
- Ballot CSV import and CDN ballot import — `elections.finalizedWriteBlocked`
- Online voter submit (create or update a pending online ballot) — `voting.submit.finalized`, even if the online window is still open

**Still allowed:** reads (people, ballots, votes, roll, stats), election settings, locations, teller names, computers, analysis/results, test-election reset, people-import file upload/mapping. `GetPersonDetails` does not mint a new kiosk code after Finalized. Online-window open/close still gates submit when the election is **not** Finalized. Leaving Finalized still requires `ConfirmLeavingFinalized` (#309 is out of scope).

Does not implement #309 (in-UI unlock confirm) or #310 (move FullTellers).

## Test plan

- API: Finalized election → people/ballot/vote/Front Desk writes return 400 with `elections.finalizedWriteBlocked`; GETs still 200.
- API: ProcessingBallots / GatheringBallots → the same writes still succeed.
- API: Accept-all on a Finalized election still returns `monitoring.acceptAll.finalized` and creates no ballots.
- API: Finalized + open online window → submit returns 400 with `voting.submit.finalized` and creates no `OnlineVotingInfo`.
- API: non-Finalized + open online window → submit still succeeds (window rules unchanged).
- API: stage change to Finalized while the online window is open → 400 with `elections.stageChangeError.onlineVotingStillOpen`; after close, Finalize succeeds; `UseOnlineVoting` false still Finalizes as today.
- UI: StageControl disables Finalize (tooltip + toast) while the current election window is open. Other stage-change errors still toast via `translateElectionStageChangeError`.
- UI: people/ballot forms and Front Desk show the teller finalized message. Voter ballot submit shows “This election is finalized. You cannot submit or change an online ballot.”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc6f3df5-8977-4300-ae43-64e7f119948f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc6f3df5-8977-4300-ae43-64e7f119948f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

