### PR TITLE
FullTeller stage change: stay put + opt-in Go there (#310)

### DIFF
--- a/context/election-state.md
+++ b/context/election-state.md
@@ -41,9 +41,20 @@ There is no separate `Locked` flag. After analysis is complete and counts reconc
 ## “Move all tellers to this state” is the stage broadcast
 
 **Status:** active  
-**Evidence:** inferred (issue #172 names; no separate move-tellers API)
+**Evidence:** inferred (issue #172 names; no separate move-tellers API); FullTeller opt-in confirmed by issue #310
 
-Changing stage is the move. `ChangeElectionStageAsync` persists the stage and broadcasts `statusChanged` on MainHub. Remote `electionStore` clients update `currentStage`. GuestTellers are redirected to that stage’s work page; FullTellers are notified and stay on their current page (they can still open other stage groups).
+Changing stage is the move. `ChangeElectionStageAsync` persists the stage and broadcasts `statusChanged` on MainHub. Remote `electionStore` clients update `currentStage`.
+
+- **GuestTellers** auto-redirect to that stage’s primary work page (`useGuestTellerStageRedirect`).
+- **FullTellers** stay on their current page and get a toast. The toast includes a **Go there** action that opens the same work page guests land on. They are not auto-navigated: a FullTeller may be mid-ballot or mid-edit.
+
+Work pages (`getStageWorkPagePath`): GatheringBallots → Front Desk; ProcessingBallots → Enter Ballots; SettingUp / Finalized → election landing.
+
+v3 `statusChanged` updated status in place (`site.broadcast`); there is no documented v3 auto-move for known tellers. Issue #310 left the product choice open; v4 keeps stay-put + opt-in.
+
+**Rejected alternative:** auto-navigate FullTellers the same as guests. Rejected — FullTellers often have unsaved ballot/person edits; yanking the route would lose work. Guests have a narrower page set and are meant to follow the stage.
+
+**Rejected alternative:** toast-only with no action (pre-#310). Rejected — FullTellers had no way to follow the stage from the notice itself.
 
 There is no separate “Move all tellers to this state” button or endpoint.
 

--- a/frontend/src/composables/useGuestTellerStageRedirect.ts
+++ b/frontend/src/composables/useGuestTellerStageRedirect.ts
@@ -9,9 +9,10 @@ import { watch, type WatchStopHandle } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 /**
- * Keeps GuestTellers on the stage-appropriate page when election stage changes
- * over SignalR (or any store update). Lives in the layout so redirects do not
- * depend on the lazy-loaded sidebar menu being mounted.
+ * Auto-moves GuestTellers to the stage work page when election stage changes
+ * over SignalR (or any store update). FullTellers are not redirected here —
+ * they stay put and can opt in via Go there on the stage-change toast.
+ * Lives in the layout so redirects do not depend on the lazy sidebar menu.
  */
 export function useGuestTellerStageRedirect(): WatchStopHandle {
   const route = useRoute();

--- a/frontend/src/domain/__tests__/electionStages.test.ts
+++ b/frontend/src/domain/__tests__/electionStages.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { STAGES, STAGE_META, STAGE_PAGES } from "../electionStages";
+import {
+  getStageWorkPagePath,
+  STAGES,
+  STAGE_META,
+  STAGE_PAGES,
+} from "../electionStages";
 
 describe("electionStages", () => {
   describe("STAGES + STAGE_META", () => {
@@ -22,6 +27,28 @@ describe("electionStages", () => {
         expect(meta.bgVar).toMatch(/^--color-stage-.+-bg$/);
         expect(meta.icon).toBeDefined();
       }
+    });
+  });
+
+  describe("getStageWorkPagePath", () => {
+    const guid = "elec-1";
+
+    it("sends GatheringBallots to Front Desk", () => {
+      expect(getStageWorkPagePath(guid, "GatheringBallots")).toBe(
+        "/elections/elec-1/frontdesk",
+      );
+    });
+
+    it("sends ProcessingBallots to Enter Ballots (not Monitor)", () => {
+      expect(getStageWorkPagePath(guid, "ProcessingBallots")).toBe(
+        "/elections/elec-1/ballots",
+      );
+      expect(STAGE_PAGES.ProcessingBallots[0]?.key).toBe("monitor");
+    });
+
+    it("sends SettingUp and Finalized to election landing", () => {
+      expect(getStageWorkPagePath(guid, "SettingUp")).toBe("/elections/elec-1");
+      expect(getStageWorkPagePath(guid, "Finalized")).toBe("/elections/elec-1");
     });
   });
 

--- a/frontend/src/domain/electionStages.ts
+++ b/frontend/src/domain/electionStages.ts
@@ -85,6 +85,26 @@ export const STAGE_META: Record<NavElectionStage, StageMeta> = {
   },
 };
 
+/**
+ * Primary work page for a stage. GuestTellers are auto-sent here on stage
+ * change; FullTellers stay put and can open the same path from the notice.
+ * Not the first sidebar item (Processing lists Monitor first).
+ */
+export function getStageWorkPagePath(
+  electionGuid: string,
+  stage: ElectionStage,
+): string {
+  switch (stage) {
+    case "GatheringBallots":
+      return `/elections/${electionGuid}/frontdesk`;
+    case "ProcessingBallots":
+      return `/elections/${electionGuid}/ballots`;
+    case "SettingUp":
+    case "Finalized":
+      return `/elections/${electionGuid}`;
+  }
+}
+
 export const STAGE_PAGES: Record<NavElectionStage, NavPageDef[]> = {
   SettingUp: [
     {

--- a/frontend/src/domain/guestTellerAccess.ts
+++ b/frontend/src/domain/guestTellerAccess.ts
@@ -3,8 +3,12 @@ import {
   secureTokenService,
   type AuthCookieData,
 } from "@/services/secureTokenService";
-import type { ElectionStage, NavPageDef } from "./electionStages";
-import { STAGE_PAGES } from "./electionStages";
+import {
+  getStageWorkPagePath,
+  STAGE_PAGES,
+  type ElectionStage,
+  type NavPageDef,
+} from "./electionStages";
 
 /**
  * GuestTellers authenticate via election passcode (AccessCode), not as FullTellers
@@ -111,9 +115,5 @@ export function getGuestTellerRedirectPath(
   electionGuid: string,
   stage: ElectionStage,
 ): string {
-  const menuPages = getGuestTellerMenuPages(stage, electionGuid);
-  if (menuPages.length > 0) {
-    return menuPages[0]!.routePath(electionGuid);
-  }
-  return `/elections/${electionGuid}`;
+  return getStageWorkPagePath(electionGuid, stage);
 }

--- a/frontend/src/locales/en/elections.json
+++ b/frontend/src/locales/en/elections.json
@@ -180,6 +180,7 @@
   "elections.stageNav.group.ProcessingBallots": "Processing Ballots",
   "elections.stageNav.group.Finalized": "Finalized",
   "elections.stageNav.group.SettingUp": "Setting Up",
+  "elections.goToStagePage": "Go there",
   "elections.stageAdvanced": "Election changed to {stage}",
   "elections.stageChangeError.generic": "Failed to change election stage",
   "elections.stageChangeError.alreadyInStage": "Election is already in the requested stage",

--- a/frontend/src/stores/electionStore.test.ts
+++ b/frontend/src/stores/electionStore.test.ts
@@ -45,6 +45,20 @@ vi.mock("@/domain/guestTellerAccess", async (importOriginal) => {
   };
 });
 
+const routerPushMock = vi.fn();
+const currentPathRef = { value: "/elections/election-1/people" };
+
+vi.mock("@/router/router", () => ({
+  router: {
+    push: (...args: unknown[]) => routerPushMock(...args),
+    currentRoute: {
+      get value() {
+        return { path: currentPathRef.value };
+      },
+    },
+  },
+}));
+
 const elMessageMock = vi.fn();
 
 // Mock Element Plus (store calls ElMessage as a function)
@@ -74,19 +88,60 @@ vi.mock("../locales", () => ({
         if (key === "elections.stage.Finalized") {
           return "Finalized";
         }
+        if (key === "elections.goToStagePage") {
+          return "Go there";
+        }
         return key;
       },
     },
   },
 }));
 
+function stageNoticeText(message: unknown): string {
+  if (typeof message === "string") {
+    return message;
+  }
+  const vnode = message as { children?: unknown };
+  if (!Array.isArray(vnode.children) || vnode.children.length === 0) {
+    return "";
+  }
+  const textNode = vnode.children[0] as { children?: unknown };
+  return typeof textNode.children === "string" ? textNode.children : "";
+}
+
+function stageNoticeGoThere(message: unknown): (() => void) | undefined {
+  if (typeof message === "string") {
+    return undefined;
+  }
+  const vnode = message as { children?: unknown };
+  if (!Array.isArray(vnode.children) || vnode.children.length < 2) {
+    return undefined;
+  }
+  const button = vnode.children[1] as {
+    props?: { onClick?: (event: MouseEvent) => void };
+  };
+  const onClick = button.props?.onClick;
+  if (!onClick) {
+    return undefined;
+  }
+  return () =>
+    onClick(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
 describe("Election Store", () => {
   let electionStore: ReturnType<typeof useElectionStore>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     setActivePinia(createPinia());
     electionStore = useElectionStore();
     elMessageMock.mockClear();
+    routerPushMock.mockReset();
+    currentPathRef.value = "/elections/election-1/people";
+    const { isFullTeller, isGuestTeller } = await import(
+      "@/domain/guestTellerAccess"
+    );
+    vi.mocked(isFullTeller).mockReturnValue(true);
+    vi.mocked(isGuestTeller).mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -531,11 +586,16 @@ describe("Election Store", () => {
         "GatheringBallots",
       );
       expect(elMessageMock).toHaveBeenCalledTimes(1);
-      expect(elMessageMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: "Election changed to Gathering Ballots",
-          type: "info",
-        }),
+      const notice = elMessageMock.mock.calls[0]![0] as { message: unknown };
+      expect(stageNoticeText(notice.message)).toBe(
+        "Election changed to Gathering Ballots",
+      );
+      expect(routerPushMock).not.toHaveBeenCalled();
+      const goThere = stageNoticeGoThere(notice.message);
+      expect(goThere).toBeDefined();
+      goThere!();
+      expect(routerPushMock).toHaveBeenCalledWith(
+        "/elections/election-1/frontdesk",
       );
     });
 
@@ -596,12 +656,15 @@ describe("Election Store", () => {
       });
 
       expect(electionStore.currentStage).toBe("Finalized");
-      expect(elMessageMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: "Election changed to Finalized",
-          type: "info",
-        }),
+      const notice = elMessageMock.mock.calls[0]![0] as { message: unknown };
+      expect(stageNoticeText(notice.message)).toBe(
+        "Election changed to Finalized",
       );
+      expect(routerPushMock).not.toHaveBeenCalled();
+      const goThere = stageNoticeGoThere(notice.message);
+      expect(goThere).toBeDefined();
+      goThere!();
+      expect(routerPushMock).toHaveBeenCalledWith("/elections/election-1");
     });
 
     it("statusChanged does not toast when local setStage already suppressed echo", async () => {
@@ -647,6 +710,50 @@ describe("Election Store", () => {
       expect(electionStore.currentElection?.electionStage).toBe(
         "ProcessingBallots",
       );
+    });
+
+    it("statusChanged for GuestTeller toasts without Go there (redirect is separate)", async () => {
+      const { isFullTeller, isGuestTeller } = await import(
+        "@/domain/guestTellerAccess"
+      );
+      vi.mocked(isFullTeller).mockReturnValue(false);
+      vi.mocked(isGuestTeller).mockReturnValue(true);
+
+      const { signalrService } = await import("../services/signalrService");
+      const handlers = new Map<string, (data: unknown) => void>();
+      const mockConnection = {
+        on: vi.fn((event: string, handler: (data: unknown) => void) => {
+          handlers.set(event, handler);
+        }),
+      };
+      signalrService.connectToMainHub.mockResolvedValue(mockConnection);
+      signalrService.connectToFrontDeskHub.mockResolvedValue({ on: vi.fn() });
+
+      electionStore.currentElection = {
+        electionGuid: "election-1",
+        name: "Springfield LSA",
+        electionStage: "GatheringBallots",
+      } as ElectionDto;
+      currentPathRef.value = "/elections/election-1/frontdesk";
+
+      await electionStore.initializeSignalR();
+      handlers.get("statusChanged")!({
+        electionGuid: "election-1",
+        name: "Springfield LSA",
+        electionStage: "ProcessingBallots",
+        updatedAt: new Date().toISOString(),
+      });
+
+      expect(electionStore.currentElection?.electionStage).toBe(
+        "ProcessingBallots",
+      );
+      expect(elMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Election changed to Processing Ballots",
+          type: "info",
+        }),
+      );
+      expect(routerPushMock).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/stores/electionStore.test.ts
+++ b/frontend/src/stores/electionStore.test.ts
@@ -46,16 +46,10 @@ vi.mock("@/domain/guestTellerAccess", async (importOriginal) => {
 });
 
 const routerPushMock = vi.fn();
-const currentPathRef = { value: "/elections/election-1/people" };
 
 vi.mock("@/router/router", () => ({
   router: {
     push: (...args: unknown[]) => routerPushMock(...args),
-    currentRoute: {
-      get value() {
-        return { path: currentPathRef.value };
-      },
-    },
   },
 }));
 
@@ -136,10 +130,8 @@ describe("Election Store", () => {
     electionStore = useElectionStore();
     elMessageMock.mockClear();
     routerPushMock.mockReset();
-    currentPathRef.value = "/elections/election-1/people";
-    const { isFullTeller, isGuestTeller } = await import(
-      "@/domain/guestTellerAccess"
-    );
+    const { isFullTeller, isGuestTeller } =
+      await import("@/domain/guestTellerAccess");
     vi.mocked(isFullTeller).mockReturnValue(true);
     vi.mocked(isGuestTeller).mockReturnValue(false);
   });
@@ -594,9 +586,11 @@ describe("Election Store", () => {
       const goThere = stageNoticeGoThere(notice.message);
       expect(goThere).toBeDefined();
       goThere!();
-      expect(routerPushMock).toHaveBeenCalledWith(
-        "/elections/election-1/frontdesk",
-      );
+      await vi.waitFor(() => {
+        expect(routerPushMock).toHaveBeenCalledWith(
+          "/elections/election-1/frontdesk",
+        );
+      });
     });
 
     it("statusChanged accepts PascalCase payload and case-insensitive electionGuid", async () => {
@@ -664,7 +658,9 @@ describe("Election Store", () => {
       const goThere = stageNoticeGoThere(notice.message);
       expect(goThere).toBeDefined();
       goThere!();
-      expect(routerPushMock).toHaveBeenCalledWith("/elections/election-1");
+      await vi.waitFor(() => {
+        expect(routerPushMock).toHaveBeenCalledWith("/elections/election-1");
+      });
     });
 
     it("statusChanged does not toast when local setStage already suppressed echo", async () => {
@@ -713,9 +709,8 @@ describe("Election Store", () => {
     });
 
     it("statusChanged for GuestTeller toasts without Go there (redirect is separate)", async () => {
-      const { isFullTeller, isGuestTeller } = await import(
-        "@/domain/guestTellerAccess"
-      );
+      const { isFullTeller, isGuestTeller } =
+        await import("@/domain/guestTellerAccess");
       vi.mocked(isFullTeller).mockReturnValue(false);
       vi.mocked(isGuestTeller).mockReturnValue(true);
 
@@ -734,7 +729,6 @@ describe("Election Store", () => {
         name: "Springfield LSA",
         electionStage: "GatheringBallots",
       } as ElectionDto;
-      currentPathRef.value = "/elections/election-1/frontdesk";
 
       await electionStore.initializeSignalR();
       handlers.get("statusChanged")!({

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -5,7 +5,6 @@ import { electionService } from "../services/electionService";
 import { signalrService } from "../services/signalrService";
 import { useAuthStore } from "./authStore";
 
-import { ElMessage } from "element-plus";
 import type {
   CreateElectionDto,
   DuplicateElectionDto,
@@ -23,7 +22,7 @@ import {
   setActiveElectionHubGuid,
 } from "../utils/activeElectionHubStorage";
 import { STAGE_META, type ElectionStage } from "../domain/electionStages";
-import { i18n } from "../locales";
+import { notifyElectionStageChanged } from "../utils/electionStageNotice";
 
 /** How long to suppress remote stage toasts after a local setStage (covers SignalR racing HTTP). */
 const LOCAL_STAGE_NOTIFY_SUPPRESS_MS = 5000;
@@ -425,25 +424,8 @@ export const useElectionStore = defineStore("election", () => {
       data.electionStage &&
       !isRemoteStageNotifySuppressed(data.electionGuid)
     ) {
-      showElectionStageNotification(data.electionStage);
+      notifyElectionStageChanged(data.electionGuid, data.electionStage);
     }
-  }
-
-  function showElectionStageNotification(newStage: string) {
-    // Own-property check (not `in`) so prototype keys like "toString" never match.
-    const meta = Object.hasOwn(STAGE_META, newStage)
-      ? STAGE_META[newStage as ElectionStage]
-      : undefined;
-    const stageKey = meta ? meta.i18nKey : `elections.stage.${newStage}`;
-    const stageLabel = i18n.global.t(stageKey);
-    const message = i18n.global.t("elections.stageAdvanced", {
-      stage: stageLabel,
-    });
-    ElMessage({
-      message,
-      type: "info",
-      duration: 5000,
-    });
   }
 
   async function joinElection(electionGuid: string) {

--- a/frontend/src/styles/element-plus.less
+++ b/frontend/src/styles/element-plus.less
@@ -166,3 +166,26 @@
 .el-select-group .el-select-dropdown__item {
   padding-left: 30px;
 }
+
+.election-stage-notice {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75em;
+  flex-wrap: wrap;
+
+  &__go-there {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--el-color-primary);
+    font: inherit;
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus-visible {
+      color: var(--el-color-primary-dark-2);
+    }
+  }
+}

--- a/frontend/src/utils/__tests__/electionStageNotice.test.ts
+++ b/frontend/src/utils/__tests__/electionStageNotice.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { VNode } from "vue";
+import {
+  notifyElectionStageChanged,
+  STAGE_NOTICE_GO_THERE_MS,
+  STAGE_NOTICE_TEXT_MS,
+} from "../electionStageNotice";
+
+const elMessageMock = vi.fn();
+
+vi.mock("element-plus", () => ({
+  ElMessage: (opts: unknown) => elMessageMock(opts),
+}));
+
+vi.mock("@/locales", () => ({
+  i18n: {
+    global: {
+      t: (key: string, opts?: Record<string, string>) => {
+        if (key === "elections.stageAdvanced" && opts?.stage) {
+          return `Election changed to ${opts.stage}`;
+        }
+        if (key === "elections.stage.GatheringBallots") {
+          return "Gathering Ballots";
+        }
+        if (key === "elections.stage.ProcessingBallots") {
+          return "Processing Ballots";
+        }
+        if (key === "elections.stage.Finalized") {
+          return "Finalized";
+        }
+        if (key === "elections.goToStagePage") {
+          return "Go there";
+        }
+        return key;
+      },
+    },
+  },
+}));
+
+vi.mock("@/domain/guestTellerAccess", () => ({
+  isFullTeller: vi.fn(() => true),
+  isGuestTeller: vi.fn(() => false),
+}));
+
+vi.mock("@/router/router", () => ({
+  router: {
+    push: vi.fn(),
+    currentRoute: { value: { path: "/elections/elec-1/people" } },
+  },
+}));
+
+function noticeOpts() {
+  return elMessageMock.mock.calls[0]![0] as {
+    message: string | VNode;
+    type: string;
+    duration: number;
+    showClose?: boolean;
+  };
+}
+
+function noticeText(message: string | VNode): string {
+  if (typeof message === "string") {
+    return message;
+  }
+  const children = message.children;
+  if (!Array.isArray(children) || children.length === 0) {
+    return "";
+  }
+  const textNode = children[0] as VNode;
+  return typeof textNode.children === "string" ? textNode.children : "";
+}
+
+function goThereClick(message: string | VNode): (() => void) | undefined {
+  if (typeof message === "string") {
+    return undefined;
+  }
+  const children = message.children;
+  if (!Array.isArray(children) || children.length < 2) {
+    return undefined;
+  }
+  const button = children[1] as VNode;
+  const onClick = button.props?.onClick as
+    | ((event: MouseEvent) => void)
+    | undefined;
+  if (!onClick) {
+    return undefined;
+  }
+  return () =>
+    onClick(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+}
+
+describe("notifyElectionStageChanged", () => {
+  const navigate = vi.fn();
+
+  beforeEach(() => {
+    elMessageMock.mockClear();
+    navigate.mockReset();
+  });
+
+  it("FullTeller toast stays put and wires Go there to the stage work page", () => {
+    notifyElectionStageChanged("elec-1", "GatheringBallots", {
+      isFullTeller: true,
+      currentPath: "/elections/elec-1/people",
+      navigate,
+    });
+
+    const opts = noticeOpts();
+    expect(opts.type).toBe("info");
+    expect(opts.duration).toBe(STAGE_NOTICE_GO_THERE_MS);
+    expect(opts.showClose).toBe(true);
+    expect(noticeText(opts.message)).toBe(
+      "Election changed to Gathering Ballots",
+    );
+    expect(navigate).not.toHaveBeenCalled();
+
+    const click = goThereClick(opts.message);
+    expect(click).toBeDefined();
+    click!();
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith("/elections/elec-1/frontdesk");
+  });
+
+  it("FullTeller Go there opens Enter Ballots for ProcessingBallots", () => {
+    notifyElectionStageChanged("elec-1", "ProcessingBallots", {
+      isFullTeller: true,
+      currentPath: "/elections/elec-1/frontdesk",
+      navigate,
+    });
+
+    const click = goThereClick(noticeOpts().message);
+    expect(click).toBeDefined();
+    click!();
+    expect(navigate).toHaveBeenCalledWith("/elections/elec-1/ballots");
+  });
+
+  it("FullTeller already on the work page gets text only (no Go there)", () => {
+    notifyElectionStageChanged("elec-1", "GatheringBallots", {
+      isFullTeller: true,
+      currentPath: "/elections/elec-1/frontdesk",
+      navigate,
+    });
+
+    const opts = noticeOpts();
+    expect(opts.message).toBe("Election changed to Gathering Ballots");
+    expect(opts.duration).toBe(STAGE_NOTICE_TEXT_MS);
+    expect(goThereClick(opts.message)).toBeUndefined();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("GuestTeller toast is text only (auto-redirect is separate)", () => {
+    notifyElectionStageChanged("elec-1", "ProcessingBallots", {
+      isFullTeller: false,
+      currentPath: "/elections/elec-1/frontdesk",
+      navigate,
+    });
+
+    const opts = noticeOpts();
+    expect(opts.message).toBe("Election changed to Processing Ballots");
+    expect(opts.duration).toBe(STAGE_NOTICE_TEXT_MS);
+    expect(opts.showClose).toBeFalsy();
+    expect(goThereClick(opts.message)).toBeUndefined();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/__tests__/electionStageNotice.test.ts
+++ b/frontend/src/utils/__tests__/electionStageNotice.test.ts
@@ -86,9 +86,7 @@ function goThereClick(message: string | VNode): (() => void) | undefined {
     return undefined;
   }
   return () =>
-    onClick(
-      new MouseEvent("click", { bubbles: true, cancelable: true }),
-    );
+    onClick(new MouseEvent("click", { bubbles: true, cancelable: true }));
 }
 
 describe("notifyElectionStageChanged", () => {

--- a/frontend/src/utils/electionStageNotice.ts
+++ b/frontend/src/utils/electionStageNotice.ts
@@ -7,7 +7,6 @@ import {
   type ElectionStage,
 } from "@/domain/electionStages";
 import { i18n } from "@/locales";
-import { router } from "@/router/router";
 
 /** Longer than the text-only toast so a FullTeller can click Go there. */
 export const STAGE_NOTICE_GO_THERE_MS = 8000;
@@ -69,8 +68,11 @@ export function notifyElectionStageChanged(
   const destination = parsedStage
     ? getStageWorkPagePath(electionGuid, parsedStage)
     : undefined;
+  // Do not import router at module load — electionStore is pulled into suites
+  // that mock vue-router without createRouter. History path matches the SPA URL.
   const currentPath =
-    options?.currentPath ?? router.currentRoute.value.path;
+    options?.currentPath ??
+    (typeof window !== "undefined" ? window.location.pathname : "");
   const fullTeller = options?.isFullTeller ?? isFullTeller();
   const showGoThere =
     fullTeller &&
@@ -78,7 +80,12 @@ export function notifyElectionStageChanged(
     !pathsEqualIgnoreCase(currentPath, destination);
 
   const navigate =
-    options?.navigate ?? ((path: string) => void router.push(path));
+    options?.navigate ??
+    ((path: string) => {
+      void import("@/router/router").then(({ router }) => {
+        void router.push(path);
+      });
+    });
 
   ElMessage({
     message: showGoThere

--- a/frontend/src/utils/electionStageNotice.ts
+++ b/frontend/src/utils/electionStageNotice.ts
@@ -1,0 +1,91 @@
+import { ElMessage } from "element-plus";
+import { h, type VNode } from "vue";
+import { isFullTeller } from "@/domain/guestTellerAccess";
+import {
+  getStageWorkPagePath,
+  STAGE_META,
+  type ElectionStage,
+} from "@/domain/electionStages";
+import { i18n } from "@/locales";
+import { router } from "@/router/router";
+
+/** Longer than the text-only toast so a FullTeller can click Go there. */
+export const STAGE_NOTICE_GO_THERE_MS = 8000;
+export const STAGE_NOTICE_TEXT_MS = 5000;
+
+export function pathsEqualIgnoreCase(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function stageLabel(newStage: string): string {
+  // Own-property check (not `in`) so prototype keys like "toString" never match.
+  const meta = Object.hasOwn(STAGE_META, newStage)
+    ? STAGE_META[newStage as ElectionStage]
+    : undefined;
+  const stageKey = meta ? meta.i18nKey : `elections.stage.${newStage}`;
+  return i18n.global.t(stageKey);
+}
+
+function buildGoThereMessage(text: string, onGoThere: () => void): VNode {
+  return h("span", { class: "election-stage-notice" }, [
+    h("span", { class: "election-stage-notice__text" }, text),
+    h(
+      "button",
+      {
+        type: "button",
+        class: "election-stage-notice__go-there",
+        onClick: (event: MouseEvent) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onGoThere();
+        },
+      },
+      i18n.global.t("elections.goToStagePage"),
+    ),
+  ]);
+}
+
+/**
+ * Stage-change toast. GuestTellers auto-redirect separately and see text only.
+ * FullTellers stay on the current page; the toast offers Go there when they
+ * are not already on that stage's work page.
+ */
+export function notifyElectionStageChanged(
+  electionGuid: string,
+  newStage: string,
+  options?: {
+    currentPath?: string;
+    navigate?: (path: string) => void;
+    isFullTeller?: boolean;
+  },
+): void {
+  const text = i18n.global.t("elections.stageAdvanced", {
+    stage: stageLabel(newStage),
+  });
+
+  const parsedStage = Object.hasOwn(STAGE_META, newStage)
+    ? (newStage as ElectionStage)
+    : undefined;
+  const destination = parsedStage
+    ? getStageWorkPagePath(electionGuid, parsedStage)
+    : undefined;
+  const currentPath =
+    options?.currentPath ?? router.currentRoute.value.path;
+  const fullTeller = options?.isFullTeller ?? isFullTeller();
+  const showGoThere =
+    fullTeller &&
+    !!destination &&
+    !pathsEqualIgnoreCase(currentPath, destination);
+
+  const navigate =
+    options?.navigate ?? ((path: string) => void router.push(path));
+
+  ElMessage({
+    message: showGoThere
+      ? buildGoThereMessage(text, () => navigate(destination!))
+      : text,
+    type: "info",
+    duration: showGoThere ? STAGE_NOTICE_GO_THERE_MS : STAGE_NOTICE_TEXT_MS,
+    showClose: showGoThere,
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #310.

## What
Stage change still broadcasts MainHub `statusChanged`.

- **GuestTellers** auto-redirect to the stage work page (unchanged).
- **FullTellers** still stay on their current page and get the existing toast. The toast now includes a **Go there** action that opens that same work page (Front Desk / Enter Ballots / election landing).

The operator who changed the stage still has the local `setStage` echo suppressed — no extra toast for them.

## Judgment
v3 `statusChanged` updated status in place (`site.broadcast`). I did not find evidence that known tellers were auto-moved. Issue #172’s “Move all tellers” maps to this broadcast; only guests were auto-moved in v4.

Auto-navigating FullTellers would interrupt mid-ballot / mid-edit work. Stay-put + opt-in is the safer default. Documented in `context/election-state.md`.

Does not reopen #308 / #309 leave-Finalized confirm behavior.

## Test plan
- [x] Vitest: `electionStageNotice`, `electionStore` statusChanged, `useGuestTellerStageRedirect`, `getStageWorkPagePath` (`npm run check` clean)
- [ ] GuestTeller: change stage on another computer → guest lands on the new work page (no Go there on the toast)
- [ ] FullTeller mid-page (e.g. People or open ballot): toast appears, page does not change
- [ ] Click **Go there** → Front Desk / Enter Ballots / landing for the new stage
- [ ] Already on that work page → text-only toast, no Go there
- [ ] Local StageControl change → still no echo toast for the operator

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9669a914-95dd-42cf-892d-8e4046d266fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9669a914-95dd-42cf-892d-8e4046d266fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

