### PR TITLE
People import/export remaining tests: hard spaces, empty files, exports (#170)

### DIFF
--- a/Backend.Tests/IntegrationTests/FinalizedPeopleBallotWriteTests.cs
+++ b/Backend.Tests/IntegrationTests/FinalizedPeopleBallotWriteTests.cs
@@ -126,6 +126,14 @@ public class FinalizedPeopleBallotWriteTests : IntegrationTestBase
             FirstName = "New"
         });
         Assert.Equal(HttpStatusCode.Created, createPerson.StatusCode);
+        var created = await DeserializeResponseAsync<ApiResponse<PersonDto>>(createPerson);
+
+        var updatePerson = await PutJsonAsync($"/api/People/{created!.Data!.PersonGuid}/updatePerson", new UpdatePersonDto
+        {
+            LastName = "Allowed",
+            FirstName = "Edited"
+        });
+        Assert.Equal(HttpStatusCode.OK, updatePerson.StatusCode);
 
         var createBallot = await PostJsonAsync("/api/Ballots/createBallot", new CreateBallotDto
         {

--- a/Backend.Tests/UnitTests/ReportExportServiceTests.cs
+++ b/Backend.Tests/UnitTests/ReportExportServiceTests.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using System.Text;
+using ClosedXML.Excel;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Backend.DTOs.Results;
@@ -488,6 +491,91 @@ public class ReportExportServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task GenerateCsvReportAsync_WithValidData_ContainsOverviewElectedAndLocations()
+    {
+        var electionId = Guid.NewGuid();
+        SetupTypicalReport(electionId, includeCommaInName: false);
+
+        var result = await _service.GenerateCsvReportAsync(electionId);
+        var csv = Encoding.UTF8.GetString(result);
+
+        Assert.Contains("Election Report", csv);
+        Assert.Contains("Test Election", csv);
+        Assert.Contains("Total Registered Voters", csv);
+        Assert.Contains("150", csv);
+        Assert.Contains("Elected People", csv);
+        Assert.Contains("John Doe", csv);
+        Assert.Contains("Jane Smith", csv);
+        Assert.Contains("Location Statistics", csv);
+        Assert.Contains("Location A", csv);
+        Assert.Contains("66.67%", csv);
+    }
+
+    [Fact]
+    public async Task GenerateCsvReportAsync_NameWithCommaAndQuote_Rfc4180Escapes()
+    {
+        var electionId = Guid.NewGuid();
+        SetupTypicalReport(electionId, includeCommaInName: true);
+
+        var result = await _service.GenerateCsvReportAsync(electionId);
+        var csv = Encoding.UTF8.GetString(result);
+
+        Assert.Contains("\"Doe, John \"\"JJ\"\"\"", csv);
+    }
+
+    [Fact]
+    public async Task GenerateCsvReportAsync_WithNoElectedPeople_OmitsElectedSection()
+    {
+        var electionId = Guid.NewGuid();
+        var electionReport = new ElectionReportDto
+        {
+            ElectionName = "Empty Elected",
+            Elected = new List<PersonReportDto>()
+        };
+        var detailedStats = new DetailedStatisticsDto
+        {
+            Overview = new ElectionOverviewDto
+            {
+                ElectionName = "Empty Elected",
+                TotalRegisteredVoters = 0,
+                TotalBallotsCast = 0,
+                ValidBallots = 0,
+                SpoiledBallots = 0,
+                TotalVotes = 0,
+                PositionsToElect = 3,
+                OverallTurnoutPercentage = 0
+            },
+            LocationStatistics = new List<LocationStatisticsDto>()
+        };
+        _tallyServiceMock.Setup(x => x.GetElectionReportAsync(electionId)).ReturnsAsync(electionReport);
+        _tallyServiceMock.Setup(x => x.GetDetailedStatisticsAsync(electionId)).ReturnsAsync(detailedStats);
+
+        var result = await _service.GenerateCsvReportAsync(electionId);
+        var csv = Encoding.UTF8.GetString(result);
+
+        Assert.Contains("Election Overview", csv);
+        Assert.DoesNotContain("Elected People", csv);
+        Assert.DoesNotContain("Location Statistics", csv);
+    }
+
+    [Fact]
+    public async Task GenerateExcelReportAsync_WithValidData_ContainsElectedPeopleSheet()
+    {
+        var electionId = Guid.NewGuid();
+        SetupTypicalReport(electionId, includeCommaInName: false);
+
+        var result = await _service.GenerateExcelReportAsync(electionId);
+
+        using var stream = new MemoryStream(result);
+        using var workbook = new XLWorkbook(stream);
+        Assert.True(workbook.Worksheets.Contains("Elected People"));
+        var elected = workbook.Worksheet("Elected People");
+        Assert.Equal("John Doe", elected.Cell(4, 2).GetString());
+        Assert.Equal("Jane Smith", elected.Cell(5, 2).GetString());
+        Assert.Equal(95, elected.Cell(4, 3).GetDouble());
+    }
+
+    [Fact]
     public async Task GenerateExcelReportAsync_WhenTallyServiceThrows_LogsErrorAndRethrows()
     {
         // Arrange
@@ -499,6 +587,52 @@ public class ReportExportServiceTests : ServiceTestBase
         // Act & Assert
         var thrownException = await Assert.ThrowsAsync<InvalidOperationException>(() => _service.GenerateExcelReportAsync(electionId));
         Assert.Equal("Election not found", thrownException.Message);
+    }
+
+    private void SetupTypicalReport(Guid electionId, bool includeCommaInName)
+    {
+        var firstName = includeCommaInName ? "Doe, John \"JJ\"" : "John Doe";
+        var electionReport = new ElectionReportDto
+        {
+            ElectionName = "Test Election",
+            ElectionDate = DateTime.UtcNow.AddDays(30),
+            NumToElect = 3,
+            TotalBallots = 100,
+            SpoiledBallots = 5,
+            TotalVotes = 285,
+            Elected = new List<PersonReportDto>
+            {
+                new() { Rank = 1, FullName = firstName, VoteCount = 95, Section = "A" },
+                new() { Rank = 2, FullName = "Jane Smith", VoteCount = 88, Section = "B" }
+            }
+        };
+
+        var detailedStats = new DetailedStatisticsDto
+        {
+            Overview = new ElectionOverviewDto
+            {
+                ElectionName = "Test Election",
+                ElectionDate = DateTime.UtcNow.AddDays(30),
+                TotalRegisteredVoters = 150,
+                TotalBallotsCast = 100,
+                ValidBallots = 95,
+                SpoiledBallots = 5,
+                TotalVotes = 285,
+                PositionsToElect = 3,
+                OverallTurnoutPercentage = 66.67m
+            },
+            LocationStatistics = new List<LocationStatisticsDto>
+            {
+                new() { LocationName = "Location A", RegisteredVoters = 75, BallotsCast = 50, ValidBallots = 48, SpoiledBallots = 2, TurnoutPercentage = 66.67m, TotalVotes = 144 }
+            },
+            PersonPerformance = new[]
+            {
+                new PersonPerformanceDto { FullName = firstName, TotalVotes = 95, VotePercentage = 33.33m, Rank = 1, IsElected = true, IsEliminated = false }
+            }
+        };
+
+        _tallyServiceMock.Setup(x => x.GetElectionReportAsync(electionId)).ReturnsAsync(electionReport);
+        _tallyServiceMock.Setup(x => x.GetDetailedStatisticsAsync(electionId)).ReturnsAsync(detailedStats);
     }
 }
 

--- a/Backend.Tests/UnitTests/ReportServiceTests.cs
+++ b/Backend.Tests/UnitTests/ReportServiceTests.cs
@@ -566,6 +566,15 @@ public class ReportServiceTests : ServiceTestBase, IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetVoters_NoPeople_ReturnsEmptyList()
+    {
+        var report = await _service.GetVotersAsync(_electionGuid);
+
+        Assert.Equal(0, report.TotalCount);
+        Assert.Empty(report.People);
+    }
+
+    [Fact]
     public async Task GetVoters_ReturnsVoterParticipation()
     {
         var loc = await AddLocation("Hall");

--- a/Backend.Tests/UnitTests/Services/ElectionPackageImportServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/ElectionPackageImportServiceTests.cs
@@ -109,4 +109,48 @@ public class ElectionPackageImportServiceTests : ServiceTestBase
         Assert.True(person.CanVote);
         Assert.True(person.CanReceiveVotes);
     }
+
+    [Fact]
+    public async Task ExportElectionToJsonAsync_IncludesPeopleList()
+    {
+        var electionGuid = Guid.NewGuid();
+        var personGuid = Guid.NewGuid();
+        Context.Elections.Add(new Backend.Entities.Election
+        {
+            ElectionGuid = electionGuid,
+            Name = "People export test",
+            NumberToElect = 3,
+            ElectionType = "LSA",
+            ElectionStage = Backend.Enumerations.ElectionStage.SettingUp,
+            RowVersion = new byte[8]
+        });
+        Context.People.Add(new Backend.Entities.Person
+        {
+            PersonGuid = personGuid,
+            ElectionGuid = electionGuid,
+            FirstName = "Ada",
+            LastName = "Lovelace",
+            Email = "ada@example.com",
+            Phone = "+15550001111",
+            Area = "North",
+            CanVote = true,
+            CanReceiveVotes = true,
+            RowVersion = new byte[8]
+        });
+        await Context.SaveChangesAsync();
+
+        var service = new JsonElectionImportExportService(Context, _electionServiceMock.Object, _signalRMock.Object);
+        var json = await service.ExportElectionToJsonAsync(electionGuid);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        var people = doc.RootElement.GetProperty("people");
+        Assert.Equal(1, people.GetArrayLength());
+        var exported = people[0];
+        Assert.Equal(personGuid, exported.GetProperty("PersonGuid").GetGuid());
+        Assert.Equal("Ada", exported.GetProperty("FirstName").GetString());
+        Assert.Equal("Lovelace", exported.GetProperty("LastName").GetString());
+        Assert.Equal("ada@example.com", exported.GetProperty("Email").GetString());
+        Assert.Equal("+15550001111", exported.GetProperty("Phone").GetString());
+        Assert.Equal("North", exported.GetProperty("Area").GetString());
+    }
 }

--- a/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleImportServiceTests.cs
@@ -1000,6 +1000,33 @@ public class PeopleImportServiceTests : ServiceTestBase
         Assert.Equal("import.errors.unrecognizedEligibility", Assert.Single(result.Errors).Key);
     }
 
+    private async Task<ImportFile> AddMappedNameFile(Guid electionGuid, string fileContent, bool includeOtherInfo = false)
+    {
+        var mappings = new List<ColumnMappingDto>
+        {
+            new() { FileColumn = "FirstName", TargetField = "FirstName" },
+            new() { FileColumn = "LastName", TargetField = "LastName" }
+        };
+        if (includeOtherInfo)
+        {
+            mappings.Add(new ColumnMappingDto { FileColumn = "Other Info", TargetField = "OtherInfo" });
+        }
+
+        var importFile = new ImportFile
+        {
+            ElectionGuid = electionGuid,
+            FileType = "csv",
+            CodePage = 65001,
+            FirstDataRow = 1,
+            Contents = Encoding.UTF8.GetBytes(fileContent),
+            HasContent = true,
+            ColumnsToRead = System.Text.Json.JsonSerializer.Serialize(mappings)
+        };
+        Context.ImportFiles.Add(importFile);
+        await Context.SaveChangesAsync();
+        return importFile;
+    }
+
     private async Task<ImportFile> AddMappedEligibilityFile(Guid electionGuid, string fileContent)
     {
         var mappings = new List<ColumnMappingDto>
@@ -1142,6 +1169,164 @@ public class PeopleImportServiceTests : ServiceTestBase
 
         Assert.False(result.Success);
         Assert.Contains(result.Errors, e => e.Key == ElectionStageMessageKeys.FinalizedWriteBlocked);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_EmptyFile_ThrowsArgumentException()
+    {
+        var electionGuid = Guid.NewGuid();
+        var file = CreateFormFile("empty.csv", "text/csv", "");
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.UploadFileAsync(electionGuid, file));
+        Assert.Contains("No file provided", exception.Message);
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_EmptyContents_ReturnsNoHeadersOrRows()
+    {
+        var electionGuid = Guid.NewGuid();
+        var importFile = new ImportFile
+        {
+            ElectionGuid = electionGuid,
+            FileType = "csv",
+            CodePage = 65001,
+            FirstDataRow = 1,
+            Contents = Array.Empty<byte>(),
+            HasContent = true
+        };
+        Context.ImportFiles.Add(importFile);
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ParseFileAsync(electionGuid, importFile.RowId);
+
+        Assert.Empty(result.Headers);
+        Assert.Empty(result.PreviewRows);
+        Assert.Equal(0, result.TotalDataRows);
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_WhitespaceOnlyFile_ReturnsNoHeadersOrRows()
+    {
+        var electionGuid = Guid.NewGuid();
+        var importFile = new ImportFile
+        {
+            ElectionGuid = electionGuid,
+            FileType = "csv",
+            CodePage = 65001,
+            FirstDataRow = 1,
+            Contents = Encoding.UTF8.GetBytes("\n\n  \r\n"),
+            HasContent = true
+        };
+        Context.ImportFiles.Add(importFile);
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ParseFileAsync(electionGuid, importFile.RowId);
+
+        Assert.Empty(result.Headers);
+        Assert.Equal(0, result.TotalDataRows);
+    }
+
+    [Fact]
+    public async Task ImportPeopleAsync_HeadersOnlyFile_SucceedsWithZeroPeople()
+    {
+        var electionGuid = Guid.NewGuid();
+        var importFile = await AddMappedNameFile(electionGuid, "FirstName,LastName\n");
+
+        var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
+
+        Assert.True(result.Success);
+        Assert.Equal(0, result.TotalRows);
+        Assert.Equal(0, result.PeopleAdded);
+        Assert.Empty(await Context.People.Where(p => p.ElectionGuid == electionGuid).ToListAsync<Person>());
+    }
+
+    [Fact]
+    public async Task ImportPeopleAsync_HardSpacesInNames_NormalizedToRegularSpaces()
+    {
+        var electionGuid = Guid.NewGuid();
+        // Excel/Word NBSP around and inside names
+        var fileContent = "FirstName,LastName,Other Info\n" +
+                          $"Mary{'\u00A0'}Jane,{'\u00A0'}Doe{'\u00A0'},North{'\u00A0'}Unit\n";
+        var importFile = await AddMappedNameFile(electionGuid, fileContent, includeOtherInfo: true);
+
+        var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.PeopleAdded);
+        var person = Assert.Single(await Context.People.Where(p => p.ElectionGuid == electionGuid).ToListAsync<Person>());
+        Assert.Equal("Mary Jane", person.FirstName);
+        Assert.Equal("Doe", person.LastName);
+        Assert.Equal("North Unit", person.OtherInfo);
+    }
+
+    [Fact]
+    public async Task ImportPeopleAsync_HardSpaceOnlyName_SkipsAsMissingName()
+    {
+        var electionGuid = Guid.NewGuid();
+        var fileContent = $"FirstName,LastName\n{'\u00A0'}{'\u00A0'},Smith\nJane,Doe\n";
+        var importFile = await AddMappedNameFile(electionGuid, fileContent);
+
+        var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.PeopleAdded);
+        Assert.Equal(1, result.PeopleSkipped);
+        Assert.Contains(result.Errors, e => e.Key == "import.errors.missingFirstName");
+        var person = Assert.Single(await Context.People.Where(p => p.ElectionGuid == electionGuid).ToListAsync<Person>());
+        Assert.Equal("Jane", person.FirstName);
+    }
+
+    [Fact]
+    public async Task ImportPeopleAsync_InvalidAndBlankLines_SkipInvalidAndImportValid()
+    {
+        var electionGuid = Guid.NewGuid();
+        var fileContent =
+            "FirstName,LastName\n" +
+            "John,Doe\n" +
+            "\n" +
+            ",MissingFirst\n" +
+            "MissingLast,\n" +
+            ",,\n" +
+            "Jane,Smith\n" +
+            "\"Unclosed quote,Still\n" +
+            "OnlyOneColumn\n";
+        var importFile = await AddMappedNameFile(electionGuid, fileContent);
+
+        var result = await _service.ImportPeopleAsync(electionGuid, importFile.RowId);
+
+        Assert.True(result.Success);
+        Assert.True(result.PeopleAdded >= 2);
+        Assert.True(result.PeopleSkipped >= 2);
+        var people = await Context.People.Where(p => p.ElectionGuid == electionGuid).ToListAsync<Person>();
+        Assert.Contains(people, p => p.FirstName == "John" && p.LastName == "Doe");
+        Assert.Contains(people, p => p.FirstName == "Jane" && p.LastName == "Smith");
+        Assert.Contains(result.Errors, e => e.Key == "import.errors.missingFirstName");
+        Assert.Contains(result.Errors, e => e.Key == "import.errors.missingLastName");
+    }
+
+    [Fact]
+    public async Task ParseFileAsync_HardSpaceHeader_AutoMapsFirstName()
+    {
+        var electionGuid = Guid.NewGuid();
+        var header = $"First{'\u00A0'}Name";
+        var fileContent = $"{header},Last Name\nMary,Doe";
+        var importFile = new ImportFile
+        {
+            ElectionGuid = electionGuid,
+            FileType = "csv",
+            CodePage = 65001,
+            FirstDataRow = 1,
+            Contents = Encoding.UTF8.GetBytes(fileContent),
+            HasContent = true
+        };
+        Context.ImportFiles.Add(importFile);
+        await Context.SaveChangesAsync();
+
+        var result = await _service.ParseFileAsync(electionGuid, importFile.RowId);
+
+        Assert.Equal("First Name", result.Headers[0]);
+        Assert.Equal("FirstName", result.AutoMappings.Single(m => m.FileColumn == "First Name").TargetField);
     }
 
     [Fact]

--- a/Backend.Tests/UnitTests/Services/PeopleServiceTests.cs
+++ b/Backend.Tests/UnitTests/Services/PeopleServiceTests.cs
@@ -1082,6 +1082,62 @@ public class PeopleServiceTests : ServiceTestBase
     }
 
     [Fact]
+    public async Task CreatePersonAsync_GatheringBallots_Succeeds()
+    {
+        var electionGuid = SeedElection(ElectionStage.GatheringBallots);
+
+        var result = await _service.CreatePersonAsync(new CreatePersonDto
+        {
+            ElectionGuid = electionGuid,
+            LastName = "Hopper",
+            FirstName = "Grace"
+        });
+
+        Assert.Equal("Grace", result.FirstName);
+        Assert.Equal("Hopper", result.LastName);
+        Assert.Single(Context.People);
+    }
+
+    [Fact]
+    public async Task CreatePersonAsync_SettingUp_Succeeds()
+    {
+        var electionGuid = SeedElection(ElectionStage.SettingUp);
+
+        var result = await _service.CreatePersonAsync(new CreatePersonDto
+        {
+            ElectionGuid = electionGuid,
+            LastName = "Lovelace",
+            FirstName = "Ada"
+        });
+
+        Assert.Equal("Ada", result.FirstName);
+        Assert.Single(Context.People);
+    }
+
+    [Theory]
+    [InlineData(ElectionStage.SettingUp)]
+    [InlineData(ElectionStage.GatheringBallots)]
+    [InlineData(ElectionStage.ProcessingBallots)]
+    public async Task UpdatePersonAsync_NonFinalizedStages_Succeeds(ElectionStage stage)
+    {
+        var electionGuid = SeedElection(stage);
+        var person = SeedPerson(electionGuid);
+
+        var result = await _service.UpdatePersonAsync(person.PersonGuid, new UpdatePersonDto
+        {
+            LastName = "Changed",
+            FirstName = "Ada",
+            OtherInfo = "Added during election"
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("Changed", result.LastName);
+        Assert.Equal("Ada", result.FirstName);
+        Assert.Equal("Added during election", result.OtherInfo);
+        Assert.Equal("Changed", Context.People.Single().LastName);
+    }
+
+    [Fact]
     public async Task UpdatePersonAsync_VotingMethodSet_CannotMarkCannotVote()
     {
         var electionGuid = SeedElection(ElectionStage.GatheringBallots);

--- a/backend/Services/PeopleImportService.Files.cs
+++ b/backend/Services/PeopleImportService.Files.cs
@@ -22,6 +22,11 @@ public partial class PeopleImportService
     /// <returns>The created import file information.</returns>
     public async Task<ImportFileDto> UploadFileAsync(Guid electionGuid, IFormFile file)
     {
+        if (file == null || file.Length == 0)
+        {
+            throw new ArgumentException("No file provided");
+        }
+
         // Validate file extension
         var allowedExtensions = new[] { ".csv", ".tsv", ".tab", ".txt", ".xlsx" };
         var fileExtension = Path.GetExtension(file.FileName).ToLowerInvariant();

--- a/backend/Services/PeopleImportService.Import.cs
+++ b/backend/Services/PeopleImportService.Import.cs
@@ -317,7 +317,7 @@ public partial class PeopleImportService
             var columnIndex = headers.IndexOf(mapping.FileColumn);
             if (columnIndex >= 0 && columnIndex < cellsInRow.Count)
             {
-                var value = cellsInRow[columnIndex]?.Trim();
+                var value = NormalizeImportedCell(cellsInRow[columnIndex]);
                 ApplyFieldMapping(person, mapping.TargetField!, value);
             }
         }
@@ -400,7 +400,7 @@ public partial class PeopleImportService
             var columnIndex = headers.IndexOf(ineligibleReasonMapping.FileColumn);
             if (columnIndex >= 0 && columnIndex < cellsInRow.Count)
             {
-                var eligibilityValue = cellsInRow[columnIndex]?.Trim();
+                var eligibilityValue = NormalizeImportedCell(cellsInRow[columnIndex]);
                 if (!TrySetEligibility(person, eligibilityValue, eligibilityLookup, result, rowNumber))
                 {
                     foundErrors = true;

--- a/backend/Services/PeopleImportService.Parse.cs
+++ b/backend/Services/PeopleImportService.Parse.cs
@@ -60,7 +60,7 @@ public partial class PeopleImportService
         var columnCount = headerRow.CellsUsed().Count();
         foreach (var cell in headerRow.CellsUsed())
         {
-            headers.Add(cell.GetValue<string>() ?? "");
+            headers.Add(NormalizeImportedCell(cell.GetValue<string>()));
         }
 
         var allRows = worksheet.RowsUsed().ToList();
@@ -84,7 +84,7 @@ public partial class PeopleImportService
             for (int colNum = 1; colNum <= columnCount; colNum++)
             {
                 var cell = row.Cell(colNum);
-                rowData.Add(cell.GetValue<string>() ?? "");
+                rowData.Add(NormalizeImportedCell(cell.GetValue<string>()));
             }
 
             totalDataRows++;
@@ -150,7 +150,7 @@ public partial class PeopleImportService
 
         foreach (var cell in cells)
         {
-            var value = cell.GetValue<string>()?.Trim() ?? "";
+            var value = NormalizeImportedCell(cell.GetValue<string>());
 
             if (string.IsNullOrWhiteSpace(value))
                 continue;
@@ -287,7 +287,7 @@ public partial class PeopleImportService
                 continue;
             }
 
-            var value = col < row.Count ? row[col]?.Trim() ?? "" : "";
+            var value = col < row.Count ? NormalizeImportedCell(row[col]) : "";
             if (value.Length > 0)
             {
                 samplesByColumn[col].Add(value);
@@ -339,7 +339,7 @@ public partial class PeopleImportService
             }
             else if (c == delimiter && !inQuotes)
             {
-                result.Add(current);
+                result.Add(NormalizeImportedCell(current));
                 current = "";
             }
             else
@@ -348,8 +348,26 @@ public partial class PeopleImportService
             }
         }
 
-        result.Add(current);
+        result.Add(NormalizeImportedCell(current));
         return result;
+    }
+
+    /// <summary>
+    /// Excel and Word often emit NBSP / narrow-NBSP ("hard spaces") that look like
+    /// regular spaces. Leave them in and names fail search/uniqueness; treat a
+    /// hard-space-only cell as empty.
+    /// </summary>
+    private static string NormalizeImportedCell(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "";
+        }
+
+        return value
+            .Replace('\u00A0', ' ')
+            .Replace('\u202F', ' ')
+            .Trim();
     }
 
     private List<ColumnMappingDto> GenerateAutoMappings(List<string> headers)

--- a/context/people-import.md
+++ b/context/people-import.md
@@ -50,6 +50,49 @@ The execute endpoint reads mappings from the file row, not from the browser. Con
 
 Skip messages use the spreadsheet's own row number (Excel row 12 after headers on row 6), not a count of data rows. `FirstDataRow` is the header row only; parse already excludes it, so import must not skip that many rows again.
 
+## Hard spaces from Excel/Word are regular spaces
+
+**Status:** active  
+**Evidence:** inferred (v3 import bug class named on #170; Excel/Word emit U+00A0)  
+**Source:** issue #170  
+**Revisit when:** another Unicode space (e.g. ideographic) shows up in real files
+
+Import cells replace NBSP (`U+00A0`) and narrow NBSP (`U+202F`) with a normal space, then trim. A cell that is only hard spaces is empty — missing First/Last Name skips the row; empty eligibility stays fully eligible. Mid-name hard spaces become a real space (`Mary Jane`) so search and uniqueness match what the teller sees.
+
+**Rejected alternative:** leave hard spaces in the stored name. They look identical in the UI and then fail Front Desk search and unique-field matching.
+
+**Rejected alternative:** strip every Unicode space category. That would also delete intended separators in some names; only the Excel/Word hard-space pair is rewritten.
+
+## Empty files and invalid lines do not abort the load
+
+**Status:** active  
+**Evidence:** confirmed (controller already refused 0-byte upload; import skips validation failures without `errorsFound`)  
+**Source:** issue #170; `PeopleImportController.UploadFile`; `PeopleImportService.ImportPeopleAsync`  
+**Revisit when:** import gains a fail-fast / all-or-nothing option
+
+A 0-byte upload is refused (`No file provided`) in both the controller and `UploadFileAsync`. A file that parses to no rows (empty bytes, whitespace, or headers only) can still be mapped; execute succeeds with zero people added.
+
+Invalid data rows (blank names, hard-space-only names, jagged/unquoted junk) increment `PeopleSkipped`, log a line error, and leave valid rows in the same file imported. Unexpected exceptions still roll back the batch (`errorsFound`).
+
+**Rejected alternative:** treat any skipped row as a failed import and roll back. Duplicate unique fields and unrecognized eligibility already commit the good rows; missing-name and empty-line cases follow that.
+
+## People list export is the package + voter reports
+
+**Status:** active  
+**Evidence:** inferred (no People-page CSV download in v4; #170 asked to test export, not add one)  
+**Source:** issue #170  
+**Revisit when:** tellers need a CSV that round-trips through Import People
+
+v4 does not download a people CSV from People Management. The people list leaves the system as:
+
+- Election JSON package (`ExportElectionToJsonAsync` `people` array) — full records for backup / move
+- Voter reports (`Voters`, `AllCanReceive`, `VoterEmails`, `ChangedPeople`, …) — on-screen + browser print
+- Tally report export API (`/api/report-exports`) — PDF / Excel / CSV of results (elected names, overview), not the roll
+
+The Reporting page only offers Print; the unused `reporting.exportCSV` strings are leftovers.
+
+**Rejected alternative:** add a People-page CSV export in this #170 slice. Import already accepts many column layouts; a new download would be a product feature, not the remaining test gap.
+
 ## Eligibility import uses person-form codes, not four invented statuses
 
 **Status:** active  


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #170.

## What was already true
- CSV/XLSX people import (mapping, eligibility codes, unique email/phone/Bahá'í ID, duplicate names allowed) is in use and well tested.
- Add/edit people is normal People CRUD. **Finalized still blocks writes** (#308 / #312): create/update/delete, import execute, delete-all. Reads stay open. Non-Finalized stages already allowed create (ProcessingBallots).
- Voter/people **reports** (`Voters`, `AllCanReceive`, `VoterEmails`, `ChangedPeople`, …) already had ReportService tests.
- Tally report **PDF/Excel** generation already had byte-length tests.
- Empty upload was already refused by `PeopleImportController` (`No file provided`).
- Invalid/skipped import rows (missing names, unrecognized eligibility, duplicate unique fields) already commit the good rows; they do not roll back the file.

## What this PR fixes
- **Hard spaces:** import replaces Excel/Word NBSP (`U+00A0`) and narrow NBSP (`U+202F`) with a normal space, then trims. Hard-space-only names skip as missing. Mid-name hard spaces become `Mary Jane`.
- **Empty files:** `UploadFileAsync` now matches the controller (0-byte → `No file provided`). Parse of empty/whitespace contents does not throw. Headers-only execute succeeds with zero people.
- **Invalid lines:** blank, jagged, and unclosed-quote rows skip with line errors; valid rows in the same file still import.
- **Export tests:** CSV report content + RFC 4180 quoting; Excel “Elected People” sheet; empty Voters report; election JSON package `people` array.

## Product judgment
- v4 has **no People-page CSV download**. People leave via the election JSON package and voter reports; `/api/report-exports` is tally results (PDF/Excel/CSV). Reporting UI is Print only (`reporting.exportCSV` strings are unused leftovers). A round-trip CSV from People Management would be a new feature, not this test gap.
- Add/edit during an election is intended. Only Finalized locks the roll.

## Test plan
- [x] Backend (local): 162 tests passed (`PeopleImportServiceTests`, `PeopleServiceTests`, `ReportExportServiceTests`, `ReportServiceTests`, `ElectionPackageImportServiceTests`, `FinalizedPeopleBallotWriteTests`)
- [x] Backend (local): people import — hard spaces, empty/whitespace/headers-only, invalid lines; upload 0-byte
- [x] Backend (local): report CSV/Excel content; empty Voters list; JSON package includes people
- [x] Backend (local): create/update in SettingUp / GatheringBallots / ProcessingBallots; Finalized still refuses
- [ ] Manual: import a CSV with NBSP names from Excel — names search on Front Desk
- [ ] Manual: upload a 0-byte file — “No file provided”
- [ ] Manual: add and edit a person while Gathering / Processing; after Finalize, edits refuse
- [ ] Confirm People Management has no CSV download (JSON export is on the election)

UAT: https://uat.v4.tallyj.com

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb9dcef2-4d6d-4284-b943-8a7a905ad332?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb9dcef2-4d6d-4284-b943-8a7a905ad332&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

