### PR TITLE
grokbot: Stop UAT from tagging Sentry as development

### DIFF
--- a/Backend.Tests/UnitTests/ClientEnvMiddlewareTests.cs
+++ b/Backend.Tests/UnitTests/ClientEnvMiddlewareTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Backend.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace Backend.Tests.UnitTests;
+
+public class ClientEnvMiddlewareTests
+{
+    private static IHostEnvironment Env(string name)
+    {
+        var mock = new Mock<IHostEnvironment>();
+        mock.Setup(e => e.EnvironmentName).Returns(name);
+        return mock.Object;
+    }
+
+    private static IConfiguration Config(string? env, string? frontendUrl, string? apiUrl = "https://example.com")
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["ClientEnv:apiUrl"] = apiUrl
+        };
+
+        if (env is not null)
+        {
+            values["ClientEnv:env"] = env;
+        }
+
+        if (frontendUrl is not null)
+        {
+            values["ClientEnv:frontendUrl"] = frontendUrl;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    private static async Task<JsonElement> GetClientEnvAsync(IConfiguration configuration, IHostEnvironment environment)
+    {
+        var middleware = new ClientEnvMiddleware(_ => Task.CompletedTask, configuration, environment);
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/clientEnv.json";
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Body.Position = 0;
+        using var document = await JsonDocument.ParseAsync(context.Response.Body);
+        return document.RootElement.Clone();
+    }
+
+    [Fact]
+    public async Task ClientEnvJson_Development_EmitsDevelopment()
+    {
+        var json = await GetClientEnvAsync(
+            Config("development", "https://localhost:8095", "http://localhost:5016"),
+            Env(Environments.Development));
+
+        Assert.Equal("development", json.GetProperty("env").GetString());
+        Assert.Equal("http://localhost:5016", json.GetProperty("apiUrl").GetString());
+    }
+
+    [Fact]
+    public async Task ClientEnvJson_Testing_EmitsDevelopment()
+    {
+        var json = await GetClientEnvAsync(
+            Config("development", "https://localhost:8095"),
+            Env("Testing"));
+
+        Assert.Equal("development", json.GetProperty("env").GetString());
+    }
+
+    [Fact]
+    public async Task ClientEnvJson_ProductionUatHost_DoesNotEmitDevelopment()
+    {
+        var json = await GetClientEnvAsync(
+            Config("development", "https://uat.v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal("uat", json.GetProperty("env").GetString());
+        Assert.NotEqual("development", json.GetProperty("env").GetString());
+    }
+
+    [Fact]
+    public async Task ClientEnvJson_ProductionOtherHost_EmitsProduction()
+    {
+        var json = await GetClientEnvAsync(
+            Config("development", "https://v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal("production", json.GetProperty("env").GetString());
+    }
+
+    [Fact]
+    public async Task ClientEnvJson_Production_ExplicitOverride_IsHonored()
+    {
+        var json = await GetClientEnvAsync(
+            Config("uat", "https://v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal("uat", json.GetProperty("env").GetString());
+    }
+
+    [Fact]
+    public async Task ClientEnvJson_IgnoresOtherPaths()
+    {
+        var nextCalled = false;
+        var middleware = new ClientEnvMiddleware(
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            },
+            Config("development", "https://uat.v4.tallyj.com"),
+            Env(Environments.Production));
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/health";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+    }
+}

--- a/Backend.Tests/UnitTests/ClientEnvResolverTests.cs
+++ b/Backend.Tests/UnitTests/ClientEnvResolverTests.cs
@@ -1,0 +1,156 @@
+using Backend.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace Backend.Tests.UnitTests;
+
+public class ClientEnvResolverTests
+{
+    private static IHostEnvironment Env(string name)
+    {
+        var mock = new Mock<IHostEnvironment>();
+        mock.Setup(e => e.EnvironmentName).Returns(name);
+        return mock.Object;
+    }
+
+    private static IConfiguration Config(string? env, string? frontendUrl = null)
+    {
+        var values = new Dictionary<string, string?>();
+        if (env is not null)
+        {
+            values[ClientEnvResolver.EnvConfigKey] = env;
+        }
+
+        if (frontendUrl is not null)
+        {
+            values[FrontendUrlResolver.ConfigKey] = frontendUrl;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    [Fact]
+    public void ResolveEnv_Development_KeepsConfiguredDevelopment()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("development", "https://localhost:8095"),
+            Env(Environments.Development));
+
+        Assert.Equal(ClientEnvResolver.DevelopmentEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Development_MissingConfig_DefaultsToDevelopment()
+    {
+        var env = ClientEnvResolver.ResolveEnv(Config(null), Env(Environments.Development));
+        Assert.Equal(ClientEnvResolver.DevelopmentEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Testing_KeepsDevelopmentDefault()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("development"),
+            Env("Testing"));
+
+        Assert.Equal(ClientEnvResolver.DevelopmentEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Production_UatFrontendHost_DoesNotEmitDevelopment()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("development", "https://uat.v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal(ClientEnvResolver.UatEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Production_UatFrontendHost_IsCaseInsensitive()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("Development", "https://UAT.v4.tallyj.com/"),
+            Env(Environments.Production));
+
+        Assert.Equal(ClientEnvResolver.UatEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Production_OtherHost_DefaultsToProduction()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("development", "https://v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal(ClientEnvResolver.ProductionEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Production_MissingFrontendUrl_DefaultsToProduction()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("development"),
+            Env(Environments.Production));
+
+        Assert.Equal(ClientEnvResolver.ProductionEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_NonDevelopmentTestingHost_DoesNotEmitDevelopment()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("development", "https://v4.tallyj.com"),
+            Env("Staging"));
+
+        Assert.Equal(ClientEnvResolver.ProductionEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Production_HonorsExplicitNonDevelopmentOverride()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("staging", "https://uat.v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal("staging", env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Production_HonorsExplicitUat()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("uat", "https://v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal(ClientEnvResolver.UatEnv, env);
+    }
+
+    [Fact]
+    public void ResolveEnv_Production_BlankEnv_InfersFromHost()
+    {
+        var env = ClientEnvResolver.ResolveEnv(
+            Config("   ", "https://uat.v4.tallyj.com"),
+            Env(Environments.Production));
+
+        Assert.Equal(ClientEnvResolver.UatEnv, env);
+    }
+
+    [Fact]
+    public void InferHostedEnv_UatHost_ReturnsUat()
+    {
+        Assert.Equal(
+            ClientEnvResolver.UatEnv,
+            ClientEnvResolver.InferHostedEnv(Config(null, "https://uat.v4.tallyj.com")));
+    }
+
+    [Fact]
+    public void InferHostedEnv_NonUatHost_ReturnsProduction()
+    {
+        Assert.Equal(
+            ClientEnvResolver.ProductionEnv,
+            ClientEnvResolver.InferHostedEnv(Config(null, "https://example.com")));
+    }
+}

--- a/backend/Configuration/ClientEnvResolver.cs
+++ b/backend/Configuration/ClientEnvResolver.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Backend.Configuration;
+
+/// <summary>
+/// Resolves the client/Sentry environment name advertised in <c>/clientEnv.json</c>.
+/// </summary>
+/// <remarks>
+/// <c>backend/appsettings.json</c> defaults <c>ClientEnv:env</c> to <c>development</c> for local work.
+/// Hosted sites (UAT, production) typically run with <c>ASPNETCORE_ENVIRONMENT=Production</c> and
+/// inherit that default unless Azure App Settings override it. This resolver treats that inherited
+/// <c>development</c> value as unset outside Development/Testing so Sentry is not tagged as a
+/// local environment. An explicit non-development <c>ClientEnv:env</c> (or <c>ClientEnv__env</c>)
+/// is always honored.
+/// </remarks>
+internal static class ClientEnvResolver
+{
+    public const string EnvConfigKey = "ClientEnv:env";
+    public const string DevelopmentEnv = "development";
+    public const string ProductionEnv = "production";
+    public const string UatEnv = "uat";
+    public const string UatFrontendHost = "uat.v4.tallyj.com";
+
+    /// <summary>
+    /// Returns the environment name the SPA should report (Sentry <c>environment</c>, sampling keys).
+    /// </summary>
+    public static string ResolveEnv(IConfiguration configuration, IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        var configured = configuration[EnvConfigKey]?.Trim();
+
+        if (environment.IsDevelopment() || environment.IsEnvironment("Testing"))
+        {
+            return string.IsNullOrWhiteSpace(configured) ? DevelopmentEnv : configured;
+        }
+
+        if (!string.IsNullOrWhiteSpace(configured) &&
+            !string.Equals(configured, DevelopmentEnv, StringComparison.OrdinalIgnoreCase))
+        {
+            return configured;
+        }
+
+        return InferHostedEnv(configuration);
+    }
+
+    /// <summary>
+    /// Hosted default when <c>ClientEnv:env</c> is missing, blank, or the repo <c>development</c> default.
+    /// Prefer <c>uat</c> for the public UAT SPA host; otherwise <c>production</c>.
+    /// </summary>
+    internal static string InferHostedEnv(IConfiguration configuration)
+    {
+        var raw = configuration[FrontendUrlResolver.ConfigKey]?.Trim();
+        if (Uri.TryCreate(raw, UriKind.Absolute, out var uri) &&
+            string.Equals(uri.Host, UatFrontendHost, StringComparison.OrdinalIgnoreCase))
+        {
+            return UatEnv;
+        }
+
+        return ProductionEnv;
+    }
+}

--- a/backend/Middleware/ClientEnvMiddleware.cs
+++ b/backend/Middleware/ClientEnvMiddleware.cs
@@ -1,16 +1,21 @@
 using System.Text.Json;
+using Backend.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace Backend.Middleware;
 
 /// <summary>
 /// Middleware that intercepts requests to /clientEnv.json and serves environment-specific configuration.
 /// The values served out are from appSettings in the "ClientEnv" section, which should only contain non-sensitive settings needed by client-side code.
+/// <c>env</c> is adjusted for hosted (non-Development/Testing) hosts so the SPA does not advertise
+/// the repo default <c>development</c> to Sentry. See <see cref="ClientEnvResolver"/>.
 /// </summary>
 public class ClientEnvMiddleware
 {
     private readonly string? _cachedConfig;
     private readonly RequestDelegate _next;
     private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _environment;
 
     private string MakeClientEnv()
     {
@@ -25,6 +30,8 @@ public class ClientEnvMiddleware
           pair => pair.Value
         );
 
+        camelCaseDict["env"] = ClientEnvResolver.ResolveEnv(_configuration, _environment);
+
         // serialize the dictionary to a JSON string. Use indented to make debugging easier.
         return JsonSerializer.Serialize(
           camelCaseDict,
@@ -32,14 +39,15 @@ public class ClientEnvMiddleware
         );
     }
 
-    public ClientEnvMiddleware(RequestDelegate next, IConfiguration configuration)
+    public ClientEnvMiddleware(RequestDelegate next, IConfiguration configuration, IHostEnvironment environment)
     {
         _next = next;
         _configuration = configuration;
+        _environment = environment;
 
         // serialize the dictionary to a JSON string. Use indented to make debugging easier.
         // only if not in Development
-        if (_configuration["ASPNETCORE_ENVIRONMENT"] != "Development")
+        if (!_environment.IsDevelopment())
         {
             _cachedConfig = MakeClientEnv();
         }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -42,6 +42,7 @@ The backend reads standard ASP.NET Core configuration sources. At minimum, set:
 - `Jwt__Issuer`
 - `Jwt__Audience`
 - `ClientEnv__frontendUrl` (public SPA origin used in emails, OAuth redirects, and CORS)
+- `ClientEnv__env` (Sentry/client environment advertised at `/clientEnv.json`. Set **`uat`** on UAT and **`production`** on production. If this is unset or still `development` outside Development/Testing, the host infers `uat` when `ClientEnv__frontendUrl` is `https://uat.v4.tallyj.com`, otherwise `production`. Local Development/Testing keep `development`.)
 
 Common optional settings:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
grokbot: Hosted UAT (`uat.v4.tallyj.com`) currently serves `/clientEnv.json` with `"env": "development"` because that is the repo default in `backend/appsettings.json` and there is no Production override. The SPA then calls `Sentry.init({ environment: config.env })`, so UAT events land in Sentry as development (javascript-vue A/B/9).

## Change

When `ASPNETCORE_ENVIRONMENT` is not Development or Testing, treat `ClientEnv:env` of `development` (or blank) as the shared repo default and replace it:

- `uat` when `ClientEnv:frontendUrl` host is `uat.v4.tallyj.com`
- `production` otherwise

An explicit non-development `ClientEnv:env` / `ClientEnv__env` is left as-is. Development and Testing still advertise `development`.

DSN, traces, and replay rates are unchanged; they already key off `config.env === "development"` and will drop from 100% on UAT once env is correct.

## Docs

`docs/DEPLOYMENT.md` now documents `ClientEnv__env`. UAT should be set to `uat` (recommended even though the host can infer it).

## Tests

- Development / Testing still emit `development`
- Production + UAT frontend host does not emit `development`
- Production + other host defaults to `production`
- Explicit `ClientEnv:env` overrides are honored

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e31472ed-442f-5cd5-85da-f626abd9c99f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e31472ed-442f-5cd5-85da-f626abd9c99f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

